### PR TITLE
improved Erosion

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,18 @@
       "Bash(sort:*)",
       "WebSearch",
       "WebFetch(domain:github.com)",
-      "WebFetch(domain:docs.github.com)"
+      "WebFetch(domain:docs.github.com)",
+      "WebFetch(domain:aparis69.github.io)",
+      "WebFetch(domain:www.gamedev.net)",
+      "WebFetch(domain:www.proceduralpixels.com)",
+      "WebFetch(domain:www-sop.inria.fr)",
+      "WebFetch(domain:perso.liris.cnrs.fr)",
+      "WebFetch(domain:web.mit.edu)",
+      "WebFetch(domain:nickmcd.me)",
+      "WebFetch(domain:inria.hal.science)",
+      "WebFetch(domain:jobtalle.com)",
+      "WebFetch(domain:frozenfractal.com)",
+      "WebFetch(domain:old.cescg.org)"
     ]
   }
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All three are considered together; ties are broken in the order above.
 - **Ocean floor features** — mid-ocean ridges at divergent boundaries, deep trenches at subduction zones, fracture zones at transform boundaries, back-arc basins behind subduction zones
 - **Island arcs** — volcanic island chains at ocean-ocean convergent boundaries with ridged noise shaping
 - **Hotspot volcanism** — mantle plume simulation with drift-trail island chains, per-hotspot variation in strength/decay/spacing, and volcanic texture noise
-- **Terrain post-processing** — independently controllable bilateral smoothing to blend harsh BFS distance-field boundaries, and flow-accumulation erosion that carves natural drainage valleys using stream power law
+- **Terrain post-processing** — independently controllable bilateral smoothing to blend harsh BFS distance-field boundaries, glacial erosion that carves fjords, U-shaped valleys, and lake basins at high latitudes and altitudes via latitude-driven ice flow with drainage accumulation, priority-flood pit resolution with canyon carving (Barnes et al. algorithm that ensures every land cell drains to the ocean, carving dramatic canyons through mountain saddle points rather than filling basins), iterative implicit stream power hydraulic erosion (Braun-Willett style) that carves self-reinforcing river valleys with automatic sediment deposition in flat receivers, thermal erosion that softens ridges via talus-angle material transport, ridge sharpening that accentuates mountain ridgelines, and always-on soil creep (Laplacian diffusion) that rounds off hillslopes
 - **Coastal roughening** — fractal noise with active/passive margin differentiation, domain warping for bays/headlands, and offshore island scattering
 - **3D globe rendering** with atmosphere rim shader, translucent water sphere, terrain displacement, and starfield
 - **Equirectangular map projection** with antimeridian wrapping
@@ -48,7 +48,7 @@ Click **Build New World** to create a new random planet.
 
 ### Sharing Planets
 
-Every generated planet produces a **planet code** (shown below the Build button) that encodes the random seed, all slider values, and any plate edits. An unedited planet is 13 characters; Ctrl-click edits extend the code to include the toggled plates. To share a planet:
+Every generated planet produces a **planet code** (shown below the Build button) that encodes the random seed, all slider values, and any plate edits. An unedited planet is 17 characters; Ctrl-click edits extend the code to include the toggled plates. Legacy 13-character, 14-character, and 16-character codes (from earlier versions) are still supported and will use default values for any newer sliders. To share a planet:
 
 - **Copy** the code with the copy button and send it to someone
 - **Load** a code by pasting it into the planet code field and clicking Load (or pressing Enter). The Load button turns blue when a new code is ready to apply.
@@ -58,7 +58,7 @@ Every generated planet produces a **planet code** (shown below the Build button)
 
 ### Shape Your World
 
-All generation parameters live in a single section:
+Core world parameters that control the planet's structure (changing these requires a full rebuild):
 
 | Control | Range | Default | Description |
 |---------|-------|---------|-------------|
@@ -67,10 +67,18 @@ All generation parameters live in a single section:
 | Plates | 4 – 120 | 80 | Number of tectonic plates |
 | Continents | 1 – 10 | 4 | Target number of separate landmasses |
 | Roughness | 0 – 0.5 | 0.40 | Fractal noise magnitude for terrain roughness |
-| Smoothing | 0 – 1 | 0.10 | Blends harsh terrain boundaries from tectonic generation |
-| Basic Erosion | 0 – 1 | 0.10 | Simulates basic water erosion — carves drainage valleys using flow accumulation |
 
-Smoothing and Erosion do not require a full rebuild. Adjusting either slider lights up the **reapply** button (↻) next to Build New World — click it to reapply only the post-processing passes on the current planet.
+### Terrain Sculpting
+
+Post-processing passes that refine the terrain (collapsed by default — the defaults produce good results). These do not require a full rebuild; adjusting any slider lights up the **Reapply** button at the bottom of this section — click it to reapply only the sculpting passes on the current planet.
+
+| Control | Range | Default | Description |
+|---------|-------|---------|-------------|
+| Smoothing | 0 – 1 | 0.10 | Blends harsh terrain boundaries from tectonic generation |
+| Glacial Erosion | 0 – 1 | 0.35 | Ice-age sculpting — carves fjords, U-shaped valleys, and lake basins at high latitudes and altitudes via latitude-driven ice flow |
+| Hydraulic Erosion | 0 – 1 | 0.35 | Iterative stream-power erosion — resolves endorheic basins via priority-flood canyon carving, then carves river valleys and dendritic drainage networks, with automatic sediment deposition in flat receivers |
+| Thermal Erosion | 0 – 1 | 0.10 | Slope-driven material transport — softens ridges and creates natural talus slopes |
+| Ridge Sharpening | 0 – 1 | 0.35 | Accentuates mountain ridgelines — pushes peaks further above their surroundings for more dramatic terrain |
 
 ### Visual Options
 
@@ -124,7 +132,7 @@ Navigation hints are shown in the sidebar panel and as a contextual tooltip when
 7. **Collision detection** simulates plate drift to classify convergent/divergent/transform boundaries
 8. **Stress propagation** diffuses collision stress inward through continental plates via frontier BFS
 9. **Elevation assignment** combines distance fields, stress-driven uplift, ocean floor profiles, rift valleys, back-arc basins, hotspot volcanism, island arcs, coastal roughening, and multi-layered noise
-10. **Terrain post-processing** applies bilateral smoothing (controlled by Smoothing slider) to blend BFS banding artefacts, and flow-accumulation erosion (controlled by Erosion slider) carves drainage valleys using stream power law
+10. **Terrain post-processing** applies bilateral smoothing (controlled by Smoothing slider) to blend BFS banding artefacts, glacial erosion (controlled by Glacial Erosion slider) carves fjords, U-shaped valleys, and lake basins at high latitudes and altitudes, priority-flood pit resolution carves canyons through mountain saddle points to ensure all land drains to the ocean, iterative implicit stream power hydraulic erosion with sediment deposition (controlled by Hydraulic Erosion slider) carves self-reinforcing river valleys, thermal erosion (controlled by Thermal Erosion slider) softens ridges via talus-angle material transport, ridge sharpening (controlled by Ridge Sharpening slider) accentuates mountain ridgelines, and always-on soil creep gently rounds off hillslopes
 11. **Rendering** builds a Voronoi cell mesh with per-vertex colors and terrain displacement
 
 ### Key Algorithms
@@ -154,7 +162,7 @@ js/
   plates.js             Tectonic plate generation (round-robin flood fill)
   ocean-land.js         Ocean/land assignment with continent seeding
   elevation.js          Collisions, stress propagation, distance fields, elevation
-  terrain-post.js       Bilateral smoothing and flow-based erosion
+  terrain-post.js       Bilateral smoothing, glacial/hydraulic/thermal erosion, ridge sharpening, soil creep
   scene.js              Three.js scene, cameras, controls, lights
   planet-mesh.js        Voronoi mesh, map projection, hover highlight
   edit-mode.js          Ctrl-click plate toggle + hover info

--- a/index.html
+++ b/index.html
@@ -57,28 +57,46 @@
                     <input type="range" id="sNs" min="0" max="0.5" value="0.40" step="0.01">
                     <div class="slider-hint"><span>Smooth</span><span>Rugged</span></div>
                 </div>
-                <div class="cg">
-                    <label>Smoothing <span class="tip" data-tip="Blends harsh terrain boundaries from tectonic generation — smooths banded ridges and abrupt transitions">?</span> <span class="v" id="vS">0.1</span></label>
-                    <input type="range" id="sS" min="0" max="1" value="0.1" step="0.05">
-                    <div class="slider-hint"><span>None</span><span>Heavy</span></div>
-                </div>
-                <div class="cg">
-                    <label>Basic Erosion <span class="tip" data-tip="Simulates basic water erosion — carves natural drainage valleys using flow accumulation">?</span> <span class="v" id="vEr">0.1</span></label>
-                    <input type="range" id="sEr" min="0" max="1" value="0.1" step="0.05">
-                    <div class="slider-hint"><span>None</span><span>Heavy</span></div>
-                </div>
             </div>
         </details>
