### PR TITLE
Performance: direct adjacency access + erosion optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,8 @@ styles.css              All CSS
 js/
   main.js               Entry point — UI wiring, animation loop
   state.js              Shared mutable application state
-  generate.js           Orchestrates the full geology pipeline
+  generate.js           Worker dispatcher — posts jobs, handles results
+  planet-worker.js      Web Worker — runs geology pipeline off main thread
   planet-code.js        Planet code encode/decode (seed + sliders → base36)
   rng.js                Seeded PRNG (Park-Miller LCG)
   simplex-noise.js      3D Simplex noise with fBm and ridged fBm

--- a/js/generate.js
+++ b/js/generate.js
@@ -1,74 +1,306 @@
-// Planet generation — orchestrates the full geology pipeline.
+// Planet generation — dispatches work to a Web Worker, falls back to
+// synchronous main-thread generation if module workers aren't supported.
 
-import { makeRng } from './rng.js';
-import { SimplexNoise } from './simplex-noise.js';
-import { buildSphere, generateTriangleCenters } from './sphere-mesh.js';
-import { generatePlates } from './plates.js';
-import { assignOceanLand } from './ocean-land.js';
-import { assignElevation } from './elevation.js';
-import { smoothElevation, erodeComposite, sharpenRidges, applySoilCreep } from './terrain-post.js';
+import Delaunator from 'delaunator';
+import { setDelaunator, SphereMesh } from './sphere-mesh.js';
 import { computePlateColors, buildMesh } from './planet-mesh.js';
 import { state } from './state.js';
 import { detailFromSlider } from './detail-scale.js';
 
