### PR TITLE
Multi-plate selection & batch rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ All three are considered together; ties are broken in the order above.
 - **Coastal roughening** — fractal noise with active/passive margin differentiation, domain warping for bays/headlands, and offshore island scattering
 - **3D globe rendering** with atmosphere rim shader, translucent water sphere, terrain displacement, and starfield
 - **Equirectangular map projection** with antimeridian wrapping
-- **Interactive editing** — Ctrl-click any plate to toggle between land and ocean, with live elevation recomputation
+- **Interactive editing** — Ctrl-click plates to mark them for reshaping (multi-select with visual tinting), then click Rebuild to apply all changes at once. Ctrl-click again to undo a pending selection. Press Escape to cancel all pending edits
 - **Seasonal wind simulation** — pressure-driven wind patterns with a longitude-varying ITCZ that tracks the thermal equator (~5° over ocean, up to 15-20° over continents), Gaussian pressure bands (subtropical highs, subpolar lows, polar highs), land/sea thermal contrast for monsoon-like pressure reversals, elevation barometric effects, and Coriolis-deflected geostrophic wind with natural cross-equatorial flow reversal. Computed for both summer and winter seasons.
 - **Ocean surface currents** — rule-based geographic gyre simulation driven by wind belts (trade winds, westerlies, polar easterlies) with a longitude-varying ITCZ equatorial countercurrent. Continental shelves are classified as western or eastern boundaries via coast-normal BFS, producing subtropical gyres (CW in NH, CCW in SH) with western boundary intensification (Gulf Stream, Kuroshio effect) and weaker eastern boundary return flow. Detects circumpolar channels for unobstructed eastward currents (Antarctic Circumpolar Current). Currents are colored by heat transport: red = warm poleward flow, blue = cold equatorward flow, black = zonal (neutral). Computed for both summer and winter seasons.
 - **Precipitation** — blended dual-model approach: a complex moisture advection simulation is combined 50-50 with a fast heuristic zonal model. The advection model simulates wind-driven moisture transport from coasts with six mechanisms: ITCZ convective uplift, frontal convergence, orographic rain/shadow, lee cyclogenesis, polar-front precipitation, and subtropical high suppression. The heuristic model provides smooth latitude-based patterns (ITCZ wet belt, subtropical dry belt, mid-latitude recovery, polar dryness) modulated by continentality and orographic effects. Blending the two reduces splotchiness while preserving terrain-informed detail and strengthening subtropical desert formation (~20–35°). Visualized on a brown (dry) → green (moderate) → blue (wet) color ramp. Computed for both summer and winter seasons.
@@ -56,7 +56,7 @@ Click **Build New World** to create a new random planet. The button changes colo
 
 ### Sharing Planets
 
-Every generated planet produces a **planet code** (shown below the Build button) that encodes the random seed, all slider values, and any plate edits. An unedited planet is 18 characters; Ctrl-click edits extend the code to include the toggled plates. To share a planet:
+Every generated planet produces a **planet code** (shown below the Build button) that encodes the random seed, all slider values, and any plate edits. An unedited planet is 18 characters; plate edits (applied via Rebuild) extend the code to include the toggled plates. To share a planet:
 
 - **Copy** the code with the copy button and send it to someone
 - **Load** a code by pasting it into the planet code field and clicking Load (or pressing Enter). The Load button turns blue when a new code is ready to apply.
@@ -146,9 +146,12 @@ Navigation hints are shown in the sidebar panel and as a contextual tooltip when
 | Rotate globe / pan map | Drag | Drag (one finger) |
 | Zoom | Scroll wheel | Pinch with two fingers |
 | Highlight plate + info card | Hover | — |
-| Reshape continents | Ctrl-click a plate | Tap the edit button (pencil), then tap a plate |
+| Mark plate for reshaping | Ctrl-click a plate (multi-select) | Tap the edit button (pencil), then tap plates |
+| Undo pending plate | Ctrl-click the same plate again | Tap the same plate again |
+| Apply pending edits | Click the Rebuild button | Tap the Rebuild button |
+| Cancel all pending edits | Press Escape | — |
 
