### PR TITLE
Add power-user survey prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -232,6 +232,18 @@
         </div>
     </div>
 
+    <div id="surveyOverlay" class="hidden">
+        <div id="surveyCard">
+            <button id="surveyClose">&times;</button>
+            <h3>Thanks for exploring!</h3>
+            <p>You've spent some real time with World Orogen &mdash; that means a lot. If you have a minute, I'd love to hear what you think.</p>
+            <div class="survey-actions">
+                <button id="surveyDismiss" class="btn-ghost">Maybe later</button>
+                <a id="surveyLink" href="https://docs.google.com/forms/d/e/1FAIpQLScFSryT8Uom4jMkpb-YQnyjHMSWqZmDDT3bSOSabHovsjKL7A/viewform?usp=dialog" target="_blank" rel="noopener" class="btn-primary">Take the survey</a>
+            </div>
+        </div>
+    </div>
+
     <div id="topInfo">Drag to rotate &middot; Scroll to zoom &middot; Ctrl-click to reshape continents</div>
     <button id="editToggle" class="edit-toggle" title="Toggle plate edit mode">
         <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" stroke-width="2">

--- a/styles.css
+++ b/styles.css
@@ -428,6 +428,51 @@ button#generate.generating {
     margin-top: 18px;
 }
 
+/* Survey overlay */
+#surveyOverlay {
+    position: fixed; inset: 0;
+    background: rgba(0,0,0,0.6);
+    z-index: 200;
+    display: flex; align-items: center; justify-content: center;
+    transition: opacity 0.5s ease;
+}
+#surveyOverlay.hidden {
+    opacity: 0; pointer-events: none;
+}
+#surveyCard {
+    position: relative;
+    max-width: 380px; width: 90%;
+    background: rgba(8,8,28,0.94); backdrop-filter: blur(16px);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 12px;
+    padding: 28px 24px 20px;
+    color: #cde;
+}
+#surveyCard h3 {
+    font-size: 18px; font-weight: 600; color: #fff;
+    margin-bottom: 10px;
+}
+#surveyCard p {
+    font-size: 14px; line-height: 1.6; color: #9ab;
+    margin-bottom: 0;
+}
+#surveyClose {
+    position: absolute; top: 10px; right: 14px;
+    background: none; border: none;
+    color: #667; font-size: 22px; cursor: pointer;
+    line-height: 1; padding: 4px;
+    transition: color 0.2s;
+}
+#surveyClose:hover { color: #fff; }
+.survey-actions {
+    display: flex; justify-content: flex-end; gap: 10px;
+    margin-top: 18px;
+}
+.survey-actions .btn-primary {
+    text-decoration: none;
+    display: inline-flex; align-items: center;
+}
+
 /* Sheet handle — hidden on desktop */
 .sheet-handle { display: none; }
 


### PR DESCRIPTION
## Summary
- Adds a survey modal that appears for engaged users (3+ distinct hours across 2+ days)
- Tracks usage via localStorage with hashed timestamps for privacy
- Shows the prompt once after planet generation, with dismiss/close options that permanently suppress it
- Links to a Google Forms feedback survey

## Test plan
- [ ] Reset localStorage (`localStorage.removeItem('wo-survey-dismissed'); localStorage.setItem('wo-usage', JSON.stringify({h:3,d:2,lh:'',ld:''}))`) and reload — modal should appear ~1s after generation
- [ ] Clicking "Maybe later", the X button, backdrop, or pressing Escape all dismiss and suppress permanently
- [ ] "Take the survey" opens the Google Form in a new tab and dismisses
- [ ] Modal displays correctly on mobile (bottom-sheet layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)