-export function generate(overrideSeed, toggledIndices = [], onProgress) {
-    const btn = document.getElementById('generate');
-    btn.disabled = true;
-    btn.textContent = 'Building\u2026';
-    btn.classList.add('generating');
+// Main thread still needs Delaunator for SphereMesh reconstruction
+setDelaunator(Delaunator);
 
-    // Capture slider values before deferring so they're consistent
-    const N     = detailFromSlider(+document.getElementById('sN').value);
-    const P     = +document.getElementById('sP').value;
-    const jitter= +document.getElementById('sJ').value;
-    const nMag  = +document.getElementById('sNs').value;
+// --- Worker setup ---
+let worker = null;
+let workerSupported = true;
+try {
+    worker = new Worker(new URL('./planet-worker.js', import.meta.url), { type: 'module' });
+} catch (e) {
+    console.warn('[Atlas Engine] Module workers not supported, falling back to main thread:', e);
+    workerSupported = false;
+}
+
+// Active callback state
+let _onProgress = null;
+let _onDone = null;
+let _t0 = 0;
+
+function resetUI() {
+    const btn = document.getElementById('generate');
+    btn.disabled = false;
+    btn.textContent = 'Build New World';
+    btn.classList.remove('generating', 'stale');
+}
+
+function fail(err) {
+    console.error('[Atlas Engine] Generation failed:', err);
+    resetUI();
+    if (_onProgress) _onProgress(0, '');
+}
+
+// Reconstruct SphereMesh from transferred data
+function reconstructMesh(triangles, halfedges, numRegions) {
+    return new SphereMesh(triangles, halfedges, numRegions);
+}
+
+if (worker) {
+    worker.onmessage = (e) => {
+        const msg = e.data;
+        switch (msg.type) {
+            case 'progress':
+                if (_onProgress) _onProgress(msg.pct, msg.label);
+                break;
+
+            case 'done': {
+                const tMainStart = performance.now();
+
+                const tReconStart = performance.now();
+                const mesh = reconstructMesh(msg.triangles, msg.halfedges, msg.numRegions);
+                const tRecon = performance.now() - tReconStart;
+
+                const tColorsStart = performance.now();
+                computePlateColors(new Set(msg.plateSeeds), new Set(msg.plateIsOcean));
+                const tColors = performance.now() - tColorsStart;
+
+                const tStateStart = performance.now();
+                state.curData = {
+                    mesh,
+                    r_xyz: msg.r_xyz,
+                    t_xyz: msg.t_xyz,
+                    r_plate: msg.r_plate,
+                    plateSeeds: new Set(msg.plateSeeds),
+                    plateVec: msg.plateVec,
+                    plateIsOcean: new Set(msg.plateIsOcean),
+                    originalPlateIsOcean: new Set(msg.originalPlateIsOcean),
+                    plateDensity: msg.plateDensity,
+                    plateDensityLand: msg.plateDensityLand,
+                    plateDensityOcean: msg.plateDensityOcean,
+                    prePostElev: msg.prePostElev,
+                    r_elevation: msg.r_elevation,
+                    t_elevation: msg.t_elevation,
+                    mountain_r: new Set(msg.mountain_r),
+                    coastline_r: new Set(msg.coastline_r),
+                    ocean_r: new Set(msg.ocean_r),
+                    r_stress: msg.r_stress,
+                    seed: msg.seed,
+                    nMag: msg.nMag,
+                    debugLayers: msg.debugLayers
+                };
+                const tState = performance.now() - tStateStart;
+
+                const tBuildStart = performance.now();
+                buildMesh();
+                const tBuild = performance.now() - tBuildStart;
+
+                const tMainTotal = performance.now() - tMainStart;
+                const tTotal = performance.now() - _t0;
+
+                // Diagnostics
+                {
+                    let landCount = 0, nanCount = 0;
+                    const plateIsOcean = state.curData.plateIsOcean;
+                    const r_plate = state.curData.r_plate;
+                    const r_elevation = state.curData.r_elevation;
+                    for (let r = 0; r < mesh.numRegions; r++) {
+                        if (!plateIsOcean.has(r_plate[r])) landCount++;
+                        if (isNaN(r_elevation[r])) nanCount++;
+                    }
+                    const landPct = (100 * landCount / mesh.numRegions).toFixed(1);
+                    if (nanCount > 0) console.error(`[Atlas Engine] WARNING: ${nanCount} NaN elevation values detected!`);
+                    if (landCount / mesh.numRegions < 0.10) console.warn(`[Atlas Engine] WARNING: Only ${landPct}% land (${landCount} regions). Ocean/land growth may have stalled.`);
+                }
+
+                const f = v => typeof v === 'number' ? v.toFixed(1) : v;
+
+                console.log(`%c[Atlas Engine] Generation complete`, 'color:#6cf;font-weight:bold');
+                if (msg._params) {
+                    console.log(`  Params: N=${msg._params.N.toLocaleString()} P=${msg._params.P} jitter=${msg._params.jitter} noise=${msg._params.nMag} continents=${msg._params.numContinents} seed=${msg._params.seed}`);
+                    console.log(`  Sculpting: smooth=${msg._params.smoothing} glacial=${msg._params.glacialErosion} hydraulic=${msg._params.hydraulicErosion} thermal=${msg._params.thermalErosion} ridge=${msg._params.ridgeSharpening}`);
+                }
+                console.log(`  Regions: ${mesh.numRegions.toLocaleString()}  Triangles: ${mesh.numTriangles.toLocaleString()}  Sides: ${mesh.numSides.toLocaleString()}`);
+
+                // Worker pipeline stages
+                if (msg._pipelineTiming) {
+                    console.groupCollapsed('  %cWorker pipeline stages', 'color:#8cf');
+                    console.table(msg._pipelineTiming.map(r => ({ Stage: r.stage, 'ms': f(r.ms) })));
+                    console.groupEnd();
+                }
+
+                // Elevation sub-stages
+                if (msg._timing) {
+                    console.groupCollapsed('  %cElevation sub-stages', 'color:#fc8');
+                    console.table(msg._timing.map(r => ({ Stage: r.stage, 'ms': f(r.ms) })));
+                    console.groupEnd();
+                }
+
+                // Post-processing sub-stages
+                if (msg._postTiming && msg._postTiming.length > 0) {
+                    console.groupCollapsed('  %cPost-processing sub-stages', 'color:#8f8');
+                    console.table(msg._postTiming.map(r => ({ Stage: r.stage, 'ms': f(r.ms) })));
+                    console.groupEnd();
+                }
+
+                // Summary
+                const tWorker = msg._workerTotal || 0;
+                const tTransfer = tTotal - tWorker - tMainTotal;
+                console.log(
+                    `  %cSummary:%c Worker: ${f(tWorker)} ms | Transfer: ${f(tTransfer)} ms | Main thread: ${f(tMainTotal)} ms (reconstruct=${f(tRecon)}, colors=${f(tColors)}, state=${f(tState)}, buildMesh=${f(tBuild)}) | TOTAL: ${f(tTotal)} ms`,
+                    'color:#ff6;font-weight:bold', ''
+                );
+
+                const ms = tTotal.toFixed(0);
+                document.getElementById('stats').innerHTML =
+                    `Regions: ${mesh.numRegions.toLocaleString()}<br>` +
+                    `Triangles: ${mesh.numTriangles.toLocaleString()}<br>` +
+                    `Generated in ${ms} ms<br>` +
+                    `<span style="color:#445;font-size:10px">worker ${tWorker.toFixed(0)} · render ${tBuild.toFixed(0)}</span>`;
+
+                if (_onProgress) _onProgress(100, 'Done');
+                resetUI();
+                document.getElementById('generate').dispatchEvent(new CustomEvent('generate-done'));
+                if (_onDone) { _onDone(); _onDone = null; }
+                break;
+            }
+
+            case 'reapplyDone': {
+                const tMainStart = performance.now();
+                const d = state.curData;
+                d.r_elevation = msg.r_elevation;
+                d.t_elevation = msg.t_elevation;
+                d.debugLayers.erosionDelta = msg.erosionDelta;
+
+                const tBuildStart = performance.now();
+                buildMesh();
+                const tBuild = performance.now() - tBuildStart;
+
+                const tMainTotal = performance.now() - tMainStart;
+
+                const f = v => typeof v === 'number' ? v.toFixed(1) : v;
+                const rt = msg._reapplyTiming || {};
+                console.log(`%c[Atlas Engine] Reapply complete`, 'color:#8f8;font-weight:bold');
+                if (msg._postTiming && msg._postTiming.length > 0) {
+                    console.groupCollapsed('  %cPost-processing sub-stages', 'color:#8f8');
+                    console.table(msg._postTiming.map(r => ({ Stage: r.stage, 'ms': f(r.ms) })));
+                    console.groupEnd();
+                }
+                console.log(
+                    `  %cSummary:%c Worker: ${f(rt.workerTotal || 0)} ms (clone=${f(rt.clone || 0)}, postProcess=${f(rt.postProcessing || 0)}, triElev=${f(rt.triangleElevations || 0)}) | Main: ${f(tMainTotal)} ms (buildMesh=${f(tBuild)})`,
+                    'color:#ff6;font-weight:bold', ''
+                );
+
+                if (_onProgress) _onProgress(100, 'Done');
+                if (_onDone) { _onDone(); _onDone = null; }
+                break;
+            }
+
+            case 'editDone': {
+                const tMainStart = performance.now();
+                const d = state.curData;
+                d.prePostElev = msg.prePostElev;
+                d.r_elevation = msg.r_elevation;
+                d.t_elevation = msg.t_elevation;
+                d.mountain_r = new Set(msg.mountain_r);
+                d.coastline_r = new Set(msg.coastline_r);
+                d.ocean_r = new Set(msg.ocean_r);
+                d.r_stress = msg.r_stress;
+                d.debugLayers = msg.debugLayers;
+
+                const tColorsStart = performance.now();
+                computePlateColors(d.plateSeeds, d.plateIsOcean);
+                const tColors = performance.now() - tColorsStart;
+
+                const tBuildStart = performance.now();
+                buildMesh();
+                const tBuild = performance.now() - tBuildStart;
+
+                const tMainTotal = performance.now() - tMainStart;
+
+                const f = v => typeof v === 'number' ? v.toFixed(1) : v;
+                const et = msg._editTiming || {};
+                console.log(`%c[Atlas Engine] Edit recompute complete`, 'color:#fc8;font-weight:bold');
+
+                if (msg._timing) {
+                    console.groupCollapsed('  %cElevation sub-stages', 'color:#fc8');
+                    console.table(msg._timing.map(r => ({ Stage: r.stage, 'ms': f(r.ms) })));
+                    console.groupEnd();
+                }
+                if (msg._postTiming && msg._postTiming.length > 0) {
+                    console.groupCollapsed('  %cPost-processing sub-stages', 'color:#8f8');
+                    console.table(msg._postTiming.map(r => ({ Stage: r.stage, 'ms': f(r.ms) })));
+                    console.groupEnd();
+                }
+                console.log(
+                    `  %cSummary:%c Worker: ${f(et.workerTotal || 0)} ms (elevation=${f(et.elevation || 0)}, postProcess=${f(et.postProcessing || 0)}, triElev=${f(et.triangleElevations || 0)}, retain=${f(et.retainState || 0)}) | Main: ${f(tMainTotal)} ms (colors=${f(tColors)}, buildMesh=${f(tBuild)})`,
+                    'color:#ff6;font-weight:bold', ''
+                );
+
+                if (_onProgress) _onProgress(100, 'Done');
+                if (_onDone) { _onDone(); _onDone = null; }
+                break;
+            }
+
+            case 'error':
+                fail(msg.message);
+                if (_onDone) { _onDone(); _onDone = null; }
+                break;
+        }
+    };
+
+    worker.onerror = (e) => {
+        fail(e.message || 'Worker crashed');
+        if (_onDone) { _onDone(); _onDone = null; }
+    };
+}
+
+// --- Synchronous fallback (imported lazily to avoid loading when worker works) ---
+let _fallbackModules = null;
+async function loadFallback() {
+    if (_fallbackModules) return _fallbackModules;
+    const [rng, simplex, sphere, plates, ocean, elev, post] = await Promise.all([
+        import('./rng.js'),
+        import('./simplex-noise.js'),
+        import('./sphere-mesh.js'),
+        import('./plates.js'),
+        import('./ocean-land.js'),
+        import('./elevation.js'),
+        import('./terrain-post.js')
+    ]);
+    _fallbackModules = { rng, simplex, sphere, plates, ocean, elev, post };
+    return _fallbackModules;
+}
+
+function generateFallback(overrideSeed, toggledIndices, onProgress) {
+    // Dynamic import already resolved — run synchronously via rAF stages
+    const m = _fallbackModules;
+    const btn = document.getElementById('generate');
+    const N = detailFromSlider(+document.getElementById('sN').value);
+    const P = +document.getElementById('sP').value;
+    const jitter = +document.getElementById('sJ').value;
+    const nMag = +document.getElementById('sNs').value;
     const numContinents = +document.getElementById('sCn').value;
     const smoothing = +document.getElementById('sS').value;
     const hydraulicErosion = +document.getElementById('sHEr').value;
     const thermalErosion = +document.getElementById('sTEr').value;
     const ridgeSharpening = +document.getElementById('sRs').value;
     const glacialErosion = +document.getElementById('sGl').value;
-    const spread = 5;
-
-    // Shared context passed between stages
-    const ctx = {};
     const progress = onProgress || (() => {});
+    const ctx = {};
 
-    // Each stage: { pct, label, work }
-    // The runner sets progress THEN yields a frame for the browser to paint,
-    // THEN executes the work. This guarantees the label and bar are visible
-    // before the heavy synchronous computation blocks the main thread.
     const stages = [
-        { pct: 0,  label: 'Shaping the world\u2026', work() {
-            ctx.t0 = performance.now();
+        { pct: 0, label: 'Shaping the world\u2026', work() {
             ctx.seed = overrideSeed ?? Math.floor(Math.random() * 16777216);
-            ctx.rng  = makeRng(ctx.seed);
-
-            const t1 = performance.now();
-            const { mesh, r_xyz } = buildSphere(N, jitter, ctx.rng);
-            ctx.tMesh = performance.now() - t1;
-            ctx.mesh = mesh;
-            ctx.r_xyz = r_xyz;
-
-            const tTri0 = performance.now();
-            ctx.t_xyz = generateTriangleCenters(mesh, r_xyz);
-            ctx.tTriCenters = performance.now() - tTri0;
+            ctx.rng = m.rng.makeRng(ctx.seed);
+            const { mesh, r_xyz } = m.sphere.buildSphere(N, jitter, ctx.rng);
+            ctx.mesh = mesh; ctx.r_xyz = r_xyz;
+            ctx.t_xyz = m.sphere.generateTriangleCenters(mesh, r_xyz);
         }},
         { pct: 15, label: 'Forming tectonic plates\u2026', work() {
-            const t2 = performance.now();
-            const { r_plate, plateSeeds, plateVec } = generatePlates(ctx.mesh, ctx.r_xyz, P, ctx.seed);
-            ctx.tPlates = performance.now() - t2;
-            ctx.r_plate = r_plate;
-            ctx.plateSeeds = plateSeeds;
-            ctx.plateVec = plateVec;
+            const { r_plate, plateSeeds, plateVec } = m.plates.generatePlates(ctx.mesh, ctx.r_xyz, P, ctx.seed);
+            ctx.r_plate = r_plate; ctx.plateSeeds = plateSeeds; ctx.plateVec = plateVec;
         }},
         { pct: 25, label: 'Carving oceans\u2026', work() {
-            const tOcean0 = performance.now();
-            const plateIsOcean = assignOceanLand(ctx.mesh, ctx.r_plate, ctx.plateSeeds, ctx.r_xyz, ctx.seed, numContinents);
-            ctx.tOcean = performance.now() - tOcean0;
-
+            const plateIsOcean = m.ocean.assignOceanLand(ctx.mesh, ctx.r_plate, ctx.plateSeeds, ctx.r_xyz, ctx.seed, numContinents);
             ctx.originalPlateIsOcean = new Set(plateIsOcean);
-
             if (toggledIndices.length > 0) {
                 const seedArr = Array.from(ctx.plateSeeds);
                 for (const i of toggledIndices) {
@@ -79,214 +311,145 @@ export function generate(overrideSeed, toggledIndices = [], onProgress) {
                     }
                 }
             }
-
             computePlateColors(ctx.plateSeeds, plateIsOcean);
-
-            const plateDensity = {};
-            const plateDensityLand = {};
-            const plateDensityOcean = {};
+            const plateDensity = {}, plateDensityLand = {}, plateDensityOcean = {};
             for (const r of ctx.plateSeeds) {
-                const drng = makeRng(r + 777);
+                const drng = m.rng.makeRng(r + 777);
                 plateDensityOcean[r] = 3.0 + drng() * 0.5;
                 plateDensityLand[r] = 2.4 + drng() * 0.5;
                 plateDensity[r] = plateIsOcean.has(r) ? plateDensityOcean[r] : plateDensityLand[r];
             }
-
-            ctx.plateIsOcean = plateIsOcean;
-            ctx.plateDensity = plateDensity;
-            ctx.plateDensityLand = plateDensityLand;
-            ctx.plateDensityOcean = plateDensityOcean;
-            ctx.noise = new SimplexNoise(ctx.seed);
+            ctx.plateIsOcean = plateIsOcean; ctx.plateDensity = plateDensity;
+            ctx.plateDensityLand = plateDensityLand; ctx.plateDensityOcean = plateDensityOcean;
+            ctx.noise = new m.simplex.SimplexNoise(ctx.seed);
         }},
         { pct: 35, label: 'Raising mountains\u2026', work() {
-            const t3 = performance.now();
             const { r_elevation, mountain_r, coastline_r, ocean_r, r_stress, debugLayers, _timing } =
-                assignElevation(ctx.mesh, ctx.r_xyz, ctx.plateIsOcean, ctx.r_plate, ctx.plateVec, ctx.plateSeeds, ctx.noise, nMag, ctx.seed, spread, ctx.plateDensity);
-            ctx.tElev = performance.now() - t3;
-            ctx.r_elevation = r_elevation;
-            ctx.mountain_r = mountain_r;
-            ctx.coastline_r = coastline_r;
-            ctx.ocean_r = ocean_r;
-            ctx.r_stress = r_stress;
-            ctx.debugLayers = debugLayers;
-            ctx._timing = _timing;
+                m.elev.assignElevation(ctx.mesh, ctx.r_xyz, ctx.plateIsOcean, ctx.r_plate, ctx.plateVec, ctx.plateSeeds, ctx.noise, nMag, ctx.seed, 5, ctx.plateDensity);
+            ctx.r_elevation = r_elevation; ctx.mountain_r = mountain_r; ctx.coastline_r = coastline_r;
+            ctx.ocean_r = ocean_r; ctx.r_stress = r_stress; ctx.debugLayers = debugLayers;
             ctx.prePostElev = new Float32Array(r_elevation);
-
-            // Terrain post-processing: smoothing + erosion + ridge + creep
-            // Soil creep always runs (hardcoded at 0.75 strength)
-            {
-                const tPost0 = performance.now();
-
-                // Use elevation to determine ocean — cells below sea level are ocean
-                // regardless of plate type, so islands on ocean plates get processed too
-                const r_isOcean = new Uint8Array(ctx.mesh.numRegions);
-                for (let r = 0; r < ctx.mesh.numRegions; r++) {
-                    if (r_elevation[r] <= 0) r_isOcean[r] = 1;
-                }
-
-                const preErosion = new Float32Array(r_elevation);
-
-                if (smoothing > 0) {
-                    const smoothIters = Math.round(1 + smoothing * 4);   // 1–5
-                    const smoothStr = 0.2 + smoothing * 0.5;             // 0.2–0.7
-                    const tSmooth0 = performance.now();
-                    smoothElevation(ctx.mesh, r_elevation, r_isOcean, smoothIters, smoothStr);
-                    ctx._timing.push({ stage: 'Smoothing', ms: performance.now() - tSmooth0 });
-                }
-
-                if (glacialErosion > 0 || hydraulicErosion > 0 || thermalErosion > 0) {
-                    const gIters = Math.round(glacialErosion * 10);      // 0–10
-                    const hIters = Math.round(hydraulicErosion * 20);    // 0–20
-                    const hK = hydraulicErosion * 0.001;                 // 0–0.001
-                    const tIters = Math.round(thermalErosion * 10);      // 0–10
-                    const talusSlope = 1.2 - thermalErosion * 0.4;       // 1.2–0.8
-                    const kThermal = thermalErosion * 0.15;              // 0–0.15
-                    const tErode0 = performance.now();
-                    erodeComposite(ctx.mesh, r_elevation, ctx.r_xyz, r_isOcean,
-                        hIters, hK, 0.5, 1.0,
-                        tIters, talusSlope, kThermal,
-                        gIters, glacialErosion);
-                    ctx._timing.push({ stage: 'Erosion (glacial+hydraulic+thermal)', ms: performance.now() - tErode0 });
-                }
-
-                if (ridgeSharpening > 0) {
-                    const rsIters = Math.round(1 + ridgeSharpening * 3); // 1–4
-                    const rsStr = ridgeSharpening * 0.08;                // 0–0.08
-                    const tRS0 = performance.now();
-                    sharpenRidges(ctx.mesh, r_elevation, r_isOcean, rsIters, rsStr);
-                    ctx._timing.push({ stage: 'Ridge sharpening', ms: performance.now() - tRS0 });
-                }
-
-                {
-                    const tSC0 = performance.now();
-                    applySoilCreep(ctx.mesh, r_elevation, r_isOcean, 3, 0.1125);
-                    ctx._timing.push({ stage: 'Soil creep', ms: performance.now() - tSC0 });
-                }
-
-                // Compute erosion delta layer (post - pre)
-                const dl_erosionDelta = new Float32Array(ctx.mesh.numRegions);
-                for (let r = 0; r < ctx.mesh.numRegions; r++) {
-                    dl_erosionDelta[r] = r_elevation[r] - preErosion[r];
-                }
-                debugLayers.erosionDelta = dl_erosionDelta;
-
-                ctx.tPost = performance.now() - tPost0;
-            }
-
-            const tTriElev0 = performance.now();
+            const r_isOcean = new Uint8Array(ctx.mesh.numRegions);
+            for (let r = 0; r < ctx.mesh.numRegions; r++) { if (r_elevation[r] <= 0) r_isOcean[r] = 1; }
+            const preErosion = new Float32Array(r_elevation);
+            if (smoothing > 0) m.post.smoothElevation(ctx.mesh, r_elevation, r_isOcean, Math.round(1 + smoothing * 4), 0.2 + smoothing * 0.5);
+            if (glacialErosion > 0 || hydraulicErosion > 0 || thermalErosion > 0)
+                m.post.erodeComposite(ctx.mesh, r_elevation, ctx.r_xyz, r_isOcean, Math.round(hydraulicErosion * 20), hydraulicErosion * 0.001, 0.5, 1.0, Math.round(thermalErosion * 10), 1.2 - thermalErosion * 0.4, thermalErosion * 0.15, Math.round(glacialErosion * 10), glacialErosion);
+            if (ridgeSharpening > 0) m.post.sharpenRidges(ctx.mesh, r_elevation, r_isOcean, Math.round(1 + ridgeSharpening * 3), ridgeSharpening * 0.08);
+            m.post.applySoilCreep(ctx.mesh, r_elevation, r_isOcean, 3, 0.1125);
+            const dl_erosionDelta = new Float32Array(ctx.mesh.numRegions);
+            for (let r = 0; r < ctx.mesh.numRegions; r++) dl_erosionDelta[r] = r_elevation[r] - preErosion[r];
+            debugLayers.erosionDelta = dl_erosionDelta;
             const t_elevation = new Float32Array(ctx.mesh.numTriangles);
             for (let t = 0; t < ctx.mesh.numTriangles; t++) {
                 const s0 = 3 * t;
                 const a = ctx.mesh.s_begin_r(s0), b = ctx.mesh.s_begin_r(s0+1), c = ctx.mesh.s_begin_r(s0+2);
                 t_elevation[t] = (r_elevation[a] + r_elevation[b] + r_elevation[c]) / 3;
             }
-            ctx.tTriElev = performance.now() - tTriElev0;
             ctx.t_elevation = t_elevation;
         }},
         { pct: 85, label: 'Painting the surface\u2026', work() {
-            state.curData = { mesh: ctx.mesh, r_xyz: ctx.r_xyz, t_xyz: ctx.t_xyz,
-                              r_plate: ctx.r_plate, plateSeeds: ctx.plateSeeds, plateVec: ctx.plateVec,
-                              plateIsOcean: ctx.plateIsOcean, originalPlateIsOcean: ctx.originalPlateIsOcean,
-                              plateDensity: ctx.plateDensity, plateDensityLand: ctx.plateDensityLand,
-                              plateDensityOcean: ctx.plateDensityOcean,
-                              prePostElev: ctx.prePostElev,
-                              r_elevation: ctx.r_elevation, t_elevation: ctx.t_elevation,
-                              mountain_r: ctx.mountain_r, coastline_r: ctx.coastline_r, ocean_r: ctx.ocean_r,
-                              r_stress: ctx.r_stress, noise: ctx.noise, seed: ctx.seed, debugLayers: ctx.debugLayers };
-
-            const t4 = performance.now();
+            state.curData = {
+                mesh: ctx.mesh, r_xyz: ctx.r_xyz, t_xyz: ctx.t_xyz,
+                r_plate: ctx.r_plate, plateSeeds: ctx.plateSeeds, plateVec: ctx.plateVec,
+                plateIsOcean: ctx.plateIsOcean, originalPlateIsOcean: ctx.originalPlateIsOcean,
+                plateDensity: ctx.plateDensity, plateDensityLand: ctx.plateDensityLand,
+                plateDensityOcean: ctx.plateDensityOcean, prePostElev: ctx.prePostElev,
+                r_elevation: ctx.r_elevation, t_elevation: ctx.t_elevation,
+                mountain_r: ctx.mountain_r, coastline_r: ctx.coastline_r, ocean_r: ctx.ocean_r,
+                r_stress: ctx.r_stress, noise: ctx.noise, seed: ctx.seed, debugLayers: ctx.debugLayers
+            };
             buildMesh();
-            const tBuild = performance.now() - t4;
-            ctx.tBuild = tBuild;
-
-            const tTotal = performance.now() - ctx.t0;
-
-            // ---- Diagnostics ----
-            {
-                const mesh = ctx.mesh;
-                let landCount = 0, nanCount = 0;
-                for (let r = 0; r < mesh.numRegions; r++) {
-                    if (!ctx.plateIsOcean.has(ctx.r_plate[r])) landCount++;
-                    if (isNaN(ctx.r_elevation[r])) nanCount++;
-                }
-                const landPct = (100 * landCount / mesh.numRegions).toFixed(1);
-                if (nanCount > 0) console.error(`[Atlas Engine] WARNING: ${nanCount} NaN elevation values detected!`);
-                if (landCount / mesh.numRegions < 0.10) console.warn(`[Atlas Engine] WARNING: Only ${landPct}% land (${landCount} regions). Ocean/land growth may have stalled.`);
-            }
-
-            // ---- Console timing report ----
-            const f = v => v.toFixed(1);
-            console.log(
-                `%c[Atlas Engine] Generation complete`,
-                'color:#6cf;font-weight:bold'
-            );
-            console.log(
-                `  Parameters: detail=${N}  plates=${P}  continents=${numContinents}  jitter=${jitter}  roughness=${nMag}  smoothing=${smoothing}  glacialErosion=${glacialErosion}  hydraulicErosion=${hydraulicErosion}  thermalErosion=${thermalErosion}  ridgeSharpening=${ridgeSharpening}  seed=${ctx.seed}`
-            );
-            console.log(
-                `  Regions: ${ctx.mesh.numRegions.toLocaleString()}  Triangles: ${ctx.mesh.numTriangles.toLocaleString()}  Sides: ${ctx.mesh.numSides.toLocaleString()}`
-            );
-
-            const pipelineRows = [
-                { stage: 'Sphere mesh',      ms: ctx.tMesh },
-                { stage: 'Triangle centers', ms: ctx.tTriCenters },
-                { stage: 'Plates',           ms: ctx.tPlates },
-                { stage: 'Ocean/land',       ms: ctx.tOcean },
-                { stage: 'Elevation (total)', ms: ctx.tElev },
-                ...(ctx.tPost ? [{ stage: 'Terrain post', ms: ctx.tPost }] : []),
-                { stage: 'Triangle elevs',   ms: ctx.tTriElev },
-                { stage: 'Render (buildMesh)', ms: tBuild },
-            ];
-            console.log('  Pipeline breakdown:');
-            console.table(pipelineRows.map(r => ({ Stage: r.stage, 'ms': f(r.ms), '%': f(r.ms / tTotal * 100) + '%' })));
-
-            if (ctx._timing) {
-                console.log('  Elevation sub-stages:');
-                console.table(ctx._timing.map(r => ({ Stage: r.stage, 'ms': f(r.ms), '%': f(r.ms / ctx.tElev * 100) + '%' })));
-            }
-
-            console.log(`  TOTAL: ${f(tTotal)} ms`);
-
-            const ms = tTotal.toFixed(0);
-            document.getElementById('stats').innerHTML =
-                `Regions: ${ctx.mesh.numRegions.toLocaleString()}<br>` +
-                `Triangles: ${ctx.mesh.numTriangles.toLocaleString()}<br>` +
-                `Plates: ${P}<br>Generated in ${ms} ms<br>` +
-                `<span style="color:#445;font-size:10px">mesh ${ctx.tMesh.toFixed(0)} · plates ${ctx.tPlates.toFixed(0)} · elev ${ctx.tElev.toFixed(0)} · render ${tBuild.toFixed(0)}</span>`;
-
             progress(100, 'Done');
-
-            btn.disabled = false;
-            btn.textContent = 'Build New World';
-            btn.classList.remove('generating', 'stale');
+            resetUI();
             btn.dispatchEvent(new CustomEvent('generate-done'));
         }}
     ];
 
-    function fail(err) {
-        console.error('[Atlas Engine] Generation failed:', err);
-        btn.disabled = false;
-        btn.textContent = 'Build New World';
-        btn.classList.remove('generating');
-        progress(0, '');
-    }
-
-    // Runner: set progress → rAF (browser commits paint) → setTimeout (paint
-    // flushes) → execute work → advance to next stage.
     function runStage(idx) {
         if (idx >= stages.length) return;
         const s = stages[idx];
-        try { progress(s.pct, s.label); } catch (e) { return fail(e); }
-        requestAnimationFrame(() => {
-            setTimeout(() => {
-                try {
-                    s.work();
-                    runStage(idx + 1);
-                } catch (e) { fail(e); }
-            }, 0);
-        });
+        try { progress(s.pct, s.label); } catch (e) { fail(e); return; }
+        requestAnimationFrame(() => setTimeout(() => {
+            try { s.work(); runStage(idx + 1); } catch (e) { fail(e); }
+        }, 0));
+    }
+    setTimeout(() => runStage(0), 0);
+}
+
+// --- Public API ---
+
+export function generate(overrideSeed, toggledIndices = [], onProgress) {
+    const btn = document.getElementById('generate');
+    btn.disabled = true;
+    btn.textContent = 'Building\u2026';
+    btn.classList.add('generating');
+
+    _onProgress = onProgress || (() => {});
+    _t0 = performance.now();
+
+    if (!worker) {
+        // Fallback: load modules then run synchronously
+        loadFallback().then(() => generateFallback(overrideSeed, toggledIndices, onProgress));
+        return;
     }
 
-    // Kick off — initial setTimeout lets the browser paint the button state
-    setTimeout(() => runStage(0), 0);
+    const N = detailFromSlider(+document.getElementById('sN').value);
+    const P = +document.getElementById('sP').value;
+    const jitter = +document.getElementById('sJ').value;
+    const nMag = +document.getElementById('sNs').value;
+    const numContinents = +document.getElementById('sCn').value;
+    const smoothing = +document.getElementById('sS').value;
+    const hydraulicErosion = +document.getElementById('sHEr').value;
+    const thermalErosion = +document.getElementById('sTEr').value;
+    const ridgeSharpening = +document.getElementById('sRs').value;
+    const glacialErosion = +document.getElementById('sGl').value;
+
+    worker.postMessage({
+        cmd: 'generate',
+        N, P, jitter, nMag, numContinents,
+        smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion,
+        seed: overrideSeed,
+        toggledIndices
+    });
+}
+
+export function reapplyViaWorker(onDone) {
+    if (!worker || !state.curData) return;
+
+    _onProgress = (pct, label) => {
+        // Progress updates during reapply (used by build overlay if shown)
+    };
+    _onDone = onDone || null;
+    _t0 = performance.now();
+
+    worker.postMessage({
+        cmd: 'reapply',
+        smoothing: +document.getElementById('sS').value,
+        glacialErosion: +document.getElementById('sGl').value,
+        hydraulicErosion: +document.getElementById('sHEr').value,
+        thermalErosion: +document.getElementById('sTEr').value,
+        ridgeSharpening: +document.getElementById('sRs').value
+    });
+}
+
+export function editRecomputeViaWorker(onDone) {
+    if (!worker || !state.curData) return;
+
+    const d = state.curData;
+    _onProgress = () => {};
+    _onDone = onDone || null;
+    _t0 = performance.now();
+
+    worker.postMessage({
+        cmd: 'editRecompute',
+        plateIsOcean: Array.from(d.plateIsOcean),
+        plateDensity: d.plateDensity,
+        nMag: +document.getElementById('sNs').value,
+        smoothing: +document.getElementById('sS').value,
+        glacialErosion: +document.getElementById('sGl').value,
+        hydraulicErosion: +document.getElementById('sHEr').value,
+        thermalErosion: +document.getElementById('sTEr').value,
+        ridgeSharpening: +document.getElementById('sRs').value
+    });
 }

--- a/js/ocean-land.js
+++ b/js/ocean-land.js
@@ -9,7 +9,7 @@ export function assignOceanLand(mesh, r_plate, plateSeeds, r_xyz, seed, numConti
     const numRegions = mesh.numRegions;
     const plateIds = Array.from(plateSeeds);
     const numPlates = plateIds.length;
-    const out_r = [];
+    const { adjOffset, adjList } = mesh;
 
     // 1. Plate areas and centroids
     const plateArea = {};
@@ -39,10 +39,9 @@ export function assignOceanLand(mesh, r_plate, plateSeeds, r_xyz, seed, numConti
     for (const pid of plateIds) { plateAdj[pid] = new Set(); platePerim[pid] = 0; }
     for (let r = 0; r < numRegions; r++) {
         const myPlate = r_plate[r];
-        mesh.r_circulate_r(out_r, r);
         let isBoundary = false;
-        for (let ni = 0; ni < out_r.length; ni++) {
-            const nbPlate = r_plate[out_r[ni]];
+        for (let ni = adjOffset[r], niEnd = adjOffset[r + 1]; ni < niEnd; ni++) {
+            const nbPlate = r_plate[adjList[ni]];
             if (myPlate !== nbPlate) {
                 plateAdj[myPlate].add(nbPlate);
                 isBoundary = true;

--- a/js/planet-worker.js
+++ b/js/planet-worker.js
@@ -1,0 +1,358 @@
+// Web Worker — runs the pure computation pipeline off the main thread.
+// Handles: generate, reapply, editRecompute commands.
+
+import { makeRng } from './rng.js';
+import { SimplexNoise } from './simplex-noise.js';
+import { setDelaunator, buildSphere, generateTriangleCenters, SphereMesh, computeNeighborDist } from './sphere-mesh.js';
+import { generatePlates } from './plates.js';
+import { assignOceanLand } from './ocean-land.js';
+import { assignElevation } from './elevation.js';
+import { smoothElevation, erodeComposite, sharpenRidges, applySoilCreep } from './terrain-post.js';
+import Delaunator from 'https://cdn.jsdelivr.net/npm/delaunator@5.0.1/+esm';
+
+setDelaunator(Delaunator);
+
+// Retained state between commands (avoids re-sending mesh for reapply/edit)
+let W = null;
+
+function progress(pct, label) {
+    self.postMessage({ type: 'progress', pct, label });
+}
+
+// Compute triangle elevations from region elevations
+function computeTriangleElevations(mesh, r_elevation) {
+    const t_elevation = new Float32Array(mesh.numTriangles);
+    for (let t = 0; t < mesh.numTriangles; t++) {
+        const s0 = 3 * t;
+        const a = mesh.s_begin_r(s0), b = mesh.s_begin_r(s0 + 1), c = mesh.s_begin_r(s0 + 2);
+        t_elevation[t] = (r_elevation[a] + r_elevation[b] + r_elevation[c]) / 3;
+    }
+    return t_elevation;
+}
+
+// Run terrain post-processing with per-step timing
+function runPostProcessing(mesh, r_xyz, r_elevation, params, neighborDist) {
+    const { smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening } = params;
+    const timing = [];
+
+    const r_isOcean = new Uint8Array(mesh.numRegions);
+    for (let r = 0; r < mesh.numRegions; r++) {
+        if (r_elevation[r] <= 0) r_isOcean[r] = 1;
+    }
+
+    const preErosion = new Float32Array(r_elevation);
+
+    if (smoothing > 0) {
+        const smoothIters = Math.round(1 + smoothing * 4);
+        const smoothStr = 0.2 + smoothing * 0.5;
+        const t0 = performance.now();
+        smoothElevation(mesh, r_elevation, r_isOcean, smoothIters, smoothStr);
+        timing.push({ stage: `Smoothing (${smoothIters} iters, str=${smoothStr.toFixed(2)})`, ms: performance.now() - t0 });
+    }
+
+    if (glacialErosion > 0 || hydraulicErosion > 0 || thermalErosion > 0) {
+        const gIters = Math.round(glacialErosion * 10);
+        const hIters = Math.round(hydraulicErosion * 20);
+        const hK = hydraulicErosion * 0.001;
+        const tIters = Math.round(thermalErosion * 10);
+        const talusSlope = 1.2 - thermalErosion * 0.4;
+        const kThermal = thermalErosion * 0.15;
+        const t0 = performance.now();
+        erodeComposite(mesh, r_elevation, r_xyz, r_isOcean,
+            hIters, hK, 0.5, 1.0,
+            tIters, talusSlope, kThermal,
+            gIters, glacialErosion,
+            neighborDist);
+        timing.push({ stage: `Erosion composite (h=${hIters}, t=${tIters}, g=${gIters})`, ms: performance.now() - t0 });
+    }
+
+    if (ridgeSharpening > 0) {
+        const rsIters = Math.round(1 + ridgeSharpening * 3);
+        const rsStr = ridgeSharpening * 0.08;
+        const t0 = performance.now();
+        sharpenRidges(mesh, r_elevation, r_isOcean, rsIters, rsStr);
+        timing.push({ stage: `Ridge sharpening (${rsIters} iters)`, ms: performance.now() - t0 });
+    }
+
+    {
+        const t0 = performance.now();
+        applySoilCreep(mesh, r_elevation, r_isOcean, 3, 0.1125);
+        timing.push({ stage: 'Soil creep (3 iters)', ms: performance.now() - t0 });
+    }
+
+    const dl_erosionDelta = new Float32Array(mesh.numRegions);
+    for (let r = 0; r < mesh.numRegions; r++) {
+        dl_erosionDelta[r] = r_elevation[r] - preErosion[r];
+    }
+
+    return { dl_erosionDelta, postTiming: timing };
+}
+
+function handleGenerate(data) {
+    const { N, P, jitter, nMag, numContinents, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, seed: overrideSeed, toggledIndices } = data;
+    const spread = 5;
+    const timing = []; // top-level pipeline timing
+
+    try {
+        const tTotal0 = performance.now();
+
+        progress(0, 'Shaping the world\u2026');
+        const seed = overrideSeed ?? Math.floor(Math.random() * 16777216);
+        const rng = makeRng(seed);
+
+        let t0 = performance.now();
+        const { mesh, r_xyz } = buildSphere(N, jitter, rng);
+        timing.push({ stage: 'Sphere mesh (Fibonacci + Delaunay + pole)', ms: performance.now() - t0 });
+
+        t0 = performance.now();
+        const neighborDist = computeNeighborDist(mesh, r_xyz);
+        timing.push({ stage: 'Neighbor distances', ms: performance.now() - t0 });
+
+        t0 = performance.now();
+        const t_xyz = generateTriangleCenters(mesh, r_xyz);
+        timing.push({ stage: 'Triangle centers', ms: performance.now() - t0 });
+
+        progress(15, 'Forming tectonic plates\u2026');
+        t0 = performance.now();
+        const { r_plate, plateSeeds, plateVec } = generatePlates(mesh, r_xyz, P, seed);
+        timing.push({ stage: `Plates (${P} plates)`, ms: performance.now() - t0 });
+
+        progress(25, 'Carving oceans\u2026');
+        t0 = performance.now();
+        const plateIsOcean = assignOceanLand(mesh, r_plate, plateSeeds, r_xyz, seed, numContinents);
+        timing.push({ stage: `Ocean/land (${numContinents} continents)`, ms: performance.now() - t0 });
+
+        const originalPlateIsOcean = new Set(plateIsOcean);
+
+        if (toggledIndices && toggledIndices.length > 0) {
+            const seedArr = Array.from(plateSeeds);
+            for (const i of toggledIndices) {
+                if (i < seedArr.length) {
+                    const r = seedArr[i];
+                    if (plateIsOcean.has(r)) plateIsOcean.delete(r);
+                    else plateIsOcean.add(r);
+                }
+            }
+        }
+
+        const plateDensity = {};
+        const plateDensityLand = {};
+        const plateDensityOcean = {};
+        for (const r of plateSeeds) {
+            const drng = makeRng(r + 777);
+            plateDensityOcean[r] = 3.0 + drng() * 0.5;
+            plateDensityLand[r] = 2.4 + drng() * 0.5;
+            plateDensity[r] = plateIsOcean.has(r) ? plateDensityOcean[r] : plateDensityLand[r];
+        }
+
+        const noise = new SimplexNoise(seed);
+
+        progress(35, 'Raising mountains\u2026');
+        t0 = performance.now();
+        const { r_elevation, mountain_r, coastline_r, ocean_r, r_stress, debugLayers, _timing } =
+            assignElevation(mesh, r_xyz, plateIsOcean, r_plate, plateVec, plateSeeds, noise, nMag, seed, spread, plateDensity);
+        timing.push({ stage: 'Elevation (collisions + stress + distance fields + assignment)', ms: performance.now() - t0 });
+
+        const prePostElev = new Float32Array(r_elevation);
+
+        progress(60, 'Eroding terrain\u2026');
+        t0 = performance.now();
+        const { dl_erosionDelta, postTiming } = runPostProcessing(mesh, r_xyz, r_elevation, { smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening }, neighborDist);
+        timing.push({ stage: 'Terrain post-processing (total)', ms: performance.now() - t0 });
+        debugLayers.erosionDelta = dl_erosionDelta;
+
+        progress(80, 'Computing triangle elevations\u2026');
+        t0 = performance.now();
+        const t_elevation = computeTriangleElevations(mesh, r_elevation);
+        timing.push({ stage: 'Triangle elevations', ms: performance.now() - t0 });
+
+        t0 = performance.now();
+        // Retain state for reapply/edit (clone what we'll transfer)
+        W = {
+            mesh, r_xyz: new Float32Array(r_xyz), t_xyz: new Float32Array(t_xyz),
+            neighborDist,
+            r_plate: new Int32Array(r_plate), plateSeeds: new Set(plateSeeds), plateVec,
+            plateIsOcean: new Set(plateIsOcean), originalPlateIsOcean: new Set(originalPlateIsOcean),
+            plateDensity: Object.assign({}, plateDensity),
+            plateDensityLand: Object.assign({}, plateDensityLand),
+            plateDensityOcean: Object.assign({}, plateDensityOcean),
+            prePostElev: new Float32Array(prePostElev),
+            seed, nMag, noise,
+            mountain_r: new Set(mountain_r), coastline_r: new Set(coastline_r), ocean_r: new Set(ocean_r),
+            r_stress: new Float32Array(r_stress)
+        };
+        timing.push({ stage: 'Clone state for retention', ms: performance.now() - t0 });
+
+        const tWorkerTotal = performance.now() - tTotal0;
+
+        // Build result — typed arrays we no longer need are transferred (zero-copy).
+        // mesh.triangles/halfedges are NOT transferred because W.mesh retains them.
+        const result = {
+            type: 'done',
+            triangles: mesh.triangles,
+            halfedges: mesh.halfedges,
+            numRegions: mesh.numRegions,
+            r_xyz, t_xyz, r_plate,
+            plateSeeds: Array.from(plateSeeds),
+            plateVec,
+            plateIsOcean: Array.from(plateIsOcean),
+            originalPlateIsOcean: Array.from(originalPlateIsOcean),
+            plateDensity, plateDensityLand, plateDensityOcean,
+            prePostElev,
+            r_elevation, t_elevation,
+            mountain_r: Array.from(mountain_r),
+            coastline_r: Array.from(coastline_r),
+            ocean_r: Array.from(ocean_r),
+            r_stress,
+            seed, nMag,
+            debugLayers,
+            _timing,                          // elevation sub-stages from assignElevation
+            _pipelineTiming: timing,          // top-level pipeline stages
+            _postTiming: postTiming,          // post-processing sub-stages
+            _workerTotal: tWorkerTotal,
+            _params: { N, P, jitter, nMag, numContinents, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, seed }
+        };
+
+        // Transfer arrays the worker no longer needs (cloned copies kept in W)
+        const transferList = [
+            r_xyz.buffer, t_xyz.buffer, r_plate.buffer,
+            prePostElev.buffer, r_elevation.buffer, t_elevation.buffer,
+            r_stress.buffer
+        ];
+
+        self.postMessage(result, transferList);
+
+    } catch (err) {
+        self.postMessage({ type: 'error', message: err.message, stack: err.stack });
+    }
+}
+
+function handleReapply(data) {
+    if (!W) { self.postMessage({ type: 'error', message: 'No retained state for reapply' }); return; }
+
+    try {
+        const tTotal0 = performance.now();
+
+        progress(0, 'Reapplying terrain\u2026');
+
+        let t0 = performance.now();
+        const r_elevation = new Float32Array(W.prePostElev);
+        const tClone = performance.now() - t0;
+
+        progress(20, 'Eroding terrain\u2026');
+        t0 = performance.now();
+        const { dl_erosionDelta, postTiming } = runPostProcessing(W.mesh, W.r_xyz, r_elevation, data, W.neighborDist);
+        const tPost = performance.now() - t0;
+
+        progress(80, 'Computing triangle elevations\u2026');
+        t0 = performance.now();
+        const t_elevation = computeTriangleElevations(W.mesh, r_elevation);
+        const tTriElev = performance.now() - t0;
+
+        const tWorkerTotal = performance.now() - tTotal0;
+
+        const result = {
+            type: 'reapplyDone',
+            r_elevation,
+            t_elevation,
+            erosionDelta: dl_erosionDelta,
+            _reapplyTiming: {
+                clone: tClone,
+                postProcessing: tPost,
+                triangleElevations: tTriElev,
+                workerTotal: tWorkerTotal
+            },
+            _postTiming: postTiming
+        };
+
+        self.postMessage(result, [r_elevation.buffer, t_elevation.buffer, dl_erosionDelta.buffer]);
+
+    } catch (err) {
+        self.postMessage({ type: 'error', message: err.message, stack: err.stack });
+    }
+}
+
+function handleEditRecompute(data) {
+    if (!W) { self.postMessage({ type: 'error', message: 'No retained state for editRecompute' }); return; }
+
+    try {
+        const tTotal0 = performance.now();
+
+        progress(0, 'Rebuilding elevation\u2026');
+
+        // Update retained plate state
+        W.plateIsOcean = new Set(data.plateIsOcean);
+        W.plateDensity = Object.assign({}, data.plateDensity);
+
+        const { mesh, r_xyz, plateIsOcean, r_plate, plateVec, plateSeeds, noise, seed } = W;
+        const nMag = data.nMag;
+        const spread = 5;
+
+        let t0 = performance.now();
+        const { r_elevation, mountain_r, coastline_r, ocean_r, r_stress, debugLayers, _timing } =
+            assignElevation(mesh, r_xyz, plateIsOcean, r_plate, plateVec, plateSeeds, noise, nMag, seed, spread, W.plateDensity);
+        const tElev = performance.now() - t0;
+
+        const prePostElev = new Float32Array(r_elevation);
+
+        progress(50, 'Eroding terrain\u2026');
+        t0 = performance.now();
+        const { dl_erosionDelta, postTiming } = runPostProcessing(mesh, r_xyz, r_elevation, data, W.neighborDist);
+        const tPost = performance.now() - t0;
+        debugLayers.erosionDelta = dl_erosionDelta;
+
+        progress(80, 'Computing triangle elevations\u2026');
+        t0 = performance.now();
+        const t_elevation = computeTriangleElevations(mesh, r_elevation);
+        const tTriElev = performance.now() - t0;
+
+        // Update retained state
+        t0 = performance.now();
+        W.prePostElev = new Float32Array(prePostElev);
+        W.mountain_r = new Set(mountain_r);
+        W.coastline_r = new Set(coastline_r);
+        W.ocean_r = new Set(ocean_r);
+        W.r_stress = new Float32Array(r_stress);
+        const tRetain = performance.now() - t0;
+
+        const tWorkerTotal = performance.now() - tTotal0;
+
+        const result = {
+            type: 'editDone',
+            prePostElev,
+            r_elevation,
+            t_elevation,
+            mountain_r: Array.from(mountain_r),
+            coastline_r: Array.from(coastline_r),
+            ocean_r: Array.from(ocean_r),
+            r_stress,
+            debugLayers,
+            _editTiming: {
+                elevation: tElev,
+                postProcessing: tPost,
+                triangleElevations: tTriElev,
+                retainState: tRetain,
+                workerTotal: tWorkerTotal
+            },
+            _timing,        // elevation sub-stages
+            _postTiming: postTiming
+        };
+
+        self.postMessage(result, [
+            prePostElev.buffer, r_elevation.buffer, t_elevation.buffer, r_stress.buffer
+        ]);
+
+    } catch (err) {
+        self.postMessage({ type: 'error', message: err.message, stack: err.stack });
+    }
+}
+
+self.onmessage = (e) => {
+    const { cmd } = e.data;
+    switch (cmd) {
+        case 'generate': handleGenerate(e.data); break;
+        case 'reapply': handleReapply(e.data); break;
+        case 'editRecompute': handleEditRecompute(e.data); break;
+        default: self.postMessage({ type: 'error', message: `Unknown command: ${cmd}` });
+    }
+};


### PR DESCRIPTION
## Summary

- **Eliminate `r_circulate_r` copy overhead** across all 37 call sites in the generation pipeline by exposing `adjOffset`/`adjList` typed arrays directly from `SphereMesh` and iterating them in-place
- **Pre-compute neighbor distances** once after mesh construction (`computeNeighborDist`), replacing ~30M redundant `Math.sqrt` calls in erosion's hot loops (glacial widening, hydraulic drainage, thermal slope)
- **Pre-allocate thermal erosion buffers** with typed arrays instead of per-cell dynamic `push()` arrays
- **Replace `Map` with inline array counting** in plate boundary smoothing, eliminating ~107M slow Map get/set operations
- **Fuse distance-update + top-3 search** in farthest-point plate seeding, reducing O(N) passes by ~24%
- **Eliminate redundant `landCells.sort()`** calls in the erosion loop — saves 3 sorts of ~1.8M elements when glacial iterations finish before hydraulic
- **Skip ocean cells** in `sharpenRidges` and `applySoilCreep` by pre-building land cell lists, avoiding ~40-50% unnecessary iteration
- **Move generation pipeline to a Web Worker** (`planet-worker.js`) to keep the main thread responsive

## Test plan

- [ ] Generate a planet at default settings — verify visual output is correct
- [ ] Generate at 2.56M regions — check console timing for speedup vs baseline (~42s → ~34-36s)
- [ ] Reapply erosion sliders — verify terrain updates correctly
- [ ] Ctrl-click plate toggle (edit mode) — verify recompute works
- [ ] Load a planet code from URL hash — verify deterministic reproduction
- [ ] Check for NaN warnings in console (existing diagnostic catches these)
- [ ] Test on mobile (touch device) — verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)