-Hovering over a region shows an info card with plate type, elevation, coordinates, and (when climate has been computed) temperature, precipitation, and K&ouml;ppen classification.
+Hovering over a region shows an info card with plate type, elevation, coordinates, and (when climate has been computed) temperature, precipitation, and K&ouml;ppen classification. Pending plates show a colored tint (green = ocean→land, blue = land→ocean) and hover text indicates "(pending)".
 
 ### Mobile Support
 
@@ -157,7 +160,7 @@ World Orogen is fully usable on phones and tablets:
 - **Bottom-sheet sidebar** — on screens 768px or narrower, the sidebar becomes a bottom sheet with a drag handle. Drag or tap the handle to expand/collapse. The globe stays visible above.
 - **Pinch-to-zoom** — two-finger pinch zooms the globe and map, using the same smooth lerp as desktop scroll-zoom.
 - **View switcher** — a dropdown in the top-right lets you switch between Terrain, Satellite, Climate, and Heightmap views without opening the bottom sheet.
-- **Edit-mode toggle** — a floating pencil button (bottom-right) activates plate editing. Tap it to toggle edit mode (glows green when active), then tap any plate to reshape.
+- **Edit-mode toggle** — a floating pencil button (bottom-right) activates plate editing. Tap it to toggle edit mode (glows green when active), then tap plates to mark them. Tap the Rebuild button to apply all changes at once.
 - **Touch-friendly targets** — buttons, checkboxes, and sliders are enlarged for comfortable finger input.
 - **Performance** — detail warning thresholds are lowered on touch devices (orange at 200K, red at 500K). Export widths above 8192px are disabled on mobile.
 - **Tooltips** reposition above their trigger instead of to the right, so they stay on screen.
@@ -230,7 +233,7 @@ js/
   temperature.js        Temperature simulation — ITCZ thermal equator, lapse rate, continentality, ocean currents
   scene.js              Three.js scene, cameras, controls, lights
   planet-mesh.js        Voronoi mesh, map projection, hover highlight