-        <div id="buildRow">
-            <button id="generate">Build New World</button>
-            <button id="reapplyBtn" title="Reapply smoothing &amp; erosion" disabled>&#x21bb;</button>
-        </div>
+        <button id="generate">Build New World</button>
         <div id="seedRow">
             <input type="text" id="seedCode" placeholder="Planet code">
             <button id="copyBtn" title="Copy code">&#x2398;</button>
             <button id="loadBtn" title="Load planet from code">Load</button>
         </div>
         <div id="seedError">Invalid planet code</div>
+        <details class="section">
+            <summary>Terrain Sculpting <span class="tip" data-tip="Erosion and smoothing passes that refine the raw terrain. Adjust sliders and click Reapply — no full rebuild needed.">?</span></summary>
+            <div class="section-body">
+                <div class="cg">
+                    <label>Smoothing <span class="tip" data-tip="Blends harsh terrain boundaries from tectonic generation — smooths banded ridges and abrupt transitions">?</span> <span class="v" id="vS">0.10</span></label>
+                    <input type="range" id="sS" min="0" max="1" value="0.10" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Heavy</span></div>
+                </div>
+                <div class="cg">
+                    <label>Glacial Erosion <span class="tip" data-tip="Ice-age sculpting — carves fjords, U-shaped valleys, and lake basins at high latitudes and altitudes">?</span> <span class="v" id="vGl">0.35</span></label>
+                    <input type="range" id="sGl" min="0" max="1" value="0.35" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Ice Age</span></div>
+                </div>
+                <div class="cg">
+                    <label>Hydraulic Erosion <span class="tip" data-tip="Iterative stream-power erosion — carves river valleys and dendritic drainage networks">?</span> <span class="v" id="vHEr">0.35</span></label>
+                    <input type="range" id="sHEr" min="0" max="1" value="0.35" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Deep</span></div>
+                </div>
+                <div class="cg">
+                    <label>Thermal Erosion <span class="tip" data-tip="Slope-driven material transport — softens ridges and creates natural talus slopes">?</span> <span class="v" id="vTEr">0.10</span></label>
+                    <input type="range" id="sTEr" min="0" max="1" value="0.10" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Heavy</span></div>
+                </div>
+                <div class="cg">
+                    <label>Ridge Sharpening <span class="tip" data-tip="Accentuates mountain ridgelines — pushes peaks further above their surroundings for more dramatic terrain">?</span> <span class="v" id="vRs">0.35</span></label>
+                    <input type="range" id="sRs" min="0" max="1" value="0.35" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Jagged</span></div>
+                </div>
+                <button id="reapplyBtn" title="Reapply terrain sculpting" disabled>&#x21bb; Reapply</button>
+            </div>
+        </details>
         <details class="section" open>
             <summary>Visual Options</summary>
             <div class="section-body">
@@ -147,7 +165,7 @@
             </div>
             <div class="tutorial-step" data-step="1">
                 <h3>Shape Your World</h3>
-                <p>Use the sliders in the left panel to control your planet's detail, plate count, number of continents, terrain roughness, smoothing, and basic erosion. Then hit <strong>Build New World</strong> to generate.</p>
+                <p>Use the <strong>Shape Your World</strong> sliders to control detail, plates, continents, and roughness, then hit <strong>Build New World</strong>. Expand <strong>Terrain Sculpting</strong> to fine-tune erosion and smoothing &mdash; these can be reapplied instantly with the <strong>&#x21bb;</strong> button.</p>
             </div>
             <div class="tutorial-step" data-step="2">
                 <h3>Explore &amp; Edit</h3>

--- a/js/planet-code.js
+++ b/js/planet-code.js
@@ -9,14 +9,30 @@ const SLIDERS = [
     { min: 1,     step: 1,    count: 10  }, // Continents
     { min: 0,     step: 0.01, count: 51  }, // Roughness
     { min: 0,     step: 0.05, count: 21  }, // Smoothing
-    { min: 0,     step: 0.05, count: 21  }, // Erosion
+    { min: 0,     step: 0.05, count: 21  }, // Glacial Erosion
+    { min: 0,     step: 0.05, count: 21  }, // Hydraulic Erosion
+    { min: 0,     step: 0.05, count: 21  }, // Thermal Erosion
+    { min: 0,     step: 0.05, count: 21  }, // Ridge Sharpening
+    { min: 0,     step: 0.05, count: 21  }, // Soil Creep
 ];
 
-// Mixed-radix bases (right-to-left): erIdx, smIdx, nsIdx, cnIdx, pIdx, jIdx, nIdx, seed
-const RADICES = [21, 21, 51, 10, 117, 21, 2559];
+// Mixed-radix bases (right-to-left): scIdx, rsIdx, teIdx, heIdx, glIdx, smIdx, nsIdx, cnIdx, pIdx, jIdx, nIdx, seed
+const RADICES = [21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2559];
 const SEED_MAX = 16777216; // 2^24
-const BASE_LEN = 13; // base code length (no toggles)
+const BASE_LEN = 17; // base code length (no toggles)
+const PREV2_LEN = 16; // previous 16-char codes (before glacial erosion)
+const PREV_LEN = 14; // previous 14-char codes (before ridge/creep)
+const LEGACY_LEN = 13; // legacy 13-char codes (single erosion slider)
 const IDX_CHARS = 2; // base36 chars per plate index (max index 119 = "3b")
