### PR TITLE
Improve hotspot volcanism realism

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All three are considered together; ties are broken in the order above.
 - **Elevation generation** — three distance fields (mountain/ocean/coastline) combined via harmonic-mean formula, stress-driven uplift, asymmetric mountain profiles, continental shelf/slope/abyss profiles, foreland basins, plateau formation, and rift valleys with graben profiles
 - **Ocean floor features** — mid-ocean ridges at divergent boundaries, deep trenches at subduction zones, fracture zones at transform boundaries, back-arc basins behind subduction zones
 - **Island arcs** — volcanic island chains at ocean-ocean convergent boundaries with ridged noise shaping
-- **Hotspot volcanism** — mantle plume simulation with drift-trail island chains, per-hotspot variation in strength/decay/spacing, and volcanic texture noise
+- **Hotspot volcanism** — dual-component mantle plume model (broad thermal swell + volcanic peak) with drift-trail island chains, domain-warped shape distortion, drift-direction elongation, summit calderas on active domes, radial rift-zone ridges, age-dependent volcanic texture, and per-hotspot variation in strength/decay/spacing
 - **Terrain post-processing** — independently controllable bilateral smoothing to blend harsh BFS distance-field boundaries, glacial erosion that carves fjords, U-shaped valleys, and lake basins at high latitudes and altitudes via latitude-driven ice flow with drainage accumulation, priority-flood pit resolution with canyon carving (Barnes et al. algorithm that ensures every land cell drains to the ocean, carving dramatic canyons through mountain saddle points rather than filling basins), iterative implicit stream power hydraulic erosion (Braun-Willett style) that carves self-reinforcing river valleys with automatic sediment deposition in flat receivers, thermal erosion that softens ridges via talus-angle material transport, ridge sharpening that accentuates mountain ridgelines, and always-on soil creep (Laplacian diffusion) that rounds off hillslopes
 - **Coastal roughening** — fractal noise with active/passive margin differentiation, domain warping for bays/headlands, and offshore island scattering
 - **3D globe rendering** with atmosphere rim shader, translucent water sphere, terrain displacement, and starfield
@@ -157,7 +157,7 @@ Atlas Engine is fully usable on phones and tablets:
 - **Domain warping** — noise-driven coordinate offsets for organic coastlines
 - **Density-based subduction** — tanh mapping of density differences with undulation noise
 - **BFS distance fields** — randomized frontier expansion from boundary seeds, used for elevation, coast distance, rift width, ridge profiles, and back-arc basins
-- **Gaussian dome uplift** — hotspot volcanism modeled as great-circle-distance Gaussians with shape warping noise
+- **Gaussian dome uplift** — hotspot volcanism modeled as dual-component Gaussians (thermal swell + volcanic peak) with domain-warped shape distortion, anisotropic drift elongation, summit calderas, radial rift ridges, and age-dependent texture blending
 
 ## Project Structure
 

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
                     <input type="range" id="sRs" min="0" max="1" value="0.35" step="0.05">
                     <div class="slider-hint"><span>None</span><span>Jagged</span></div>
                 </div>
-                <button id="reapplyBtn" title="Reapply terrain sculpting" disabled>&#x21bb; Reapply</button>
+                <button id="reapplyBtn" title="Reapply terrain sculpting" disabled><span class="reapply-icon">&#x21bb;</span> Reapply</button>
             </div>
         </details>
         <details class="section" open>

--- a/styles.css
+++ b/styles.css
@@ -105,7 +105,7 @@ button#generate.generating {
     transition: background 0.2s, color 0.2s, border-color 0.2s;
 }
 #reapplyBtn:disabled { opacity: 0.4; }
-#reapplyBtn.spinning { animation: spin 0.8s linear infinite; }
+#reapplyBtn.spinning .reapply-icon { display: inline-block; animation: spin 0.8s linear infinite; }
 #reapplyBtn.ready {
     background: linear-gradient(135deg, #1a7a4a, #22aa5a);
     color: #fff; border-color: transparent;


### PR DESCRIPTION
## Summary
- **Dual-component hotspot model** — each dome now produces a broad thermal swell (2x wider, 10% strength) plus a volcanic peak, replacing the single Gaussian bump
- **Domain-warped shape distortion** — pre-warped fbm breaks circular silhouettes into organic, non-repeating shapes
- **Age-dependent volcanic texture** — active domes get dramatic gullies (ridged noise 0.4–1.2 range), older chain members erode to smooth profiles (0.7–1.0)
- **Drift-direction elongation** — anisotropic Gaussian stretched 1.4x along plate motion direction
- **Summit calderas** — active domes get a subtracted narrow Gaussian creating collapsed summit craters
- **Radial rift-zone ridges** — 2–3 ridges radiate from active summits, tapering for older chain members
- **Chain variation** — age broadening on older domes, minimum chain length increased to 3
- **Reapply button fix** — spin animation now targets only the ↻ icon, not the entire button text

## Test plan
- [ ] Generate several planets with different seeds; verify hotspots look like distinct volcanic features, not smooth circles
- [ ] Use Inspect > Hotspot overlay to check elevation profiles
- [ ] Verify ocean hotspots create visible seamounts/island chains without lifting entire ocean floor
- [ ] Confirm hotspots don't bleed into each other or create continent-sized blobs
- [ ] Verify reapply button spins only the icon during processing
- [ ] Check generation time stays reasonable at default detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)