-  edit-mode.js          Ctrl-click plate toggle + hover info
+  edit-mode.js          Ctrl-click plate multi-select + hover info
   detail-scale.js       Non-linear (power-curve) detail slider mapping
 ```
 

--- a/index.html
+++ b/index.html
@@ -122,7 +122,7 @@
             <li>Multiple erosion types: glacial (fjords, U-shaped valleys), hydraulic (river valleys), and thermal (talus slopes)</li>
             <li>Climate simulation with seasonal wind patterns, ocean currents, precipitation, and K&ouml;ppen climate classification</li>
             <li>Hotspot volcanism with drift-trail island chains (like Hawaii)</li>
-            <li>Interactive plate editing — click any plate to toggle between land and ocean</li>
+            <li>Interactive plate editing — select multiple plates for batch land/ocean toggling with visual preview before rebuild</li>
             <li>Multiple visualization modes: terrain, satellite biome, climate, and heightmap</li>
             <li>26 detailed inspection layers for geology, atmosphere, ocean, and climate</li>
             <li>High-resolution equirectangular map export up to 65,536px wide</li>
@@ -345,7 +345,7 @@
             </div>
             <div class="tutorial-step" data-step="2">
                 <h3>Explore &amp; Edit</h3>
-                <p><strong>Drag</strong> to rotate the globe. <strong>Scroll</strong> to zoom in and out. <strong>Ctrl-click</strong> any plate to reshape continents &mdash; ocean rises into land, land floods into ocean. <strong>Hover</strong> any region to see elevation, coordinates, temperature, precipitation, and climate classification.</p>
+                <p><strong>Drag</strong> to rotate the globe. <strong>Scroll</strong> to zoom in and out. <strong>Ctrl-click</strong> plates to mark them for reshaping &mdash; select multiple, then hit <strong>Rebuild</strong> to apply all at once. Ctrl-click again to undo a pending selection. <strong>Hover</strong> any region to see elevation, coordinates, temperature, precipitation, and climate classification.</p>
             </div>
             <div class="tutorial-step" data-step="3">
                 <h3>Visualize Your World</h3>
@@ -431,6 +431,12 @@
         </svg>
     </button>
     <div id="hoverInfo"></div>
+    <button id="rebuildFab" class="rebuild-fab" style="display:none">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="2 8 6 12 14 4"/>
+        </svg>
+        <span>Rebuild (0)</span>
+    </button>
     <div id="info">Drag to rotate &middot; Scroll to zoom &middot; Ctrl-click to reshape continents</div>
 
     <script type="importmap">

--- a/js/edit-mode.js
+++ b/js/edit-mode.js
@@ -5,9 +5,7 @@
 import * as THREE from 'three';
 import { canvas, camera, mapCamera } from './scene.js';
 import { state } from './state.js';
-import { editRecomputeViaWorker } from './generate.js';
-import { computePlateColors, buildMesh, updateHoverHighlight, updateMapHoverHighlight } from './planet-mesh.js';
-import { detailFromSlider } from './detail-scale.js';
+import { updateHoverHighlight, updateMapHoverHighlight, updatePendingHighlight, updateMapPendingHighlight } from './planet-mesh.js';
 import { KOPPEN_CLASSES } from './koppen.js';
 import { elevToHeightKm } from './color-map.js';
 
@@ -15,13 +13,6 @@ const raycaster = new THREE.Raycaster();
 const mouse = new THREE.Vector2();
 const _inverseMatrix = new THREE.Matrix4();
 const _localRay = new THREE.Ray();
-
-/** Recompute elevation from the (possibly edited) plate data via worker. */
-function recomputeElevation(onDone) {
-    const detail = detailFromSlider(+document.getElementById('sN').value);
-    const skipClimate = detail > 300000;
-    editRecomputeViaWorker(onDone, skipClimate);
-}
 
 /** Find nearest region to a unit-sphere direction (max dot product). */
 function findNearestRegion(nx, ny, nz) {
@@ -110,12 +101,18 @@ function getHitInfo(event) {
 function buildHoverHTML(region, plate) {
     const d = state.curData;
     const isOcean = d.plateIsOcean.has(plate);
+    const isPending = state.pendingToggles.has(plate);
     const dot = `<span style="color:${isOcean ? '#4af' : '#6b3'}">●</span>`;
     const action = state.isTouchDevice ? 'Tap' : 'Ctrl-click';
     const lines = [];
 
     // Line 1: plate type + edit hint
-    lines.push(`${dot} <b>${isOcean ? 'Ocean' : 'Land'}</b> plate · ${action} to ${isOcean ? 'raise land' : 'flood'}`);
+    if (isPending) {
+        const target = isOcean ? 'Land' : 'Ocean';
+        lines.push(`${dot} <b>${isOcean ? 'Ocean' : 'Land'} → ${target}</b> <span style="color:#fa0">(pending)</span> · ${action} to undo`);
+    } else {
+        lines.push(`${dot} <b>${isOcean ? 'Ocean' : 'Land'}</b> plate · ${action} to ${isOcean ? 'raise land' : 'flood'}`);
+    }
 
     // Elevation
     const elev = d.r_elevation[region];
@@ -196,35 +193,33 @@ export function setupEditMode() {
 
         if (dx * dx + dy * dy < 36) {
             const pid = downInfo.plate;
-            const { plateIsOcean, plateDensity, plateDensityLand, plateDensityOcean } = state.curData;
-            if (plateIsOcean.has(pid)) {
-                plateIsOcean.delete(pid);
-                plateDensity[pid] = plateDensityLand[pid];
+            // Toggle pending: add if absent, remove if present (undo)
+            if (state.pendingToggles.has(pid)) {
+                state.pendingToggles.delete(pid);
             } else {
-                plateIsOcean.add(pid);
-                plateDensity[pid] = plateDensityOcean[pid];
+                state.pendingToggles.add(pid);
             }
-
+            // Remove hover highlight first so pending tint applies to base colors.
+            // Hover saves its backup from pre-pending colors; if we don't strip it,
+            // the hover restore in updateHoverHighlight wipes out the pending tint.
+            const savedHover = state.hoveredPlate;
+            state.hoveredPlate = -1;
+            if (state.mapMode) updateMapHoverHighlight();
+            else updateHoverHighlight();
+            state.hoveredPlate = savedHover;
+            // Apply pending tint to the now-clean base colors
+            updatePendingHighlight();
+            updateMapPendingHighlight();
+            // Re-apply hover on top of pending-tinted colors
+            if (state.mapMode) updateMapHoverHighlight();
+            else updateHoverHighlight();
+            // Update hover text to reflect pending state
             const hoverEl = document.getElementById('hoverInfo');
-            hoverEl.innerHTML = '\u23F3 Rebuilding\u2026';
-            hoverEl.style.display = 'block';
-
-            const btn = document.getElementById('generate');
-            btn.disabled = true;
-            btn.textContent = 'Building\u2026';
-            btn.classList.add('generating');
-
-            recomputeElevation(() => {
-                btn.disabled = false;
-                btn.textContent = 'Build New World';
-                btn.classList.remove('generating');
-                // Update hover info to reflect the new state
-                if (state.hoveredRegion >= 0 && state.curData) {
-                    hoverEl.innerHTML = buildHoverHTML(state.hoveredRegion, state.hoveredPlate);
-                }
-                // Notify main.js to update the planet code
-                document.dispatchEvent(new CustomEvent('plates-edited'));
-            });
+            if (state.hoveredRegion >= 0 && state.curData) {
+                hoverEl.innerHTML = buildHoverHTML(state.hoveredRegion, state.hoveredPlate);
+            }
+            // Notify main.js to show/hide rebuild button
+            document.dispatchEvent(new CustomEvent('pending-edits-changed'));
         }
         downInfo = null;
     });
@@ -248,8 +243,10 @@ export function setupEditMode() {
         lastHoverTime = now;
 
         const hit = getHitInfo(e);
-        const newPlate = hit ? hit.plate : -1;
         const newRegion = hit ? hit.region : -1;
+        // Only highlight the plate when in edit mode (Ctrl held or mobile edit toggle)
+        const inEditMode = e.ctrlKey || (state.isTouchDevice && state.editMode);
+        const newPlate = (hit && inEditMode) ? hit.plate : -1;
 
         // Update plate highlight only when plate changes
         if (newPlate !== state.hoveredPlate) {
@@ -261,9 +258,10 @@ export function setupEditMode() {
         // Update info text when region changes
         if (newRegion !== state.hoveredRegion) {
             state.hoveredRegion = newRegion;
+            state.hoveredPlate = (hit && inEditMode) ? hit.plate : -1;
             const hoverEl = document.getElementById('hoverInfo');
             if (newRegion >= 0) {
-                hoverEl.innerHTML = buildHoverHTML(newRegion, newPlate);
+                hoverEl.innerHTML = buildHoverHTML(newRegion, hit.plate);
                 hoverEl.style.display = 'block';
             } else {
                 hoverEl.style.display = 'none';

--- a/js/main.js
+++ b/js/main.js
@@ -5,9 +5,9 @@ import { renderer, scene, camera, ctrl, waterMesh, atmosMesh, starsMesh,
          mapCamera, updateMapCameraFrustum, mapCtrl, canvas,
          tickZoom, tickMapZoom } from './scene.js';
 import { state } from './state.js';
-import { generate, reapplyViaWorker, computeClimateViaWorker } from './generate.js';
+import { generate, reapplyViaWorker, computeClimateViaWorker, editRecomputeViaWorker } from './generate.js';
 import { encodePlanetCode, decodePlanetCode } from './planet-code.js';
-import { buildMesh, updateMeshColors, buildMapMesh, rebuildGrids, exportMap, exportMapBatch, buildWindArrows, buildOceanCurrentArrows, updateKoppenHoverHighlight, updateMapKoppenHoverHighlight } from './planet-mesh.js';
+import { buildMesh, updateMeshColors, buildMapMesh, rebuildGrids, exportMap, exportMapBatch, buildWindArrows, buildOceanCurrentArrows, updateKoppenHoverHighlight, updateMapKoppenHoverHighlight, updatePendingHighlight, updateMapPendingHighlight } from './planet-mesh.js';
 import { setupEditMode } from './edit-mode.js';
 import { detailFromSlider, sliderFromDetail } from './detail-scale.js';
 import { KOPPEN_CLASSES } from './koppen.js';
@@ -570,6 +570,8 @@ function applyCode(code) {
         el.dispatchEvent(new Event('input'));
     }
     clearReapplyPending();
+    state.pendingToggles.clear();
+    document.getElementById('rebuildFab').style.display = 'none';
     showBuildOverlay();
     generate(params.seed, params.toggledIndices, onProgress, shouldSkipClimate());
 }
@@ -798,6 +800,80 @@ if (debugLayerEl) {
 
 // Edit mode setup (pointer events, sub-mode buttons)
 setupEditMode();
+
+// Rebuild FAB — batch-apply pending plate toggles
+(function initRebuildFab() {
+    const rebuildBtn = document.getElementById('rebuildFab');
+    const rebuildLabel = rebuildBtn.querySelector('span');
+
+    function clearPending() {
+        state.pendingToggles.clear();
+        rebuildBtn.style.display = 'none';
+        state._pendingBackup = null;
+        state._mapPendingBackup = null;
+        updatePendingHighlight();
+        updateMapPendingHighlight();
+    }
+
+    // Show/hide rebuild button when pending set changes
+    document.addEventListener('pending-edits-changed', () => {
+        const count = state.pendingToggles.size;
+        if (count > 0) {
+            rebuildLabel.textContent = `Rebuild (${count})`;
+            rebuildBtn.style.display = '';
+        } else {
+            rebuildBtn.style.display = 'none';
+        }
+    });
+
+    // Click: apply all pending toggles, then recompute once
+    rebuildBtn.addEventListener('click', () => {
+        if (state.pendingToggles.size === 0) return;
+        const { plateIsOcean, plateDensity, plateDensityLand, plateDensityOcean } = state.curData;
+
+        // Apply all pending toggles
+        for (const pid of state.pendingToggles) {
+            if (plateIsOcean.has(pid)) {
+                plateIsOcean.delete(pid);
+                plateDensity[pid] = plateDensityLand[pid];
+            } else {
+                plateIsOcean.add(pid);
+                plateDensity[pid] = plateDensityOcean[pid];
+            }
+        }
+
+        clearPending();
+
+        // Show building state
+        const btn = document.getElementById('generate');
+        btn.disabled = true;
+        btn.textContent = 'Building\u2026';
+        btn.classList.add('generating');
+
+        const hoverEl = document.getElementById('hoverInfo');
+        hoverEl.innerHTML = '\u23F3 Rebuilding\u2026';
+        hoverEl.style.display = 'block';
+
+        const skipClimate = shouldSkipClimate();
+        editRecomputeViaWorker(() => {
+            btn.disabled = false;
+            btn.textContent = 'Build New World';
+            btn.classList.remove('generating');
+            hoverEl.style.display = 'none';
+            document.dispatchEvent(new CustomEvent('plates-edited'));
+        }, skipClimate);
+    });
+
+    // Escape clears all pending edits
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && state.pendingToggles.size > 0) {
+            clearPending();
+        }
+    });
+
+    // Clear pending on new generation
+    genBtn.addEventListener('generate-done', clearPending);
+})();
 
 // Sidebar toggle (desktop) + bottom sheet (mobile)
 const sidebarToggle = document.getElementById('sidebarToggle');
@@ -1068,7 +1144,7 @@ window.addEventListener('resize', () => {
         const step2 = card.querySelector('.tutorial-step[data-step="2"]');
         if (step2) {
             const p = step2.querySelector('p');
-            if (p) p.innerHTML = '<strong>Drag</strong> to rotate the globe. <strong>Pinch</strong> to zoom in and out. Tap the <strong>edit button</strong> (pencil icon) then <strong>tap</strong> any plate to reshape continents &mdash; ocean rises into land, land floods into ocean.';
+            if (p) p.innerHTML = '<strong>Drag</strong> to rotate the globe. <strong>Pinch</strong> to zoom in and out. Tap the <strong>edit button</strong> (pencil icon) then <strong>tap</strong> plates to mark them for reshaping &mdash; select multiple, then hit <strong>Rebuild</strong> to apply all at once. Tap again to undo a pending selection.';
         }
     }
 
@@ -1154,7 +1230,7 @@ window.takePreview = function(width = 1200, height = 630) {
     // Hide all UI elements
     const hiddenEls = [];
     for (const sel of ['#ui', '#topInfo', '#info', '#hoverInfo', '#helpBtn',
-                        '#editToggle', '#refreshFab', '#mobileViewSwitch',
+                        '#editToggle', '#refreshFab', '#rebuildFab', '#mobileViewSwitch',
                         '#buildOverlay', '#tutorialOverlay', '#exportOverlay', '#surveyOverlay']) {
         const el = document.querySelector(sel);
         if (el && el.style.display !== 'none') {

--- a/js/planet-mesh.js
+++ b/js/planet-mesh.js
@@ -370,6 +370,7 @@ export function buildMapMesh() {
     state.mapFaceToSide = faceToSide.subarray(0, triCount);
     state._mapHoverBackup = null;
     state._mapKoppenHoverBackup = null;
+    state._mapPendingBackup = null;
     // Wrap clones: children inherit parent visibility + transform
     const cloneL = new THREE.Mesh(geo, mat); cloneL.position.x = -4;
     const cloneR = new THREE.Mesh(geo, mat); cloneR.position.x = 4;
@@ -704,6 +705,7 @@ export function buildMesh() {
     }
 
     buildDriftArrows();
+    updatePendingHighlight();
     updateHoverHighlight();
 
     // Defer map mesh construction to reduce peak GPU memory — built on demand
@@ -829,6 +831,7 @@ export function updateMeshColors() {
     colorAttr.needsUpdate = true;
     state._hoverBackup = null;
     state._koppenHoverBackup = null;
+    state._pendingBackup = null;
 
     // Update map mesh colors in-place (if map exists)
     if (state.mapMesh && state.mapFaceToSide) {
@@ -850,11 +853,14 @@ export function updateMeshColors() {
         mapColorAttr.needsUpdate = true;
         state._mapHoverBackup = null;
         state._mapKoppenHoverBackup = null;
+        state._mapPendingBackup = null;
     }
 
     // Update water visibility
     waterMesh.visible = !state.mapMode && !showPlates && !showStress && !debugLayer;
 
+    updatePendingHighlight();
+    updateMapPendingHighlight();
     updateHoverHighlight();
     updateMapHoverHighlight();
 }
@@ -1037,6 +1043,111 @@ export function updateMapKoppenHoverHighlight() {
             }
         }
         state._mapKoppenHoverBackup = { offsets, saved };
+    }
+    colorAttr.needsUpdate = true;
+}
+
+// Pending-toggle highlight — tint plates queued for rebuild (surgical save/restore).
+// Runs BEFORE hover highlight so hover saves/restores the already-tinted colors.
+export function updatePendingHighlight() {
+    if (!state.planetMesh || !state.curData) return;
+    const colorAttr = state.planetMesh.geometry.getAttribute('color');
+    const colors = colorAttr.array;
+
+    // Restore previously highlighted cells
+    if (state._pendingBackup) {
+        const { offsets, saved } = state._pendingBackup;
+        for (let i = 0; i < offsets.length; i++) {
+            const off = offsets[i] * 9;
+            for (let j = 0; j < 9; j++) colors[off + j] = saved[i * 9 + j];
+        }
+        state._pendingBackup = null;
+    }
+
+    if (state.pendingToggles.size > 0) {
+        const { mesh, r_plate, plateIsOcean } = state.curData;
+        let count = 0;
+        for (let s = 0; s < mesh.numSides; s++) {
+            if (state.pendingToggles.has(r_plate[mesh.s_begin_r(s)])) count++;
+        }
+        const offsets = new Int32Array(count);
+        const saved = new Float32Array(count * 9);
+        let idx = 0;
+        for (let s = 0; s < mesh.numSides; s++) {
+            const pid = r_plate[mesh.s_begin_r(s)];
+            if (state.pendingToggles.has(pid)) {
+                offsets[idx] = s;
+                const off = s * 9;
+                for (let j = 0; j < 9; j++) saved[idx * 9 + j] = colors[off + j];
+                const isOcean = plateIsOcean.has(pid);
+                for (let j = 0; j < 3; j++) {
+                    if (isOcean) {
+                        // Ocean → Land pending: strong green tint
+                        colors[off + j*3]     = colors[off + j*3]     * 0.7;
+                        colors[off + j*3 + 1] = Math.min(1, colors[off + j*3 + 1] + 0.25);
+                        colors[off + j*3 + 2] = colors[off + j*3 + 2] * 0.7;
+                    } else {
+                        // Land → Ocean pending: strong blue tint
+                        colors[off + j*3]     = colors[off + j*3]     * 0.7;
+                        colors[off + j*3 + 1] = colors[off + j*3 + 1] * 0.7;
+                        colors[off + j*3 + 2] = Math.min(1, colors[off + j*3 + 2] + 0.25);
+                    }
+                }
+                idx++;
+            }
+        }
+        state._pendingBackup = { offsets, saved };
+    }
+    colorAttr.needsUpdate = true;
+}
+
+// Pending-toggle highlight for map mesh (surgical save/restore).
+export function updateMapPendingHighlight() {
+    if (!state.mapMesh || !state.curData || !state.mapFaceToSide) return;
+    const colorAttr = state.mapMesh.geometry.getAttribute('color');
+    const colors = colorAttr.array;
+
+    if (state._mapPendingBackup) {
+        const { offsets, saved } = state._mapPendingBackup;
+        for (let i = 0; i < offsets.length; i++) {
+            const off = offsets[i] * 9;
+            for (let j = 0; j < 9; j++) colors[off + j] = saved[i * 9 + j];
+        }
+        state._mapPendingBackup = null;
+    }
+
+    if (state.pendingToggles.size > 0) {
+        const { mesh, r_plate, plateIsOcean } = state.curData;
+        const fts = state.mapFaceToSide;
+        let count = 0;
+        for (let f = 0; f < fts.length; f++) {
+            if (state.pendingToggles.has(r_plate[mesh.s_begin_r(fts[f])])) count++;
+        }
+        const offsets = new Int32Array(count);
+        const saved = new Float32Array(count * 9);
+        let idx = 0;
+        for (let f = 0; f < fts.length; f++) {
+            const pid = r_plate[mesh.s_begin_r(fts[f])];
+            if (state.pendingToggles.has(pid)) {
+                offsets[idx] = f;
+                const off = f * 9;
+                for (let j = 0; j < 9; j++) saved[idx * 9 + j] = colors[off + j];
+                const isOcean = plateIsOcean.has(pid);
+                for (let j = 0; j < 3; j++) {
+                    if (isOcean) {
+                        colors[off + j*3]     = colors[off + j*3]     * 0.7;
+                        colors[off + j*3 + 1] = Math.min(1, colors[off + j*3 + 1] + 0.25);
+                        colors[off + j*3 + 2] = colors[off + j*3 + 2] * 0.7;
+                    } else {
+                        colors[off + j*3]     = colors[off + j*3]     * 0.7;
+                        colors[off + j*3 + 1] = colors[off + j*3 + 1] * 0.7;
+                        colors[off + j*3 + 2] = Math.min(1, colors[off + j*3 + 2] + 0.25);
+                    }
+                }
+                idx++;
+            }
+        }
+        state._mapPendingBackup = { offsets, saved };
     }
     colorAttr.needsUpdate = true;
 }

--- a/js/state.js
+++ b/js/state.js
@@ -28,4 +28,7 @@ export const state = {
     editMode: false,
     oceanCurrentArrowGroup: null,
     climateComputed: false,
+    pendingToggles: new Set(),
+    _pendingBackup: null,
+    _mapPendingBackup: null,
 };

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ World Orogen generates realistic procedural planets shaped by tectonic plate sim
 - Applies glacial, hydraulic, and thermal erosion to carve fjords, river valleys, and talus slopes
 - Simulates seasonal climate: wind patterns, ocean currents, precipitation, and Köppen classification
 - Creates hotspot volcanism with drift-trail island chains (like Hawaii)
-- Allows interactive editing — click any tectonic plate to reshape continents in real time
+- Allows interactive editing — select multiple tectonic plates for batch reshaping with visual preview before rebuild
 
 ## Who it's for
 

--- a/styles.css
+++ b/styles.css
@@ -625,6 +625,25 @@ button#generate.generating {
 /* Refresh FAB — hidden on desktop */
 .refresh-fab { display: none; }
 
+/* Rebuild FAB — appears when pending plate edits exist */
+.rebuild-fab {
+    position: fixed; bottom: 60px; left: 50%; transform: translateX(-50%);
+    background: linear-gradient(135deg, #1a7a4a, #22aa5a);
+    color: #fff; border: none; border-radius: 24px;
+    padding: 10px 22px;
+    font-size: 15px; font-weight: 500; font-family: inherit;
+    cursor: pointer; z-index: 25;
+    display: flex; align-items: center; gap: 8px;
+    box-shadow: 0 4px 16px rgba(34,170,90,0.35);
+    transition: filter 0.2s, box-shadow 0.2s;
+    animation: rebuildPulse 2s ease-in-out infinite;
+}
+.rebuild-fab:hover { filter: brightness(1.15); box-shadow: 0 4px 20px rgba(34,170,90,0.5); }
+@keyframes rebuildPulse {
+    0%, 100% { box-shadow: 0 4px 16px rgba(34,170,90,0.35); }
+    50% { box-shadow: 0 4px 24px rgba(34,170,90,0.55); }
+}
+
 /* ───── Mobile: tablets + phones ───── */
 @media (max-width: 768px) {
     #topInfo { display: none; }
@@ -751,6 +770,14 @@ button#generate.generating {
         border-color: rgba(34,170,90,0.5);
         color: #fff;
         box-shadow: 0 0 12px rgba(34,170,90,0.4);
+    }
+
+    /* Rebuild FAB — above bottom sheet */
+    .rebuild-fab {
+        bottom: 130px;
+        min-height: 48px;
+        padding: 12px 24px;
+        font-size: 16px;
     }
 
     /* Touch targets */


### PR DESCRIPTION
## Summary
- **Decouple plate editing from regeneration**: Ctrl-click (or edit-mode tap on mobile) now marks plates as pending instead of immediately rebuilding. Selected plates show a colored tint (green = ocean→land, blue = land→ocean).
- **Batch rebuild**: A floating "Rebuild (N)" button appears when there are pending edits. Click it to apply all changes in a single recompute.
- **Edit-mode gated hover highlight**: Plate brightening on hover now only shows when Ctrl is held (desktop) or edit mode is active (mobile). The info card still appears on normal hover.

## Test plan
- [ ] Generate a planet, Ctrl+click 3 plates — each should tint without rebuilding
- [ ] Ctrl+click one again — tint disappears (undo), button count updates
- [ ] Click Rebuild — single recompute, planet updates, button disappears
- [ ] Verify planet code encodes the edits after rebuild
- [ ] Press Escape while plates are pending — all cleared
- [ ] Test on mobile: edit mode → tap plates → Rebuild button → works
- [ ] Test map view: pending tints show on map mesh too
- [ ] Hover without Ctrl — info card shows but plate does not brighten
- [ ] Hover with Ctrl — plate brightens as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)