+
+// Legacy radices for decoding old 13-char codes (single erosion slider)
+const LEGACY_RADICES = [21, 21, 51, 10, 117, 21, 2559];
+
+// Previous-gen radices for decoding 14-char codes (two erosion sliders, no ridge/creep)
+const PREV_RADICES = [21, 21, 21, 51, 10, 117, 21, 2559];
+
+// Previous2-gen radices for decoding 16-char codes (no glacial erosion)
+const PREV2_RADICES = [21, 21, 21, 21, 21, 51, 10, 117, 21, 2559];
 
 function toIndex(value, slider) {
     return Math.round((value - slider.min) / slider.step);
@@ -47,28 +63,40 @@ function parseBase36(str) {
  * @param {number} numContinents - Continents (1–10, step 1)
  * @param {number} roughness - Roughness (0–0.5, step 0.01)
  * @param {number} smoothing - Smoothing (0–1, step 0.05)
- * @param {number} erosion - Erosion (0–1, step 0.05)
+ * @param {number} glacialErosion - Glacial Erosion (0–1, step 0.05)
+ * @param {number} hydraulicErosion - Hydraulic Erosion (0–1, step 0.05)
+ * @param {number} thermalErosion - Thermal Erosion (0–1, step 0.05)
+ * @param {number} ridgeSharpening - Ridge Sharpening (0–1, step 0.05)
+ * @param {number} soilCreep - Soil Creep (0–1, step 0.05)
  * @param {number[]} [toggledIndices=[]] - Sorted array of toggled plate indices
- * @returns {string} base36 code (13 chars without edits, 13 + '-' + 2*k with k edits)
+ * @returns {string} base36 code (17 chars without edits, 17 + '-' + 2*k with k edits)
  */
-export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, smoothing, erosion, toggledIndices = []) {
+export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, soilCreep, toggledIndices = []) {
     const nIdx  = toIndex(N, SLIDERS[0]);
     const jIdx  = toIndex(jitter, SLIDERS[1]);
     const pIdx  = toIndex(P, SLIDERS[2]);
     const cnIdx = toIndex(numContinents, SLIDERS[3]);
     const nsIdx = toIndex(roughness, SLIDERS[4]);
     const smIdx = toIndex(smoothing, SLIDERS[5]);
-    const erIdx = toIndex(erosion, SLIDERS[6]);
+    const glIdx = toIndex(glacialErosion, SLIDERS[6]);
+    const heIdx = toIndex(hydraulicErosion, SLIDERS[7]);
+    const teIdx = toIndex(thermalErosion, SLIDERS[8]);
+    const rsIdx = toIndex(ridgeSharpening, SLIDERS[9]);
+    const scIdx = toIndex(soilCreep, SLIDERS[10]);
 
-    // Mixed-radix packing (least-significant first: erIdx, smIdx)
+    // Mixed-radix packing (least-significant first: scIdx, rsIdx, teIdx, ...)
     let packed = BigInt(seed);
-    packed = packed * BigInt(RADICES[6]) + BigInt(nIdx);   // * 2559
-    packed = packed * BigInt(RADICES[5]) + BigInt(jIdx);   // * 21
-    packed = packed * BigInt(RADICES[4]) + BigInt(pIdx);   // * 117
-    packed = packed * BigInt(RADICES[3]) + BigInt(cnIdx);  // * 10
-    packed = packed * BigInt(RADICES[2]) + BigInt(nsIdx);  // * 51
-    packed = packed * BigInt(RADICES[1]) + BigInt(smIdx);  // * 21
-    packed = packed * BigInt(RADICES[0]) + BigInt(erIdx);  // * 21
+    packed = packed * BigInt(RADICES[10]) + BigInt(nIdx);   // * 2559
+    packed = packed * BigInt(RADICES[9])  + BigInt(jIdx);   // * 21
+    packed = packed * BigInt(RADICES[8])  + BigInt(pIdx);   // * 117
+    packed = packed * BigInt(RADICES[7])  + BigInt(cnIdx);  // * 10
+    packed = packed * BigInt(RADICES[6])  + BigInt(nsIdx);  // * 51
+    packed = packed * BigInt(RADICES[5])  + BigInt(smIdx);  // * 21
+    packed = packed * BigInt(RADICES[4])  + BigInt(glIdx);  // * 21
+    packed = packed * BigInt(RADICES[3])  + BigInt(heIdx);  // * 21
+    packed = packed * BigInt(RADICES[2])  + BigInt(teIdx);  // * 21
+    packed = packed * BigInt(RADICES[1])  + BigInt(rsIdx);  // * 21
+    packed = packed * BigInt(RADICES[0])  + BigInt(scIdx);  // * 21
 
     let code = packed.toString(36).padStart(BASE_LEN, '0');
 
@@ -84,8 +112,9 @@ export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, s
 
 /**
  * Decode a base36 planet code back into planet parameters.
- * @param {string} code - base36 code (13 chars, optionally followed by "-" + toggle indices)
- * @returns {{ seed: number, N: number, jitter: number, P: number, numContinents: number, roughness: number, smoothing: number, erosion: number, toggledIndices: number[] } | null}
+ * Supports 17-char (current), 16-char (prev2), 14-char (previous-gen), and 13-char (legacy) codes.
+ * @param {string} code - base36 code (13, 14, 16, or 17 chars, optionally followed by "-" + toggle indices)
+ * @returns {{ seed: number, N: number, jitter: number, P: number, numContinents: number, roughness: number, smoothing: number, glacialErosion: number, hydraulicErosion: number, thermalErosion: number, ridgeSharpening: number, soilCreep: number, toggledIndices: number[] } | null}
  */
 export function decodePlanetCode(code) {
     if (typeof code !== 'string') return null;
@@ -96,7 +125,12 @@ export function decodePlanetCode(code) {
     const base = dashIdx === -1 ? code : code.slice(0, dashIdx);
     const toggleStr = dashIdx === -1 ? '' : code.slice(dashIdx + 1);
 
-    if (!/^[0-9a-z]{13}$/.test(base)) return null;
+    const isLegacy = base.length === LEGACY_LEN;
+    const isPrev = base.length === PREV_LEN;
+    const isPrev2 = base.length === PREV2_LEN;
+    const isNew = base.length === BASE_LEN;
+    if (!isLegacy && !isPrev && !isPrev2 && !isNew) return null;
+    if (!/^[0-9a-z]+$/.test(base)) return null;
     if (toggleStr && !/^[0-9a-z]+$/.test(toggleStr)) return null;
     if (toggleStr && toggleStr.length % IDX_CHARS !== 0) return null;
 
@@ -107,27 +141,229 @@ export function decodePlanetCode(code) {
         return null;
     }
 
-    // Unpack in reverse order (least-significant first: erIdx, smIdx)
-    const erIdx = Number(packed % BigInt(RADICES[0]));
+    if (isLegacy) {
+        // Legacy 13-char decode: single erosion slider
+        const erIdx = Number(packed % BigInt(LEGACY_RADICES[0]));
+        packed = packed / BigInt(LEGACY_RADICES[0]);
+
+        const smIdx = Number(packed % BigInt(LEGACY_RADICES[1]));
+        packed = packed / BigInt(LEGACY_RADICES[1]);
+
+        const nsIdx = Number(packed % BigInt(LEGACY_RADICES[2]));
+        packed = packed / BigInt(LEGACY_RADICES[2]);
+
+        const cnIdx = Number(packed % BigInt(LEGACY_RADICES[3]));
+        packed = packed / BigInt(LEGACY_RADICES[3]);
+
+        const pIdx = Number(packed % BigInt(LEGACY_RADICES[4]));
+        packed = packed / BigInt(LEGACY_RADICES[4]);
+
+        const jIdx = Number(packed % BigInt(LEGACY_RADICES[5]));
+        packed = packed / BigInt(LEGACY_RADICES[5]);
+
+        const nIdx = Number(packed % BigInt(LEGACY_RADICES[6]));
+        packed = packed / BigInt(LEGACY_RADICES[6]);
+
+        const seed = Number(packed);
+
+        if (seed < 0 || seed >= SEED_MAX) return null;
+        if (nIdx >= SLIDERS[0].count || jIdx >= SLIDERS[1].count ||
+            pIdx >= SLIDERS[2].count || cnIdx >= SLIDERS[3].count ||
+            nsIdx >= SLIDERS[4].count || smIdx >= SLIDERS[5].count ||
+            erIdx >= SLIDERS[7].count) return null;
+
+        const P = fromIndex(pIdx, SLIDERS[2]);
+
+        const toggledIndices = [];
+        if (toggleStr) {
+            for (let i = 0; i < toggleStr.length; i += IDX_CHARS) {
+                const idx = parseInt(toggleStr.slice(i, i + IDX_CHARS), 36);
+                if (isNaN(idx) || idx >= P) return null;
+                toggledIndices.push(idx);
+            }
+        }
+
+        return {
+            seed,
+            N:                fromIndex(nIdx, SLIDERS[0]),
+            jitter:           fromIndex(jIdx, SLIDERS[1]),
+            P,
+            numContinents:    fromIndex(cnIdx, SLIDERS[3]),
+            roughness:        fromIndex(nsIdx, SLIDERS[4]),
+            smoothing:        fromIndex(smIdx, SLIDERS[5]),
+            glacialErosion:   0,
+            hydraulicErosion: fromIndex(erIdx, SLIDERS[7]), // map old erosion → hydraulic
+            thermalErosion:   0.1,                          // default for legacy codes
+            ridgeSharpening:  0.35,
+            soilCreep:        0.05,
+            toggledIndices,
+        };
+    }
+
+    if (isPrev) {
+        // Previous-gen 14-char decode: two erosion sliders, no ridge/creep/glacial
+        const teIdx = Number(packed % BigInt(PREV_RADICES[0]));
+        packed = packed / BigInt(PREV_RADICES[0]);
+
+        const heIdx = Number(packed % BigInt(PREV_RADICES[1]));
+        packed = packed / BigInt(PREV_RADICES[1]);
+
+        const smIdx = Number(packed % BigInt(PREV_RADICES[2]));
+        packed = packed / BigInt(PREV_RADICES[2]);
+
+        const nsIdx = Number(packed % BigInt(PREV_RADICES[3]));
+        packed = packed / BigInt(PREV_RADICES[3]);
+
+        const cnIdx = Number(packed % BigInt(PREV_RADICES[4]));
+        packed = packed / BigInt(PREV_RADICES[4]);
+
+        const pIdx = Number(packed % BigInt(PREV_RADICES[5]));
+        packed = packed / BigInt(PREV_RADICES[5]);
+
+        const jIdx = Number(packed % BigInt(PREV_RADICES[6]));
+        packed = packed / BigInt(PREV_RADICES[6]);
+
+        const nIdx = Number(packed % BigInt(PREV_RADICES[7]));
+        packed = packed / BigInt(PREV_RADICES[7]);
+
+        const seed = Number(packed);
+
+        if (seed < 0 || seed >= SEED_MAX) return null;
+        if (nIdx >= SLIDERS[0].count || jIdx >= SLIDERS[1].count ||
+            pIdx >= SLIDERS[2].count || cnIdx >= SLIDERS[3].count ||
+            nsIdx >= SLIDERS[4].count || smIdx >= SLIDERS[5].count ||
+            heIdx >= SLIDERS[7].count || teIdx >= SLIDERS[8].count) return null;
+
+        const P = fromIndex(pIdx, SLIDERS[2]);
+
+        const toggledIndices = [];
+        if (toggleStr) {
+            for (let i = 0; i < toggleStr.length; i += IDX_CHARS) {
+                const idx = parseInt(toggleStr.slice(i, i + IDX_CHARS), 36);
+                if (isNaN(idx) || idx >= P) return null;
+                toggledIndices.push(idx);
+            }
+        }
+
+        return {
+            seed,
+            N:                fromIndex(nIdx, SLIDERS[0]),
+            jitter:           fromIndex(jIdx, SLIDERS[1]),
+            P,
+            numContinents:    fromIndex(cnIdx, SLIDERS[3]),
+            roughness:        fromIndex(nsIdx, SLIDERS[4]),
+            smoothing:        fromIndex(smIdx, SLIDERS[5]),
+            glacialErosion:   0,
+            hydraulicErosion: fromIndex(heIdx, SLIDERS[7]),
+            thermalErosion:   fromIndex(teIdx, SLIDERS[8]),
+            ridgeSharpening:  0.35,
+            soilCreep:        0.05,
+            toggledIndices,
+        };
+    }
+
+    if (isPrev2) {
+        // Previous2-gen 16-char decode: all sliders except glacial erosion
+        const scIdx = Number(packed % BigInt(PREV2_RADICES[0]));
+        packed = packed / BigInt(PREV2_RADICES[0]);
+
+        const rsIdx = Number(packed % BigInt(PREV2_RADICES[1]));
+        packed = packed / BigInt(PREV2_RADICES[1]);
+
+        const teIdx = Number(packed % BigInt(PREV2_RADICES[2]));
+        packed = packed / BigInt(PREV2_RADICES[2]);
+
+        const heIdx = Number(packed % BigInt(PREV2_RADICES[3]));
+        packed = packed / BigInt(PREV2_RADICES[3]);
+
+        const smIdx = Number(packed % BigInt(PREV2_RADICES[4]));
+        packed = packed / BigInt(PREV2_RADICES[4]);
+
+        const nsIdx = Number(packed % BigInt(PREV2_RADICES[5]));
+        packed = packed / BigInt(PREV2_RADICES[5]);
+
+        const cnIdx = Number(packed % BigInt(PREV2_RADICES[6]));
+        packed = packed / BigInt(PREV2_RADICES[6]);
+
+        const pIdx = Number(packed % BigInt(PREV2_RADICES[7]));
+        packed = packed / BigInt(PREV2_RADICES[7]);
+
+        const jIdx = Number(packed % BigInt(PREV2_RADICES[8]));
+        packed = packed / BigInt(PREV2_RADICES[8]);
+
+        const nIdx = Number(packed % BigInt(PREV2_RADICES[9]));
+        packed = packed / BigInt(PREV2_RADICES[9]);
+
+        const seed = Number(packed);
+
+        if (seed < 0 || seed >= SEED_MAX) return null;
+        if (nIdx >= SLIDERS[0].count || jIdx >= SLIDERS[1].count ||
+            pIdx >= SLIDERS[2].count || cnIdx >= SLIDERS[3].count ||
+            nsIdx >= SLIDERS[4].count || smIdx >= SLIDERS[5].count ||
+            heIdx >= SLIDERS[7].count || teIdx >= SLIDERS[8].count ||
+            rsIdx >= SLIDERS[9].count || scIdx >= SLIDERS[10].count) return null;
+
+        const P = fromIndex(pIdx, SLIDERS[2]);
+
+        const toggledIndices = [];
+        if (toggleStr) {
+            for (let i = 0; i < toggleStr.length; i += IDX_CHARS) {
+                const idx = parseInt(toggleStr.slice(i, i + IDX_CHARS), 36);
+                if (isNaN(idx) || idx >= P) return null;
+                toggledIndices.push(idx);
+            }
+        }
+
+        return {
+            seed,
+            N:                fromIndex(nIdx, SLIDERS[0]),
+            jitter:           fromIndex(jIdx, SLIDERS[1]),
+            P,
+            numContinents:    fromIndex(cnIdx, SLIDERS[3]),
+            roughness:        fromIndex(nsIdx, SLIDERS[4]),
+            smoothing:        fromIndex(smIdx, SLIDERS[5]),
+            glacialErosion:   0,
+            hydraulicErosion: fromIndex(heIdx, SLIDERS[7]),
+            thermalErosion:   fromIndex(teIdx, SLIDERS[8]),
+            ridgeSharpening:  fromIndex(rsIdx, SLIDERS[9]),
+            soilCreep:        fromIndex(scIdx, SLIDERS[10]),
+            toggledIndices,
+        };
+    }
+
+    // New 17-char decode: all sliders including glacial erosion
+    const scIdx = Number(packed % BigInt(RADICES[0]));
     packed = packed / BigInt(RADICES[0]);
 
-    const smIdx = Number(packed % BigInt(RADICES[1]));
+    const rsIdx = Number(packed % BigInt(RADICES[1]));
     packed = packed / BigInt(RADICES[1]);
 
-    const nsIdx = Number(packed % BigInt(RADICES[2]));
+    const teIdx = Number(packed % BigInt(RADICES[2]));
     packed = packed / BigInt(RADICES[2]);
 
-    const cnIdx = Number(packed % BigInt(RADICES[3]));
+    const heIdx = Number(packed % BigInt(RADICES[3]));
     packed = packed / BigInt(RADICES[3]);
 
-    const pIdx = Number(packed % BigInt(RADICES[4]));
+    const glIdx = Number(packed % BigInt(RADICES[4]));
     packed = packed / BigInt(RADICES[4]);
 
-    const jIdx = Number(packed % BigInt(RADICES[5]));
+    const smIdx = Number(packed % BigInt(RADICES[5]));
     packed = packed / BigInt(RADICES[5]);
 
-    const nIdx = Number(packed % BigInt(RADICES[6]));
+    const nsIdx = Number(packed % BigInt(RADICES[6]));
     packed = packed / BigInt(RADICES[6]);
+
+    const cnIdx = Number(packed % BigInt(RADICES[7]));
+    packed = packed / BigInt(RADICES[7]);
+
+    const pIdx = Number(packed % BigInt(RADICES[8]));
+    packed = packed / BigInt(RADICES[8]);
+
+    const jIdx = Number(packed % BigInt(RADICES[9]));
+    packed = packed / BigInt(RADICES[9]);
+
+    const nIdx = Number(packed % BigInt(RADICES[10]));
+    packed = packed / BigInt(RADICES[10]);
 
     const seed = Number(packed);
 
@@ -136,7 +372,9 @@ export function decodePlanetCode(code) {
     if (nIdx >= SLIDERS[0].count || jIdx >= SLIDERS[1].count ||
         pIdx >= SLIDERS[2].count || cnIdx >= SLIDERS[3].count ||
         nsIdx >= SLIDERS[4].count || smIdx >= SLIDERS[5].count ||
-        erIdx >= SLIDERS[6].count) return null;
+        glIdx >= SLIDERS[6].count || heIdx >= SLIDERS[7].count ||
+        teIdx >= SLIDERS[8].count || rsIdx >= SLIDERS[9].count ||
+        scIdx >= SLIDERS[10].count) return null;
 
     const P = fromIndex(pIdx, SLIDERS[2]);
 
@@ -152,13 +390,17 @@ export function decodePlanetCode(code) {
 
     return {
         seed,
-        N:             fromIndex(nIdx, SLIDERS[0]),
-        jitter:        fromIndex(jIdx, SLIDERS[1]),
+        N:                fromIndex(nIdx, SLIDERS[0]),
+        jitter:           fromIndex(jIdx, SLIDERS[1]),
         P,
-        numContinents: fromIndex(cnIdx, SLIDERS[3]),
-        roughness:     fromIndex(nsIdx, SLIDERS[4]),
-        smoothing:     fromIndex(smIdx, SLIDERS[5]),
-        erosion:       fromIndex(erIdx, SLIDERS[6]),
+        numContinents:    fromIndex(cnIdx, SLIDERS[3]),
+        roughness:        fromIndex(nsIdx, SLIDERS[4]),
+        smoothing:        fromIndex(smIdx, SLIDERS[5]),
+        glacialErosion:   fromIndex(glIdx, SLIDERS[6]),
+        hydraulicErosion: fromIndex(heIdx, SLIDERS[7]),
+        thermalErosion:   fromIndex(teIdx, SLIDERS[8]),
+        ridgeSharpening:  fromIndex(rsIdx, SLIDERS[9]),
+        soilCreep:        fromIndex(scIdx, SLIDERS[10]),
         toggledIndices,
     };
 }

--- a/js/terrain-post.js
+++ b/js/terrain-post.js
@@ -3,6 +3,218 @@
 // natural drainage patterns.
 
 /**
+ * Inline binary min-heap keyed on an external Float32Array of priorities.
+ * Each cell is pushed/popped exactly once — no decrease-key needed.
+ */
+class MinHeap {
+    constructor(keyArray) {
+        this._key = keyArray;
+        this._data = [];
+    }
+    get size() { return this._data.length; }
+    push(cell) {
+        this._data.push(cell);
+        let i = this._data.length - 1;
+        while (i > 0) {
+            const parent = (i - 1) >> 1;
+            if (this._key[this._data[i]] >= this._key[this._data[parent]]) break;
+            const tmp = this._data[i]; this._data[i] = this._data[parent]; this._data[parent] = tmp;
+            i = parent;
+        }
+    }
+    pop() {
+        const top = this._data[0];
+        const last = this._data.pop();
+        if (this._data.length > 0) {
+            this._data[0] = last;
+            let i = 0;
+            const n = this._data.length;
+            while (true) {
+                let smallest = i;
+                const l = 2 * i + 1, r = 2 * i + 2;
+                if (l < n && this._key[this._data[l]] < this._key[this._data[smallest]]) smallest = l;
+                if (r < n && this._key[this._data[r]] < this._key[this._data[smallest]]) smallest = r;
+                if (smallest === i) break;
+                const tmp = this._data[i]; this._data[i] = this._data[smallest]; this._data[smallest] = tmp;
+                i = smallest;
+            }
+        }
+        return top;
+    }
+}
+
+/**
+ * Priority-flood pit resolution with canyon carving.
+ * Ensures every land cell has a monotonically descending drainage path to
+ * the ocean, favoring carving through spill points over filling pit floors.
+ *
+ * Pass 1: Standard Barnes et al. priority-flood fill from ocean-adjacent
+ *         land cells inward → surface[], drainTo[]
+ * Pass 2: Redistribute fill deficit as carving along spill paths
+ * Pass 3: Enforce monotonic drainage with epsilon gradient
+ */
+function priorityFloodCarve(mesh, r_elevation, r_isOcean, carveStrength) {
+    const N = mesh.numRegions;
+    const out_r = [];
+    const EPS = 1e-7;
+
+    // --- Identify the main ocean body via BFS ---
+    // Find connected ocean components and mark only the largest as "open ocean"
+    const oceanLabel = new Int32Array(N).fill(-1);
+    const componentSizes = [];
+    for (let r = 0; r < N; r++) {
+        if (!r_isOcean[r] || oceanLabel[r] >= 0) continue;
+        const label = componentSizes.length;
+        let size = 0;
+        const queue = [r];
+        oceanLabel[r] = label;
+        while (queue.length > 0) {
+            const cur = queue.pop();
+            size++;
+            mesh.r_circulate_r(out_r, cur);
+            for (let i = 0; i < out_r.length; i++) {
+                const nb = out_r[i];
+                if (r_isOcean[nb] && oceanLabel[nb] < 0) {
+                    oceanLabel[nb] = label;
+                    queue.push(nb);
+                }
+            }
+        }
+        componentSizes.push(size);
+    }
+    let mainOceanLabel = 0;
+    for (let i = 1; i < componentSizes.length; i++) {
+        if (componentSizes[i] > componentSizes[mainOceanLabel]) mainOceanLabel = i;
+    }
+    const isOpenOcean = new Uint8Array(N);
+    for (let r = 0; r < N; r++) {
+        if (r_isOcean[r] && oceanLabel[r] === mainOceanLabel) isOpenOcean[r] = 1;
+    }
+
+    // --- Deterministic hash for noise perturbation (meander paths) ---
+    // Small noise on priority keys makes the flood front irregular,
+    // producing winding drainage paths instead of straight lines
+    const NOISE_AMP = 0.01; // amplitude relative to typical elevation range
+    function cellNoise(r) {
+        let h = (r * 2654435761) >>> 0; // Knuth multiplicative hash
+        h = ((h >>> 16) ^ h) * 0x45d9f3b >>> 0;
+        h = ((h >>> 16) ^ h) >>> 0;
+        return (h / 0xffffffff) * NOISE_AMP;
+    }
+
+    const surface = new Float32Array(r_elevation);
+    const drainTo = new Int32Array(N).fill(-1);
+    const visited = new Uint8Array(N);
+
+    // Priority key array — elevation + small noise for meandering
+    const key = new Float32Array(N);
+    for (let r = 0; r < N; r++) key[r] = r_elevation[r] + cellNoise(r);
+
+    const heap = new MinHeap(key);
+
+    // Seed: land cells adjacent to the main open ocean (not inland seas)
+    for (let r = 0; r < N; r++) {
+        if (r_isOcean[r]) { visited[r] = 1; continue; }
+        mesh.r_circulate_r(out_r, r);
+        for (let i = 0; i < out_r.length; i++) {
+            if (isOpenOcean[out_r[i]]) {
+                visited[r] = 1;
+                drainTo[r] = out_r[i]; // drains to open ocean neighbor
+                heap.push(r);
+                break;
+            }
+        }
+    }
+
+    // Pass 1: priority-flood fill (noise-perturbed for winding paths)
+    while (heap.size > 0) {
+        const r = heap.pop();
+        const surfR = surface[r];
+        mesh.r_circulate_r(out_r, r);
+        for (let i = 0; i < out_r.length; i++) {
+            const nb = out_r[i];
+            if (visited[nb]) continue;
+            visited[nb] = 1;
+            drainTo[nb] = r;
+            if (r_elevation[nb] < surfR + EPS) {
+                // Pit detected — fill to current surface + epsilon
+                surface[nb] = surfR + EPS;
+                key[nb] = surface[nb] + cellNoise(nb);
+            }
+            // else: neighbor drains naturally, surface[nb] already = r_elevation[nb]
+            heap.push(nb);
+        }
+    }
+
+    // Pass 2: carve-bias redistribution
+    // For each filled cell, trace path back to ocean, find the peak (spill point),
+    // and redistribute deficit as carving near the peak
+    for (let r = 0; r < N; r++) {
+        if (r_isOcean[r]) continue;
+        const deficit = surface[r] - r_elevation[r];
+        if (deficit <= EPS) continue;
+
+        // Trace drainTo path toward ocean, collect path and find peak
+        const path = [];
+        let peakIdx = -1;
+        let peakElev = -Infinity;
+        let cur = r;
+        while (cur >= 0 && !r_isOcean[cur]) {
+            path.push(cur);
+            if (r_elevation[cur] > peakElev) {
+                peakElev = r_elevation[cur];
+                peakIdx = path.length - 1;
+            }
+            cur = drainTo[cur];
+        }
+
+        if (peakIdx < 0 || path.length === 0) continue;
+
+        // Carve: lower cells near the peak using a triangle kernel
+        const carveAmount = deficit * carveStrength;
+        const radius = Math.max(3, Math.ceil(path.length * 0.3));
+        const startIdx = Math.max(0, peakIdx - radius);
+        const endIdx = Math.min(path.length - 1, peakIdx + radius);
+
+        let kernelSum = 0;
+        for (let k = startIdx; k <= endIdx; k++) {
+            const dist = Math.abs(k - peakIdx);
+            kernelSum += 1 - dist / (radius + 1);
+        }
+        if (kernelSum > 0) {
+            for (let k = startIdx; k <= endIdx; k++) {
+                const dist = Math.abs(k - peakIdx);
+                const weight = (1 - dist / (radius + 1)) / kernelSum;
+                r_elevation[path[k]] -= carveAmount * weight;
+                if (r_elevation[path[k]] < 0) r_elevation[path[k]] = 0;
+            }
+        }
+
+        // Fill: raise the pit floor by the remaining fraction
+        const fillAmount = deficit * (1 - carveStrength);
+        r_elevation[r] += fillAmount;
+    }
+
+    // Pass 3: enforce monotonic drainage along drainTo paths
+    // Process cells in order of ascending surface (re-sort by surface)
+    const order = [];
+    for (let r = 0; r < N; r++) {
+        if (!r_isOcean[r]) order.push(r);
+    }
+    order.sort((a, b) => surface[a] - surface[b]);
+
+    for (let i = 0; i < order.length; i++) {
+        const r = order[i];
+        const target = drainTo[r];
+        if (target < 0) continue;
+        const targetElev = r_isOcean[target] ? 0 : r_elevation[target];
+        if (r_elevation[r] <= targetElev) {
+            r_elevation[r] = targetElev + EPS;
+        }
+    }
+}
+
+/**
  * Bilateral-weighted Laplacian smoothing.
  * Neighbors with similar elevation receive more weight, preserving ridges
  * and trenches while blending the banded artefacts from BFS distance fields.
@@ -50,17 +262,28 @@ export function smoothElevation(mesh, r_elevation, r_isOcean, iterations, streng
 }
 
 /**
- * Simple flow-accumulation erosion (land cells only).
+ * Combined iterative erosion — interleaves hydraulic (stream power) and
+ * thermal (talus-angle) passes so they interact each iteration.
  *
- * 1. Drainage graph — each land cell drains to its lowest neighbor (steepest descent).
- * 2. Flow accumulation — cells sorted by elevation descending; each starts with 1 unit
- *    of "rain" and passes accumulated flow to its drain target.
- * 3. Erosion & deposition — stream power law: erosion = K * sqrt(flow) * slope.
- *    Capped at 30% of cell height. A fraction of eroded material deposits at the
- *    drain target, weighted by how flat that target is.
+ * Hydraulic: Braun-Willett implicit stream power. Rebuilds drainage graph
+ * each iteration so carved valleys attract more flow.
+ *
+ * Thermal: Slope-driven material transport. Redistributes material from
+ * steep slopes to lower neighbors using a simultaneous delta buffer.
+ *
+ * Each iteration runs one hydraulic step then one thermal step (if their
+ * respective iteration counts haven't been exhausted).
  */
-export function erodeElevation(mesh, r_elevation, r_xyz, r_isOcean, erosionK) {
-    if (erosionK <= 0) return;
+export function erodeComposite(mesh, r_elevation, r_xyz, r_isOcean,
+    hIters, K, m, dt,
+    tIters, talusSlope, kThermal,
+    gIters, glacialStrength)
+{
+    gIters = gIters || 0;
+    glacialStrength = glacialStrength || 0;
+
+    const totalIters = Math.max(hIters, tIters, gIters);
+    if (totalIters <= 0) return;
 
     const N = mesh.numRegions;
     const out_r = [];
@@ -73,67 +296,395 @@ export function erodeElevation(mesh, r_elevation, r_xyz, r_isOcean, erosionK) {
     const landCount = landCells.length;
     if (landCount === 0) return;
 
-    // --- Pass 1: Drainage graph ---
-    const drainTarget = new Int32Array(N).fill(-1);
-    const drainSlope = new Float32Array(N);
+    // Shared buffers
+    const drainTarget = new Int32Array(N);
+    const cellDist = new Float32Array(N);
+    const flow = new Float32Array(N);
+    const delta = new Float32Array(N);
 
-    for (let i = 0; i < landCount; i++) {
-        const r = landCells[i];
-        const h = r_elevation[r];
-        mesh.r_circulate_r(out_r, r);
+    // Priority-flood pit resolution: ensure every land cell drains to ocean
+    // before hydraulic erosion begins. Carves canyons through spill points.
+    if (hIters > 0) {
+        priorityFloodCarve(mesh, r_elevation, r_isOcean, 0.5);
+    }
 
-        let bestNb = -1, bestDrop = 0;
-        for (let j = 0; j < out_r.length; j++) {
-            const nb = out_r[j];
-            const drop = h - r_elevation[nb];
-            if (drop > bestDrop) {
-                bestDrop = drop;
-                bestNb = nb;
+    // ---- Glacial precomputation (once — index is position-based) ----
+    let glacIdx = null;
+    let iceTarget = null;
+    let iceFlow = null;
+    let numIceUpstream = null;
+
+    if (gIters > 0 && glacialStrength > 0) {
+        function smoothstep(x, edge0, edge1) {
+            const t = Math.max(0, Math.min(1, (x - edge0) / (edge1 - edge0)));
+            return t * t * (3 - 2 * t);
+        }
+
+        glacIdx = new Float32Array(N);
+        // At strength=1 glaciation starts at ~50° latitude; at 0.5 it starts at ~70°
+        const thresholdLat = Math.PI / 2 - glacialStrength * Math.PI / 4.5;
+
+        for (let r = 0; r < N; r++) {
+            if (r_isOcean[r]) continue;
+            const y = r_xyz[3 * r + 1];
+            const polarDist = Math.abs(Math.asin(Math.max(-1, Math.min(1, y))));
+            const latFactor = smoothstep(polarDist, thresholdLat, Math.PI / 2);
+            const elevFactor = smoothstep(r_elevation[r], 0.5, 0.9);
+            const latScale = smoothstep(polarDist, Math.PI / 8, Math.PI / 3);
+            glacIdx[r] = Math.max(latFactor, elevFactor * 0.3 * (0.3 + 0.7 * latScale)) * glacialStrength;
+        }
+
+        iceTarget = new Int32Array(N);
+        iceFlow = new Float32Array(N);
+        numIceUpstream = new Uint8Array(N);
+    }
+
+    // Per-iteration glacial rates (scaled so total effect ≈ same regardless of iter count)
+    const gScale = gIters > 0 ? 1.0 / gIters : 0;
+    const gCarveRate = 0.02 * gScale;
+    const gConvergenceBonus = 0.01 * gScale;
+    const gDepositAmount = 0.005 * gScale;
+    const gFjordCarve = 0.015 * gScale;
+    const gFlowThreshold = 0.1;
+    const gFjordThreshold = 0.5;
+
+    // Mid-loop drainage fix: at 75% of iterations, run a carve-biased
+    // priority-flood to cut outlets through basins created by glaciation.
+    const midFloodIter = Math.round(totalIters * 0.75);
+    let midFloodDone = false;
+
+    for (let iter = 0; iter < totalIters; iter++) {
+
+        if (!midFloodDone && iter >= midFloodIter) {
+            midFloodDone = true;
+            priorityFloodCarve(mesh, r_elevation, r_isOcean, 0.85);
+        }
+
+        // ---- Glacial step ----
+        if (iter < gIters && glacIdx) {
+            // Sort land cells by descending elevation (also used by hydraulic below)
+            landCells.sort((a, b) => r_elevation[b] - r_elevation[a]);
+
+            // Rebuild ice drainage from current elevations
+            iceTarget.fill(-1);
+            numIceUpstream.fill(0);
+
+            for (let i = 0; i < landCount; i++) {
+                const r = landCells[i];
+                if (glacIdx[r] <= 0) continue;
+                const h = r_elevation[r];
+                mesh.r_circulate_r(out_r, r);
+                let bestNb = -1, bestDrop = 0;
+                for (let j = 0; j < out_r.length; j++) {
+                    const nb = out_r[j];
+                    const drop = h - r_elevation[nb];
+                    if (drop > bestDrop) { bestDrop = drop; bestNb = nb; }
+                }
+                if (bestNb >= 0) iceTarget[r] = bestNb;
+            }
+
+            // Accumulate ice flow downstream
+            for (let r = 0; r < N; r++) iceFlow[r] = glacIdx[r];
+            for (let i = 0; i < landCount; i++) {
+                const r = landCells[i];
+                const target = iceTarget[r];
+                if (target >= 0 && iceFlow[r] > 0) {
+                    iceFlow[target] += iceFlow[r];
+                    numIceUpstream[target]++;
+                }
+            }
+
+            // Carving: deepening + widening + over-deepening
+            for (let i = 0; i < landCount; i++) {
+                const r = landCells[i];
+                if (iceFlow[r] <= gFlowThreshold) continue;
+
+                const deepening = gCarveRate * Math.pow(iceFlow[r], 0.6) * glacialStrength;
+                r_elevation[r] -= deepening;
+
+                // Valley widening for U-shape
+                mesh.r_circulate_r(out_r, r);
+                for (let j = 0; j < out_r.length; j++) {
+                    const nb = out_r[j];
+                    if (r_isOcean[nb]) continue;
+                    const dx = r_xyz[3 * r]     - r_xyz[3 * nb];
+                    const dy = r_xyz[3 * r + 1] - r_xyz[3 * nb + 1];
+                    const dz = r_xyz[3 * r + 2] - r_xyz[3 * nb + 2];
+                    const d = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1e-6;
+                    const slope = Math.abs(r_elevation[r] - r_elevation[nb]) / d;
+                    r_elevation[nb] -= deepening * 0.4 * Math.max(0, 1 - slope);
+                }
+
+                // Over-deepening at convergence zones
+                if (numIceUpstream[r] >= 2) {
+                    r_elevation[r] -= gConvergenceBonus * Math.pow(iceFlow[r], 0.4);
+                }
+            }
+
+            // Moraine deposition at glacier termini
+            for (let i = 0; i < landCount; i++) {
+                const r = landCells[i];
+                if (iceFlow[r] <= gFlowThreshold) continue;
+                const target = iceTarget[r];
+                if (target < 0 || r_isOcean[target]) continue;
+                if (glacIdx[target] < glacIdx[r] * 0.3) {
+                    r_elevation[target] += gDepositAmount * Math.pow(iceFlow[r], 0.3);
+                }
+            }
+
+            // Fjord enhancement on coastal glaciated cells
+            for (let r = 0; r < N; r++) {
+                if (r_isOcean[r]) continue;
+                if (glacIdx[r] <= 0.2 || iceFlow[r] <= gFjordThreshold) continue;
+                mesh.r_circulate_r(out_r, r);
+                let isCoastal = false;
+                for (let j = 0; j < out_r.length; j++) {
+                    if (r_isOcean[out_r[j]]) { isCoastal = true; break; }
+                }
+                if (isCoastal) {
+                    r_elevation[r] -= gFjordCarve * Math.pow(iceFlow[r], 0.5);
+                    if (r_elevation[r] < 0) r_elevation[r] = 0;
+                }
+            }
+
+            // Clamp: land stays land
+            for (let r = 0; r < N; r++) {
+                if (!r_isOcean[r] && r_elevation[r] < 0) r_elevation[r] = 0;
             }
         }
-        if (bestNb >= 0) {
-            drainTarget[r] = bestNb;
-            // Approximate slope using great-circle distance proxy (Euclidean on unit sphere)
-            const dx = r_xyz[3 * r] - r_xyz[3 * bestNb];
-            const dy = r_xyz[3 * r + 1] - r_xyz[3 * bestNb + 1];
-            const dz = r_xyz[3 * r + 2] - r_xyz[3 * bestNb + 2];
-            const dist = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1e-6;
-            drainSlope[r] = bestDrop / dist;
+
+        // ---- Hydraulic step ----
+        if (iter < hIters) {
+            // Build drainage graph (steepest descent)
+            drainTarget.fill(-1);
+
+            for (let i = 0; i < landCount; i++) {
+                const r = landCells[i];
+                const h = r_elevation[r];
+                mesh.r_circulate_r(out_r, r);
+
+                let bestNb = -1, bestDrop = -Infinity;
+                for (let j = 0; j < out_r.length; j++) {
+                    const nb = out_r[j];
+                    const drop = h - r_elevation[nb];
+                    if (drop > bestDrop) {
+                        bestDrop = drop;
+                        bestNb = nb;
+                    }
+                }
+
+                // Pit handling: drain to least-steep-ascent neighbor
+                if (bestDrop <= 0) {
+                    let minAscent = Infinity;
+                    for (let j = 0; j < out_r.length; j++) {
+                        const nb = out_r[j];
+                        const ascent = r_elevation[nb] - h;
+                        if (ascent < minAscent) {
+                            minAscent = ascent;
+                            bestNb = nb;
+                        }
+                    }
+                }
+
+                if (bestNb >= 0) {
+                    drainTarget[r] = bestNb;
+                    const dx = r_xyz[3 * r]     - r_xyz[3 * bestNb];
+                    const dy = r_xyz[3 * r + 1] - r_xyz[3 * bestNb + 1];
+                    const dz = r_xyz[3 * r + 2] - r_xyz[3 * bestNb + 2];
+                    cellDist[r] = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1e-6;
+                }
+            }
+
+            // Flow accumulation (sort descending, propagate)
+            landCells.sort((a, b) => r_elevation[b] - r_elevation[a]);
+
+            flow.fill(0);
+            for (let i = 0; i < landCount; i++) flow[landCells[i]] = 1;
+
+            for (let i = 0; i < landCount; i++) {
+                const r = landCells[i];
+                const target = drainTarget[r];
+                if (target >= 0) flow[target] += flow[r];
+            }
+
+            // Implicit stream power solve (ascending elevation order) + sediment deposition
+            for (let i = landCount - 1; i >= 0; i--) {
+                const r = landCells[i];
+                const target = drainTarget[r];
+                if (target < 0 || cellDist[r] <= 0) continue;
+
+                const factor = K * Math.pow(flow[r], m) * dt / cellDist[r];
+                const h_receiver = Math.max(r_elevation[target], 0);
+                let h_new = (r_elevation[r] + factor * h_receiver) / (1 + factor);
+
+                if (h_new < h_receiver) h_new = h_receiver;
+                if (h_new < 0) h_new = 0;
+
+                // Sediment deposition: deposit fraction of eroded material at receiver
+                const eroded = r_elevation[r] - h_new;
+                if (eroded > 0 && !r_isOcean[target]) {
+                    const drainOfTarget = drainTarget[target];
+                    let receiverSlope = 0;
+                    if (drainOfTarget >= 0 && cellDist[target] > 0) {
+                        receiverSlope = Math.abs(r_elevation[target] - r_elevation[drainOfTarget]) / cellDist[target];
+                    }
+                    const depositFrac = 0.3 / (1 + receiverSlope * 50);
+                    const deposit = eroded * depositFrac;
+                    r_elevation[target] += deposit;
+                    if (r_elevation[target] > h_new) r_elevation[target] = h_new;
+                }
+
+                r_elevation[r] = h_new;
+            }
+        }
+
+        // ---- Thermal step ----
+        if (iter < tIters) {
+            delta.fill(0);
+
+            for (let i = 0; i < landCount; i++) {
+                const r = landCells[i];
+                const h = r_elevation[r];
+                mesh.r_circulate_r(out_r, r);
+
+                let totalExcess = 0;
+                let exStart = i * 0; // reuse inline to avoid allocation
+                const excNb = [];
+                const excVal = [];
+
+                for (let j = 0; j < out_r.length; j++) {
+                    const nb = out_r[j];
+                    if (r_isOcean[nb]) continue;
+                    const nh = r_elevation[nb];
+                    if (nh >= h) continue;
+
+                    const dx = r_xyz[3 * r]     - r_xyz[3 * nb];
+                    const dy = r_xyz[3 * r + 1] - r_xyz[3 * nb + 1];
+                    const dz = r_xyz[3 * r + 2] - r_xyz[3 * nb + 2];
+                    const d = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1e-6;
+
+                    const slope = (h - nh) / d;
+                    if (slope > talusSlope) {
+                        const excess = (slope - talusSlope) * d;
+                        excNb.push(nb);
+                        excVal.push(excess);
+                        totalExcess += excess;
+                    }
+                }
+
+                if (totalExcess <= 0) continue;
+
+                const transfer = kThermal * totalExcess * 0.5;
+                for (let j = 0; j < excNb.length; j++) {
+                    const share = (excVal[j] / totalExcess) * transfer;
+                    delta[r]       -= share;
+                    delta[excNb[j]] += share;
+                }
+            }
+
+            for (let i = 0; i < landCount; i++) {
+                r_elevation[landCells[i]] += delta[landCells[i]];
+            }
         }
     }
 
-    // --- Pass 2: Flow accumulation ---
-    // Sort land cells by elevation descending
-    landCells.sort((a, b) => r_elevation[b] - r_elevation[a]);
+    // Post-loop: light Laplacian smooth on glaciated cells to blend carving edges
+    if (glacIdx) {
+        const tmp = new Float32Array(r_elevation);
+        for (let r = 0; r < N; r++) {
+            if (r_isOcean[r] || glacIdx[r] <= 0) continue;
+            mesh.r_circulate_r(out_r, r);
+            let sum = 0, count = 0;
+            for (let j = 0; j < out_r.length; j++) {
+                if (!r_isOcean[out_r[j]]) { sum += r_elevation[out_r[j]]; count++; }
+            }
+            if (count > 0) {
+                const avg = sum / count;
+                tmp[r] = r_elevation[r] + (avg - r_elevation[r]) * 0.3;
+            }
+        }
+        for (let r = 0; r < N; r++) {
+            if (!r_isOcean[r] && glacIdx[r] > 0) r_elevation[r] = tmp[r];
+        }
+    }
+}
 
-    const flow = new Float32Array(N);
-    for (let i = 0; i < landCount; i++) flow[landCells[i]] = 1;
+/**
+ * Ridge sharpening — pushes cells that sit above their neighborhood average
+ * further upward, accentuating ridgelines without creating unrealistic spikes.
+ */
+export function sharpenRidges(mesh, r_elevation, r_isOcean, iterations, strength) {
+    const N = mesh.numRegions;
+    const tmp = new Float32Array(N);
+    const original = new Float32Array(r_elevation);
+    const out_r = [];
 
-    for (let i = 0; i < landCount; i++) {
-        const r = landCells[i];
-        const target = drainTarget[r];
-        if (target >= 0) {
-            flow[target] += flow[r];
+    for (let iter = 0; iter < iterations; iter++) {
+        for (let r = 0; r < N; r++) {
+            if (r_isOcean[r]) { tmp[r] = r_elevation[r]; continue; }
+
+            const h = r_elevation[r];
+            mesh.r_circulate_r(out_r, r);
+            let sum = 0, count = 0;
+            for (let i = 0; i < out_r.length; i++) {
+                sum += r_elevation[out_r[i]];
+                count++;
+            }
+            if (count === 0) { tmp[r] = h; continue; }
+
+            const avg = sum / count;
+            if (h > avg) {
+                let h_new = h + (h - avg) * strength;
+                // Clamp: don't exceed 1.5x original elevation
+                const cap = original[r] * 1.5;
+                if (h_new > cap) h_new = cap;
+                tmp[r] = h_new;
+            } else {
+                tmp[r] = h;
+            }
+        }
+        for (let r = 0; r < N; r++) r_elevation[r] = tmp[r];
+    }
+}
+
+/**
+ * Soil creep — simple Laplacian diffusion on land cells.
+ * Unlike bilateral smoothing, this doesn't preserve ridges — it uniformly
+ * rounds off hillslopes. Coastline cells are locked.
+ */
+export function applySoilCreep(mesh, r_elevation, r_isOcean, iterations, strength) {
+    const N = mesh.numRegions;
+    const tmp = new Float32Array(N);
+    const out_r = [];
+
+    // Pre-compute coastline lock
+    const locked = new Uint8Array(N);
+    for (let r = 0; r < N; r++) {
+        if (r_isOcean[r]) continue;
+        mesh.r_circulate_r(out_r, r);
+        for (let i = 0; i < out_r.length; i++) {
+            if (r_isOcean[out_r[i]]) { locked[r] = 1; break; }
         }
     }
 
-    // --- Pass 3: Erosion & deposition ---
-    for (let i = 0; i < landCount; i++) {
-        const r = landCells[i];
-        const target = drainTarget[r];
-        if (target < 0) continue;
+    for (let iter = 0; iter < iterations; iter++) {
+        for (let r = 0; r < N; r++) {
+            if (r_isOcean[r] || locked[r]) { tmp[r] = r_elevation[r]; continue; }
 
-        const slope = drainSlope[r];
-        const erosion = Math.min(erosionK * Math.sqrt(flow[r]) * slope, r_elevation[r] * 0.3);
-        if (erosion <= 0) continue;
+            const h = r_elevation[r];
+            mesh.r_circulate_r(out_r, r);
+            let sum = 0, count = 0;
+            for (let i = 0; i < out_r.length; i++) {
+                if (!r_isOcean[out_r[i]]) {
+                    sum += r_elevation[out_r[i]];
+                    count++;
+                }
+            }
+            if (count === 0) { tmp[r] = h; continue; }
 
-        r_elevation[r] -= erosion;
-
-        // Deposit a fraction at the drain target — flatter targets collect more
-        if (!r_isOcean[target]) {
-            const targetSlope = drainSlope[target];
-            const depositFrac = 0.3 / (1 + targetSlope * 20);
-            r_elevation[target] += erosion * depositFrac;
+            const avg = sum / count;
+            tmp[r] = h + (avg - h) * strength;
         }
+        for (let r = 0; r < N; r++) r_elevation[r] = tmp[r];
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -80,33 +80,13 @@ select {
 select:hover { border-color: rgba(255,255,255,0.18); }
 select:focus { outline: none; border-color: #48f; }
 select option { background: #12122a; color: #cde; }
-#buildRow {
-    display: flex; gap: 6px; margin-top: 10px; margin-bottom: 12px;
-}
 button#generate {
-    flex: 1; padding: 10px;
+    width: 100%; padding: 10px; margin-top: 10px; margin-bottom: 12px;
     background: linear-gradient(135deg, #2255cc, #3366ee);
     color: white; border: none; border-radius: 8px;
     font-size: 15px; font-weight: 500; cursor: pointer;
     transition: background 0.3s ease, opacity 0.3s ease;
 }
-#reapplyBtn {
-    width: 38px; flex-shrink: 0;
-    background: rgba(255,255,255,0.06); color: #556;
-    border: 1px solid rgba(255,255,255,0.08); border-radius: 8px;
-    font-size: 18px; cursor: default;
-    display: flex; align-items: center; justify-content: center;
-    transition: background 0.2s, color 0.2s, border-color 0.2s;
-    padding: 0;
-}
-#reapplyBtn:disabled { opacity: 0.4; }
-#reapplyBtn.spinning { animation: spin 0.8s linear infinite; }
-#reapplyBtn.ready {
-    background: linear-gradient(135deg, #1a7a4a, #22aa5a);
-    color: #fff; border-color: transparent;
-    cursor: pointer; opacity: 1;
-}
-#reapplyBtn.ready:hover { filter: brightness(1.15); }
 button#generate:hover { filter: brightness(1.15); }
 button#generate.stale {
     background: linear-gradient(135deg, #b87a1a, #d4922a);
@@ -116,6 +96,22 @@ button#generate.generating {
     background: linear-gradient(135deg, #333, #444);
     cursor: wait; opacity: 0.8;
 }
+#reapplyBtn {
+    width: 100%; padding: 8px; margin-top: 4px;
+    background: rgba(255,255,255,0.06); color: #556;
+    border: 1px solid rgba(255,255,255,0.08); border-radius: 8px;
+    font-size: 14px; font-weight: 500; font-family: inherit; cursor: default;
+    display: flex; align-items: center; justify-content: center; gap: 4px;
+    transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+#reapplyBtn:disabled { opacity: 0.4; }
+#reapplyBtn.spinning { animation: spin 0.8s linear infinite; }
+#reapplyBtn.ready {
+    background: linear-gradient(135deg, #1a7a4a, #22aa5a);
+    color: #fff; border-color: transparent;
+    cursor: pointer; opacity: 1;
+}
+#reapplyBtn.ready:hover { filter: brightness(1.15); }
 #seedRow {
     display: flex; gap: 4px; margin-bottom: 12px;
 }


### PR DESCRIPTION
## Terrain Sculpting: Glacial Erosion, Hydraulic/Thermal Erosion Overhaul, Ridge Sharpening & UI Reorganization

### Summary

- Replaces the single "Basic Erosion" slider with a full terrain sculpting pipeline: **glacial erosion**, **implicit stream-power hydraulic erosion**, **thermal erosion**, **ridge sharpening**, and always-on **soil creep**
- Adds **priority-flood pit resolution** (Barnes et al.) with canyon carving to ensure all land drains to the ocean
- Reorganizes the sidebar into **Shape Your World** (5 core sliders) and a collapsible **Terrain Sculpting** section (5 post-processing sliders) to reduce visual clutter
- Updates planet code encoding from 13 to 17 characters with backward compatibility for all legacy formats

### New Algorithms

- **Glacial erosion** — latitude- and altitude-driven ice flow that carves fjords, U-shaped valleys, over-deepened lake basins, and moraine ridges at glacier termini
- **Priority-flood canyon carving** — Barnes et al. algorithm ensures every land cell drains to the ocean, carving canyons through mountain saddle points rather than filling basins. Runs at the start and again at 75% of the erosion loop to handle basins created by glaciation
- **Implicit stream-power hydraulic erosion** — Braun-Willett style iterative solver that carves self-reinforcing river valleys with automatic sediment deposition in flat receivers
- **Thermal erosion** — slope-driven talus-angle material transport that softens ridges and creates natural scree slopes
- **Ridge sharpening** — pushes cells above their neighborhood average further upward, accentuating mountain ridgelines
- **Soil creep** — always-on Laplacian diffusion that gently rounds off hillslopes (hardcoded, no slider)
- All three erosion types are **interleaved** per iteration (glacial → hydraulic → thermal) for more natural interaction

### UI Changes

- **Shape Your World** section now contains only the 5 core world-structure sliders (Detail, Irregularity, Plates, Continents, Roughness)
- **Build New World** button moved directly below its section
- **Terrain Sculpting** is a new collapsible section (collapsed by default) with Smoothing, Glacial Erosion, Hydraulic Erosion, Thermal Erosion, and Ridge Sharpening sliders
- **Reapply** button moved inside the Terrain Sculpting section as a full-width labeled button — no full rebuild needed to adjust erosion
- Tutorial modal updated to reference the new section layout

### Planet Code

- Format extended from 13 to **17 characters** to encode the new sliders
- Full backward compatibility: 13-char, 14-char, and 16-char legacy codes decode with sensible defaults for missing sliders
- Soil creep is always encoded as 0.75 (no UI slider)

### Defaults

| Slider | Default |
|--------|---------|
| Smoothing | 0.10 |
| Glacial Erosion | 0.35 |
| Hydraulic Erosion | 0.35 |
| Thermal Erosion | 0.10 |
| Ridge Sharpening | 0.35 |
