### PR TITLE
Heightmap import, new generation controls, and terrain improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All three are considered together; ties are broken in the order above.
 - **Map type switcher** — first-class Terrain / Satellite / Climate / Heightmap tabs with color legends for each view
 - **On-demand climate** — optional deferred climate computation; skip climate during generation for faster terrain iteration, compute it on demand when needed
 - **Detailed visualization** — twenty-six selectable inspection layers organized by category (Geology, Atmosphere, Ocean, Climate, Elevation) for viewing each component in isolation. Wind/pressure layers show directional wind arrows, ocean current layers show current arrows colored by heat transport, on both globe and map views. Precipitation layers use a brown→green→blue ramp showing dry to wet regions.
+- **Heightmap import** — bring your own equirectangular B&W heightmap (Earth, Mars, hand-drawn maps) onto a 3D globe. Black pixels become ocean, brighter pixels become higher land. The import page (`/import`) runs full climate simulation (wind, precipitation, temperature, K&ouml;ppen) on your imported terrain, with optional terrain sculpting (smoothing, erosion, ridge sharpening). Supported formats: PNG, JPEG, WebP.
 - **Map export** — download high-resolution equirectangular PNGs (color terrain, satellite biome, climate/Köppen, B&W heightmap, land-only heightmap, or B&W land mask) at configurable widths up to 65536px with tiled rendering. **Export All** downloads Satellite, Climate, Heightmap, and Land Mask in one click, auto-computing climate if needed.
 
 ## Quick Start
@@ -54,9 +55,15 @@ Click **Build New World** to create a new random planet. The button changes colo
 - **Rebuild** (amber) — re-renders the current planet at a new detail/roughness level without changing continent shapes
 - **Regenerate** (red) — creates new tectonic plates when the Plates or Continents slider has changed
 
+### Navigation
+
+A top navigation bar connects the two pages:
+- **Generate** (`/`) — procedural planet generation with tectonic plates, erosion, and climate
+- **Import** (`/import`) — import your own equirectangular B&W heightmap, view it on a 3D globe, and run climate simulation. Black (0) = ocean, brighter = higher elevation. Supports PNG, JPEG, and WebP.
+
 ### Sharing Planets
 
-Every generated planet produces a **planet code** (shown below the Build button) that encodes the random seed, all slider values, and any plate edits. An unedited planet is 18 characters; plate edits (applied via Rebuild) extend the code to include the toggled plates. To share a planet:
+Every generated planet produces a **planet code** (shown below the Build button) that encodes the random seed, all slider values, and any plate edits. An unedited planet is 21 characters; plate edits (applied via Rebuild) extend the code to include the toggled plates. Older codes (13–18 characters) from previous versions are still supported — missing sliders default to their current default values. To share a planet:
 
 - **Copy** the code with the copy button and send it to someone
 - **Load** a code by pasting it into the planet code field and clicking Load (or pressing Enter). The Load button turns blue when a new code is ready to apply.
@@ -75,6 +82,8 @@ Core world parameters that control the planet's structure (changing these requir
 | Plates | 4 – 120 | 80 | Number of tectonic plates |
 | Continents | 1 – 10 | 4 | Target number of separate landmasses |
 | Roughness | 0 – 0.5 | 0.40 | Fractal noise magnitude for terrain roughness |
+| Continent Size Variety | 0 – 1 | 0 | How much continent sizes vary — 0 keeps continents similar in size, 1 allows a mix of large and small landmasses |
+| Land Coverage | 0 – 1 | 0.3 | Percentage of the planet covered by land. Low values create ocean worlds, high values create desert worlds. Above 40% coverage, precipitation is progressively dampened to simulate reduced oceanic moisture |
 
 ### Terrain Sculpting
 
@@ -88,6 +97,15 @@ Post-processing passes that refine the terrain (collapsed by default — the def
 | Hydraulic Erosion | 0 – 1 | 0.50 | Iterative stream-power erosion — resolves endorheic basins via priority-flood canyon carving, then carves river valleys and dendritic drainage networks, with automatic sediment deposition in flat receivers |
 | Thermal Erosion | 0 – 1 | 0.10 | Slope-driven material transport — softens ridges and creates natural talus slopes |
 | Ridge Sharpening | 0 – 1 | 0.50 | Accentuates mountain ridgelines — pushes peaks further above their surroundings for more dramatic terrain |
+
+### Climate
+
+Global climate offsets that adjust temperature and precipitation without a full rebuild. Changing these triggers a fast climate-only recompute.
+
+| Control | Range | Default | Description |
+|---------|-------|---------|-------------|
+| Temperature | -15 – 15 | 0 | Global temperature offset in °C — positive makes the planet warmer, negative colder. Climate zones shift accordingly |
+| Precipitation | -1 – 1 | 0 | Global precipitation scale — positive makes the planet wetter, negative drier. Affects desert and rainforest distribution |
 
 ### Auto Climate
 
@@ -200,8 +218,9 @@ World Orogen is fully usable on phones and tablets:
 ## Project Structure
 
 ```
-index.html              HTML markup + import map + structured data (JSON-LD)
-styles.css              All CSS
+index.html              Main page — HTML markup + import map + structured data
+import.html             Import page — heightmap upload + climate visualization
+styles.css              All CSS (shared by both pages)
 robots.txt              Search engine crawler directives
 sitemap.xml             Sitemap for search engine indexing
 site.webmanifest        Web app manifest (metadata + theming)
@@ -211,7 +230,8 @@ CNAME                   Custom domain config (orogen.studio)
 404.html                Custom 404 page
 preview.png             Social preview image (og:image / Twitter card)
 js/
-  main.js               Entry point — UI wiring, animation loop
+  main.js               Generator entry point — UI wiring, animation loop
+  import-main.js        Import page entry point — file upload, import dispatch
   state.js              Shared mutable application state
   generate.js           Worker dispatcher — posts jobs, handles results
   planet-worker.js      Web Worker — runs geology pipeline off main thread

--- a/import.html
+++ b/import.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>World Orogen — Import Heightmap</title>
+    <meta name="description" content="Import your own equirectangular heightmap onto a 3D globe with automatic climate simulation — wind, precipitation, temperature, and K&ouml;ppen classification. Free, in your browser.">
+    <meta name="keywords" content="heightmap import, equirectangular projection, climate simulation, world generator, terrain viewer, planet builder, Three.js, worldbuilding tool">
+    <meta name="author" content="World Orogen">
+    <meta name="theme-color" content="#0a0e17">
+    <link rel="canonical" href="https://orogen.studio/import">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://orogen.studio/import">
+    <meta property="og:title" content="World Orogen — Import Heightmap">
+    <meta property="og:description" content="Import your own equirectangular heightmap onto a 3D globe with automatic climate simulation. Free, in your browser.">
+    <meta property="og:image" content="https://orogen.studio/preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:site_name" content="World Orogen">
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="World Orogen — Import Heightmap">
+    <meta name="twitter:description" content="Import your own equirectangular heightmap onto a 3D globe with automatic climate simulation. Free, in your browser.">
+    <meta name="twitter:image" content="https://orogen.studio/preview.png">
+
+    <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+    <link rel="manifest" href="site.webmanifest">
+    <link rel="author" href="humans.txt">
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text x='50' y='50' dominant-baseline='central' text-anchor='middle' font-size='75'>🌍</text></svg>">
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <nav id="topNav">
+        <a href="/" class="nav-tab">Generate</a>
+        <a href="/import" class="nav-tab active">Import Heightmap</a>
+    </nav>
+    <div id="buildOverlay" class="build-overlay hidden">
+        <div class="build-overlay-inner">
+            <div class="build-overlay-spinner"></div>
+            <div class="build-overlay-title">Importing heightmap</div>
+            <div class="progress-bar-container">
+                <div class="progress-bar-fill" id="buildBarFill"></div>
+            </div>
+            <div class="progress-label" id="buildBarLabel"></div>
+        </div>
+    </div>
+    <canvas id="canvas"></canvas>
+    <div id="ui">
+        <div id="sheetHandle" class="sheet-handle"><span></span></div>
+        <div id="sidebarHeader">
+            <div>
+                <h2>World Orogen</h2>
+                <div class="sub">Import your own heightmap</div>
+            </div>
+            <button id="sidebarToggle" title="Collapse panel">&#x00AB;</button>
+        </div>
+        <div id="sidebarContent">
+        <details class="section" open>
+            <summary>Import Your Heightmap</summary>
+            <div class="section-body">
+                <div class="import-upload-area">
+                    <label class="import-file-label" for="heightmapFile">
+                        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+                        Choose Image
+                    </label>
+                    <input type="file" id="heightmapFile" accept="image/png,image/jpeg,image/webp" style="display:none">
+                    <div id="importFileName" class="import-file-name"></div>
+                </div>
+                <canvas id="importPreview" class="import-preview" style="display:none"></canvas>
+                <div id="importDims" class="import-dims" style="display:none"></div>
+                <div class="import-hint">Black (0) = ocean. Brighter = higher elevation. Use a 2:1 equirectangular image.</div>
+                <div id="importExpect" class="import-expect" style="display:none">Your heightmap will be projected onto a 3D sphere with full climate simulation — wind patterns, precipitation, temperature, and biome classification — computed automatically.</div>
+                <div class="cg">
+                    <label>Detail <span class="tip" data-tip="Resolution of the sphere mesh — more detail means finer coastlines but takes longer to process">?</span> <span class="v" id="vN">204,000</span></label>
+                    <input type="range" id="sN" min="0" max="1000" step="1" value="600">
+                    <div class="slider-hint"><span>Coarse</span><span>Fine</span></div>
+                    <div class="detail-warn" id="detailWarn"></div>
+                </div>
+                <button id="importBtn" class="import-btn" disabled>Import</button>
+            </div>
+        </details>
+        <details class="section">
+            <summary>Terrain Sculpting <span class="tip" data-tip="Post-processing passes to refine the imported terrain. All default to 0 (no effect). Adjust sliders and click Reapply.">?</span></summary>
+            <div class="section-body">
+                <div class="cg">
+                    <label>Terrain Warp <span class="tip" data-tip="Deforms the elevation field using noise for more organic coastlines and mountain ridges">?</span> <span class="v" id="vTw">0.00</span></label>
+                    <input type="range" id="sTw" min="0" max="1" value="0" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Heavy</span></div>
+                </div>
+                <div class="cg">
+                    <label>Smoothing <span class="tip" data-tip="Blends harsh terrain edges and pixelation from the source image">?</span> <span class="v" id="vS">0.00</span></label>
+                    <input type="range" id="sS" min="0" max="1" value="0" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Heavy</span></div>
+                </div>
+                <div class="cg">
+                    <label>Glacial Erosion <span class="tip" data-tip="Ice-age sculpting — carves fjords, U-shaped valleys, and lake basins at high latitudes and altitudes">?</span> <span class="v" id="vGl">0.00</span></label>
+                    <input type="range" id="sGl" min="0" max="1" value="0" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Ice Age</span></div>
+                </div>
+                <div class="cg">
+                    <label>Hydraulic Erosion <span class="tip" data-tip="Iterative stream-power erosion — carves river valleys and dendritic drainage networks">?</span> <span class="v" id="vHEr">0.00</span></label>
+                    <input type="range" id="sHEr" min="0" max="1" value="0" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Deep</span></div>
+                </div>
+                <div class="cg">
+                    <label>Thermal Erosion <span class="tip" data-tip="Slope-driven material transport — softens ridges and creates natural talus slopes">?</span> <span class="v" id="vTEr">0.00</span></label>
+                    <input type="range" id="sTEr" min="0" max="1" value="0" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Heavy</span></div>
+                </div>
+                <div class="cg">
+                    <label>Ridge Sharpening <span class="tip" data-tip="Accentuates mountain ridgelines — pushes peaks further above their surroundings">?</span> <span class="v" id="vRs">0.00</span></label>
+                    <input type="range" id="sRs" min="0" max="1" value="0" step="0.05">
+                    <div class="slider-hint"><span>None</span><span>Jagged</span></div>
+                </div>
+                <button id="reapplyBtn" title="Reapply terrain sculpting" disabled><span class="reapply-icon">&#x21bb;</span> Reapply</button>
+            </div>
+        </details>
+        <details class="section" open>
+            <summary>Visual Options</summary>
+            <div class="section-body">
+                <div class="cg">
+                    <label>View</label>
+                    <select id="viewMode">
+                        <option value="globe">Globe</option>
+                        <option value="map">Map</option>
+                    </select>
+                </div>
+                <div class="cg" id="mapCenterLonGroup" style="display:none">
+                    <label>Center Longitude <span class="v" id="vMapCenterLon">0&deg;</span></label>
+                    <input type="range" id="sMapCenterLon" min="-180" max="180" value="0" step="5">
+                </div>
+                <div class="map-tabs" id="mapTabs">
+                    <button class="map-tab active" data-layer="">Terrain</button>
+                    <button class="map-tab" data-layer="biome">Satellite</button>
+                    <button class="map-tab" data-layer="koppen">Climate</button>
+                    <button class="map-tab" data-layer="landheightmap">Heightmap</button>
+                </div>
+                <div class="cg">
+                    <label>Inspect</label>
+                    <select id="debugLayer">
+                        <option value="">Terrain</option>
+                        <option value="biome">Satellite</option>
+                        <option value="koppen">K&ouml;ppen Climate</option>
+                        <option value="landheightmap">Land Heightmap</option>
+                        <optgroup label="Atmosphere">
+                            <option value="pressureSummer">Pressure (Summer)</option>
+                            <option value="pressureWinter">Pressure (Winter)</option>
+                            <option value="windSpeedSummer">Wind Speed (Summer)</option>
+                            <option value="windSpeedWinter">Wind Speed (Winter)</option>
+                        </optgroup>
+                        <optgroup label="Ocean">
+                            <option value="oceanCurrentSummer">Currents (Summer)</option>
+                            <option value="oceanCurrentWinter">Currents (Winter)</option>
+                        </optgroup>
+                        <optgroup label="Climate">
+                            <option value="precipSummer">Precipitation (Summer)</option>
+                            <option value="precipWinter">Precipitation (Winter)</option>
+                            <option value="rainShadowSummer">Rain Shadow (Summer)</option>
+                            <option value="rainShadowWinter">Rain Shadow (Winter)</option>
+                            <option value="tempSummer">Temperature (Summer)</option>
+                            <option value="tempWinter">Temperature (Winter)</option>
+                            <option value="continentality">Continentality</option>
+                        </optgroup>
+                        <optgroup label="Elevation">
+                            <option value="heightmap">Full Heightmap</option>
+                            <option value="erosionDelta">Erosion Delta</option>
+                        </optgroup>
+                    </select>
+                </div>
+                <div id="vizLegend" class="viz-legend"></div>
+                <div class="tg">
+                    <label class="toggle-label"><input type="checkbox" id="chkWire"><span class="toggle-track"><span class="toggle-thumb"></span></span>Wireframe</label>
+                    <label class="toggle-label"><input type="checkbox" id="chkRotate"><span class="toggle-track"><span class="toggle-thumb"></span></span>Auto-Rotate</label>
+                    <label class="toggle-label"><input type="checkbox" id="chkGrid" checked><span class="toggle-track"><span class="toggle-thumb"></span></span>Grid Lines</label>
+                </div>
+                <div class="cg" id="gridSpacingGroup">
+                    <label>Grid Spacing</label>
+                    <select id="gridSpacing">
+                        <option value="30">30&deg;</option>
+                        <option value="15" selected>15&deg;</option>
+                        <option value="10">10&deg;</option>
+                        <option value="5">5&deg;</option>
+                        <option value="2.5">2.5&deg;</option>
+                    </select>
+                </div>
+                <details id="statsDetails" class="stats-toggle">
+                    <summary>Stats</summary>
+                    <div id="stats"></div>
+                </details>
+            </div>
+        </details>
+        <button id="exportBtn" class="export-btn">Export Map</button>
+        <a id="repoLink" href="https://github.com/raguilar011095/planet_heightmap_generation" target="_blank" rel="noopener">
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.64 7.64 0 0 1 4 0c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+            GitHub
+        </a>
+        </div>
+    </div>
+    <select id="mobileViewSwitch" class="mobile-view-switch">
+        <option value="">Terrain</option>
+        <option value="biome">Satellite</option>
+        <option value="koppen">Climate</option>
+        <option value="landheightmap">Heightmap</option>
+    </select>
+
+    <div id="exportOverlay" class="hidden">
+        <div id="exportCard">
+            <button id="exportClose">&times;</button>
+            <h3>Export Map</h3>
+            <div class="cg">
+                <label>Type</label>
+                <select id="exportType">
+                    <option value="color">Color Map</option>
+                    <option value="biome">Satellite</option>
+                    <option value="koppen">Climate (K&ouml;ppen)</option>
+                    <option value="heightmap">Heightmap (B&amp;W)</option>
+                    <option value="landheightmap">Land Heightmap (B&amp;W)</option>
+                    <option value="landmask">Land Mask (B&amp;W)</option>
+                </select>
+            </div>
+            <div class="cg">
+                <label>Width <span class="v" id="exportDims">4096 &times; 2048</span></label>
+                <select id="exportWidth">
+                    <option value="1024">1024</option>
+                    <option value="2048">2048</option>
+                    <option value="4096" selected>4096</option>
+                    <option value="8192">8192</option>
+                    <option value="16384">16384</option>
+                    <option value="32768">32768</option>
+                    <option value="65536">65536</option>
+                </select>
+            </div>
+            <div class="export-actions">
+                <button id="exportCancel" class="btn-ghost">Cancel</button>
+                <button id="exportGo" class="btn-primary">Export</button>
+                <button id="exportAllGo" class="btn-primary">Export All</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Hidden checkbox for planet-mesh.js compatibility (no plate view on import page) -->
+    <input type="checkbox" id="chkPlates" style="display:none">
+    <div id="topInfo">Import an equirectangular heightmap to visualize it on a globe</div>
+    <div id="hoverInfo"></div>
+    <div id="info">Import an equirectangular B&amp;W heightmap to get started</div>
+
+    <script type="importmap">
+    {
+        "imports": {
+            "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+            "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/",
+            "delaunator": "https://cdn.jsdelivr.net/npm/delaunator@5.0.1/+esm"
+        }
+    }
+    </script>
+
+    <script type="module" src="js/import-main.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
             "Climate simulation with wind, precipitation, and ocean currents",
             "Hotspot volcanism with island chains",
             "Interactive plate editing",
+            "Equirectangular heightmap import with automatic climate simulation",
             "Equirectangular map export up to 65536px",
             "Multiple visualization modes (terrain, satellite, climate, heightmap)",
             "Shareable planet codes"
@@ -110,6 +111,10 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <nav id="topNav">
+        <a href="/" class="nav-tab active">Generate</a>
+        <a href="/import" class="nav-tab">Import Heightmap</a>
+    </nav>
     <!-- Semantic content for search engines and AI crawlers (visually hidden) -->
     <main aria-hidden="true" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap">
         <h1>World Orogen — Procedural Planet Generator</h1>
@@ -123,6 +128,7 @@
             <li>Climate simulation with seasonal wind patterns, ocean currents, precipitation, and K&ouml;ppen climate classification</li>
             <li>Hotspot volcanism with drift-trail island chains (like Hawaii)</li>
             <li>Interactive plate editing — select multiple plates for batch land/ocean toggling with visual preview before rebuild</li>
+            <li>Heightmap import — bring your own equirectangular B&amp;W heightmap (Earth, Mars, hand-drawn) and run full climate simulation on it</li>
             <li>Multiple visualization modes: terrain, satellite biome, climate, and heightmap</li>
             <li>26 detailed inspection layers for geology, atmosphere, ocean, and climate</li>
             <li>High-resolution equirectangular map export up to 65,536px wide</li>
@@ -183,6 +189,16 @@
                     <input type="range" id="sNs" min="0" max="0.5" value="0.40" step="0.01">
                     <div class="slider-hint"><span>Smooth</span><span>Rugged</span></div>
                 </div>
+                <div class="cg">
+                    <label>Continent Size Variety <span class="tip" data-tip="How much continent sizes vary — at 0 all continents are similar in size, at 1 you get a mix of large and small landmasses">?</span> <span class="v" id="vCsv">0</span></label>
+                    <input type="range" id="sCsv" min="0" max="1" value="0" step="0.05">
+                    <div class="slider-hint"><span>Equal</span><span>Varied</span></div>
+                </div>
+                <div class="cg">
+                    <label>Land Coverage <span class="tip" data-tip="Percentage of the planet covered by land — low values create ocean worlds, high values create desert worlds with reduced precipitation">?</span> <span class="v" id="vLc">30%</span></label>
+                    <input type="range" id="sLc" min="0" max="1" value="0.3" step="0.01">
+                    <div class="slider-hint"><span>Ocean World</span><span>Desert World</span></div>
+                </div>
             </div>
         </details>
         <button id="generate">Build New World</button>
@@ -228,6 +244,22 @@
                 <button id="reapplyBtn" title="Reapply terrain sculpting" disabled><span class="reapply-icon">&#x21bb;</span> Reapply</button>
             </div>
         </details>
+        <details class="section">
+            <summary>Climate <span class="climate-live-badge">instant</span> <span class="tip" data-tip="Global temperature and precipitation offsets — changes apply instantly on slider release, no rebuild needed">?</span></summary>
+            <div class="section-body">
+                <div class="climate-hint">Changes apply on release — no rebuild needed.</div>
+                <div class="cg">
+                    <label>Temperature <span class="tip" data-tip="Shift global temperature — positive makes the planet warmer, negative makes it colder. Climate zones shift accordingly.">?</span> <span class="v" id="vTmp">±0°C</span></label>
+                    <input type="range" id="sTmp" min="-15" max="15" value="0" step="1">
+                    <div class="slider-hint"><span>Colder</span><span>Warmer</span></div>
+                </div>
+                <div class="cg">
+                    <label>Precipitation <span class="tip" data-tip="Scale global precipitation — positive makes the planet wetter, negative drier. Affects desert and rainforest distribution.">?</span> <span class="v" id="vPrc">±0%</span></label>
+                    <input type="range" id="sPrc" min="-1" max="1" value="0" step="0.1">
+                    <div class="slider-hint"><span>Drier</span><span>Wetter</span></div>
+                </div>
+            </div>
+        </details>
         <details class="section" open>
             <summary>Visual Options</summary>
             <div class="section-body">
@@ -267,6 +299,7 @@
                             <option value="margins">Margins</option>
                             <option value="backArc">Back-Arc</option>
                             <option value="foldRidge">Fold Ridge</option>
+                            <option value="orogenicPower">Orogenic Power</option>
                             <option value="erosionDelta">Erosion Delta</option>
                         </optgroup>
                         <optgroup label="Atmosphere">

--- a/js/coarse-plates.js
+++ b/js/coarse-plates.js
@@ -16,7 +16,7 @@ const COARSE_JITTER = 0.75; // fixed — coarse mesh shape is independent of use
  * Uses isolated RNG so it doesn't affect the main mesh's random stream.
  * Jitter is fixed so plate shapes don't change when the user adjusts irregularity.
  */
-export function generateCoarsePlates(seed, numPlates, numContinents) {
+export function generateCoarsePlates(seed, numPlates, numContinents, continentSizeVariety = 0, landCoverage = 0.3) {
     const coarseRng = makeRng(seed + 137);
     const { mesh: coarseMesh, r_xyz: coarse_xyz } = buildSphere(N_COARSE, COARSE_JITTER, coarseRng);
 
@@ -24,7 +24,7 @@ export function generateCoarsePlates(seed, numPlates, numContinents) {
         generatePlates(coarseMesh, coarse_xyz, numPlates, seed);
 
     const coarsePlateIsOcean = assignOceanLand(
-        coarseMesh, coarse_r_plate, coarsePlateSeeds, coarse_xyz, seed, numContinents
+        coarseMesh, coarse_r_plate, coarsePlateSeeds, coarse_xyz, seed, numContinents, continentSizeVariety, landCoverage
     );
 
     return {
@@ -48,7 +48,7 @@ export function generateCoarsePlates(seed, numPlates, numContinents) {
  * Uses adjacency-walk on the coarse mesh with warm-starting for O(1)
  * amortized cost per region.
  */
-export function projectCoarsePlates(mesh, r_xyz, coarseMesh, coarse_xyz, coarse_r_plate, seed) {
+export function projectCoarsePlates(mesh, r_xyz, coarseMesh, coarse_xyz, coarse_r_plate, seed, numPlates) {
     const N = mesh.numRegions;
     const r_plate = new Int32Array(N);
     const { adjOffset: cOff, adjList: cAdj } = coarseMesh;
@@ -56,7 +56,8 @@ export function projectCoarsePlates(mesh, r_xyz, coarseMesh, coarse_xyz, coarse_
     // FBM noise for fractal boundary perturbation
     const noise = new SimplexNoise(seed + 999);
     const coarseEdgeRad = Math.PI / Math.sqrt(coarseMesh.numRegions);
-    const perturbAmp = coarseEdgeRad * 1.5; // wobble by ~1.5 coarse cells
+    const lowPlateT = numPlates != null ? Math.max(0, Math.min(1, (80 - numPlates) / 60)) : 0;
+    const perturbAmp = coarseEdgeRad * (1.5 + 1.0 * lowPlateT); // 1.5 → 2.5 coarse cells
     const BASE_FREQ = 8; // ~8 features per sphere diameter → ~16 around equator
 
     const NC = coarseMesh.numRegions;

--- a/js/color-map.js
+++ b/js/color-map.js
@@ -1,13 +1,14 @@
 // Elevation → RGB colour mapping.
 
 // Convert raw mesh elevation (nonlinear, 0-~1 for land) to physical height
-// in kilometres.  Smooth power curve: ramps slowly through lowlands,
-// accelerates into highlands, caps at 6 km.
+// in kilometres.  Hybrid S-curve: quartic start gives extensive flatlands,
+// steepest rise around t≈0.75, derivative→0 at top so peaks compress.
 // Ocean (elev < 0) is mapped with a linear scale (~5 km at -0.5).
 export function elevToHeightKm(elev) {
     if (elev <= 0) return elev * 10;  // ocean: -0.5 → -5 km
     const t = Math.min(elev, 1);
-    return 6 * t * t;  // 0→0, 0.25→0.375, 0.5→1.5, 0.75→3.375, 1.0→6
+    const t2 = t * t;
+    return 6 * t2 * t2 * (5 - 4 * t);  // 0→0, 0.25→0.09, 0.5→1.13, 0.75→3.80, 1.0→6
 }
 
 // Biome base colors indexed by Köppen class ID (satellite-view palette).

--- a/js/elevation.js
+++ b/js/elevation.js
@@ -231,6 +231,7 @@ export function assignElevation(mesh, r_xyz, plateIsOcean, r_plate, plateVec, pl
     const dl_margins = new Float32Array(numRegions);
     const dl_backArc = new Float32Array(numRegions);
     const dl_foldRidge = new Float32Array(numRegions);
+    const dl_orogenicPower = new Float32Array(numRegions);
 
     const { mountain_r, coastline_r, ocean_r, r_stress, r_subductFactor, r_boundaryType, r_bothOcean, r_hasOcean } =
         findCollisions(mesh, r_xyz, plateIsOcean, r_plate, plateVec, plateDensity, noise);
@@ -547,6 +548,14 @@ export function assignElevation(mesh, r_xyz, plateIsOcean, r_plate, plateVec, pl
         const wy = y + warpScale * noise.fbm(x + 8.1, y + 2.9, z + 7.3, warpOctaves);
         const wz = z + warpScale * noise.fbm(x + 1.4, y + 6.2, z + 4.8, warpOctaves);
 
+        // Orogenic power: single-octave noise for blocky, high-contrast
+        // zones.  Computed for ALL regions so the debug layer shows the
+        // full noise field (not skewed by ocean zeros).
+        const rawOro = noise.noise3D(x * 1.5 + 33.7, y * 1.5 + 11.2, z * 1.5 + 22.9);
+        const shaped = rawOro >= 0 ? Math.sqrt(rawOro) : -Math.sqrt(-rawOro);
+        const orogenicPower = Math.max(0, Math.min(1, 0.5 + 0.5 * shaped));
+        dl_orogenicPower[r] = orogenicPower - 0.5;  // center on 0 for diverging debug color scale
+
         if (!isOceanPlate) {
             const sf = r_subductFactor[r];
             const elevBefore = r_elevation[r];
@@ -557,10 +566,10 @@ export function assignElevation(mesh, r_xyz, plateIsOcean, r_plate, plateVec, pl
             }
 
             if (stressNorm > 0.01) {
-                const stressMag = stressNorm * stressNorm * 0.55;
+                const stressMag = stressNorm * stressNorm * 0.55 * orogenicPower;
                 const uplift  = stressMag * (1 - sf);
                 const depress = stressMag * 0.4 * sf;
-                const heightVar = 0.75 + 0.5 * noise.fbm(x * 8 + 13.7, y * 8 + 9.2, z * 8 + 4.5, 3);
+                const heightVar = 0.60 + 0.8 * noise.fbm(x * 8 + 13.7, y * 8 + 9.2, z * 8 + 4.5, 3);
                 r_elevation[r] += (uplift - depress) * heightVar;
             }
 
@@ -714,6 +723,27 @@ export function assignElevation(mesh, r_xyz, plateIsOcean, r_plate, plateVec, pl
                     const dissectContrib = dissectVal * dissectAmp;
                     r_elevation[r] += dissectContrib;
                     dl_noise[r] += dissectContrib;
+                }
+            }
+
+            // Summit peaks: sparse, sharp spikes along the tallest mountain
+            // ridges.  Uses very high-frequency ridged noise with a high
+            // threshold so only occasional points jut upward.  Base orogeny
+            // caps around 4-5 km; only these peaks can push toward 6 km.
+            {
+                const SUMMIT_THRESHOLD = 0.65;  // ~2.6 km
+                const currentElev = r_elevation[r];
+                if (currentElev > SUMMIT_THRESHOLD && stressNorm > 0.2) {
+                    const excess = currentElev - SUMMIT_THRESHOLD;
+                    // Ridged noise at high frequency — sharp, spiky features
+                    const peakNoise = noise.ridgedFbm(
+                        wx * 24 + 91.3, wy * 24 + 55.7, wz * 24 + 38.2, 3, 0.5
+                    );
+                    // Only the highest peaks of the noise create summits
+                    const spike = Math.max(0, peakNoise - 0.45);
+                    const peakContrib = spike * excess * stressNorm * 1.2;
+                    r_elevation[r] += peakContrib;
+                    dl_noise[r] += peakContrib;
                 }
             }
 
@@ -1232,12 +1262,12 @@ export function assignElevation(mesh, r_xyz, plateIsOcean, r_plate, plateVec, pl
     // Compress positive elevations to soften tall peaks
     for (let r = 0; r < numRegions; r++) {
         if (r_elevation[r] > 0) {
-            r_elevation[r] = Math.pow(r_elevation[r], 0.9);
+            r_elevation[r] = Math.pow(r_elevation[r], 0.92);
         }
     }
 
     _timing.push({ stage: 'Peak compression', ms: performance.now() - _t0 });
 
-    const debugLayers = { base: dl_base, tectonic: dl_tectonic, noise: dl_noise, interior: dl_interior, coastal: dl_coastal, ocean: dl_ocean, hotspot: dl_hotspot, tecActivity: dl_tecActivity, margins: dl_margins, backArc: dl_backArc, foldRidge: dl_foldRidge };
+    const debugLayers = { base: dl_base, tectonic: dl_tectonic, noise: dl_noise, interior: dl_interior, coastal: dl_coastal, ocean: dl_ocean, hotspot: dl_hotspot, tecActivity: dl_tecActivity, margins: dl_margins, backArc: dl_backArc, foldRidge: dl_foldRidge, orogenicPower: dl_orogenicPower };
     return { r_elevation, mountain_r, coastline_r, ocean_r, r_stress, debugLayers, _timing };
 }

--- a/js/generate.js
+++ b/js/generate.js
@@ -14,6 +14,41 @@ import { classifyKoppen } from './koppen.js';
 // Main thread still needs Delaunator for SphereMesh reconstruction
 setDelaunator(Delaunator);
 
+// Read all slider values from the DOM into a params object
+function readSliders() {
+    return {
+        N: detailFromSlider(+document.getElementById('sN').value),
+        P: +document.getElementById('sP').value,
+        jitter: +document.getElementById('sJ').value,
+        nMag: +document.getElementById('sNs').value,
+        numContinents: +document.getElementById('sCn').value,
+        terrainWarp: +document.getElementById('sTw').value,
+        smoothing: +document.getElementById('sS').value,
+        hydraulicErosion: +document.getElementById('sHEr').value,
+        thermalErosion: +document.getElementById('sTEr').value,
+        ridgeSharpening: +document.getElementById('sRs').value,
+        glacialErosion: +document.getElementById('sGl').value,
+        continentSizeVariety: +document.getElementById('sCsv').value,
+        temperatureOffset: +document.getElementById('sTmp').value,
+        precipitationOffset: +document.getElementById('sPrc').value,
+        landCoverage: +document.getElementById('sLc').value,
+    };
+}
+
+// Read sliders with optional chaining (for import page where some sliders may not exist)
+function readSlidersOptional() {
+    return {
+        N: detailFromSlider(+document.getElementById('sN').value),
+        jitter: +(document.getElementById('sJ')?.value ?? 0.75),
+        terrainWarp: +(document.getElementById('sTw')?.value ?? 0),
+        smoothing: +(document.getElementById('sS')?.value ?? 0),
+        hydraulicErosion: +(document.getElementById('sHEr')?.value ?? 0),
+        thermalErosion: +(document.getElementById('sTEr')?.value ?? 0),
+        ridgeSharpening: +(document.getElementById('sRs')?.value ?? 0),
+        glacialErosion: +(document.getElementById('sGl')?.value ?? 0),
+    };
+}
+
 // --- Worker setup ---
 let worker = null;
 let workerSupported = true;
@@ -678,17 +713,7 @@ function generateFallback(overrideSeed, toggledIndices, onProgress, skipClimate)
     // Dynamic import already resolved — run synchronously via rAF stages
     const m = _fallbackModules;
     const btn = document.getElementById('generate');
-    const N = detailFromSlider(+document.getElementById('sN').value);
-    const P = +document.getElementById('sP').value;
-    const jitter = +document.getElementById('sJ').value;
-    const nMag = +document.getElementById('sNs').value;
-    const numContinents = +document.getElementById('sCn').value;
-    const terrainWarp = +document.getElementById('sTw').value;
-    const smoothing = +document.getElementById('sS').value;
-    const hydraulicErosion = +document.getElementById('sHEr').value;
-    const thermalErosion = +document.getElementById('sTEr').value;
-    const ridgeSharpening = +document.getElementById('sRs').value;
-    const glacialErosion = +document.getElementById('sGl').value;
+    const { N, P, jitter, nMag, numContinents, terrainWarp, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, continentSizeVariety, temperatureOffset, precipitationOffset, landCoverage } = readSliders();
     const progress = onProgress || (() => {});
     const ctx = {};
 
@@ -702,14 +727,14 @@ function generateFallback(overrideSeed, toggledIndices, onProgress, skipClimate)
         }},
         { pct: 10, label: 'Generating coarse plates\u2026', work() {
             const { coarseMesh, coarse_xyz, coarse_r_plate, coarsePlateSeeds, coarsePlateVec, coarsePlateIsOcean } =
-                m.coarsePlates.generateCoarsePlates(ctx.seed, P, numContinents);
+                m.coarsePlates.generateCoarsePlates(ctx.seed, P, numContinents, continentSizeVariety, landCoverage);
             ctx.coarseMesh = coarseMesh; ctx.coarse_xyz = coarse_xyz;
             ctx.coarse_r_plate = coarse_r_plate;
             ctx.plateSeeds = coarsePlateSeeds; ctx.plateVec = coarsePlateVec;
             ctx.coarsePlateIsOcean = coarsePlateIsOcean;
         }},
         { pct: 18, label: 'Projecting plates\u2026', work() {
-            ctx.r_plate = m.coarsePlates.projectCoarsePlates(ctx.mesh, ctx.r_xyz, ctx.coarseMesh, ctx.coarse_xyz, ctx.coarse_r_plate, ctx.seed);
+            ctx.r_plate = m.coarsePlates.projectCoarsePlates(ctx.mesh, ctx.r_xyz, ctx.coarseMesh, ctx.coarse_xyz, ctx.coarse_r_plate, ctx.seed, P);
             m.plates.smoothAndReconnectPlates(ctx.mesh, ctx.r_plate, ctx.plateSeeds, 3);
         }},
         { pct: 25, label: 'Carving oceans\u2026', work() {
@@ -743,13 +768,13 @@ function generateFallback(overrideSeed, toggledIndices, onProgress, skipClimate)
             ctx.r_elevation = r_elevation; ctx.mountain_r = mountain_r; ctx.coastline_r = coastline_r;
             ctx.ocean_r = ocean_r; ctx.r_stress = r_stress; ctx.debugLayers = debugLayers;
             ctx.prePostElev = new Float32Array(r_elevation);
-            if (terrainWarp > 0) m.post.warpTerrain(ctx.mesh, r_elevation, ctx.r_xyz, ctx.seed, terrainWarp);
+            if (terrainWarp > 0) m.post.warpTerrain(ctx.mesh, r_elevation, ctx.r_xyz, ctx.seed, terrainWarp, debugLayers.hotspot);
             const r_isOcean = new Uint8Array(ctx.mesh.numRegions);
             for (let r = 0; r < ctx.mesh.numRegions; r++) { if (r_elevation[r] <= 0) r_isOcean[r] = 1; }
             const preErosion = new Float32Array(r_elevation);
             if (smoothing > 0) m.post.smoothElevation(ctx.mesh, r_elevation, r_isOcean, Math.round(1 + smoothing * 4), 0.2 + smoothing * 0.5);
             if (glacialErosion > 0 || hydraulicErosion > 0 || thermalErosion > 0)
-                m.post.erodeComposite(ctx.mesh, r_elevation, ctx.r_xyz, r_isOcean, Math.round(hydraulicErosion * 20), hydraulicErosion * 0.001, 0.5, 1.0, Math.round(thermalErosion * 10), 1.2 - thermalErosion * 0.4, thermalErosion * 0.15, Math.round(glacialErosion * 10), glacialErosion);
+                m.post.erodeComposite(ctx.mesh, r_elevation, ctx.r_xyz, r_isOcean, Math.round(hydraulicErosion * 20), hydraulicErosion * 0.0006, 0.5, 1.0, Math.round(thermalErosion * 10), 1.2 - thermalErosion * 0.4, thermalErosion * 0.15, Math.round(glacialErosion * 10), glacialErosion);
             if (ridgeSharpening > 0) m.post.sharpenRidges(ctx.mesh, r_elevation, r_isOcean, Math.round(1 + ridgeSharpening * 3), ridgeSharpening * 0.08);
             m.post.applySoilCreep(ctx.mesh, r_elevation, r_isOcean, 3, 0.1125);
             const dl_erosionDelta = new Float32Array(ctx.mesh.numRegions);
@@ -764,13 +789,13 @@ function generateFallback(overrideSeed, toggledIndices, onProgress, skipClimate)
                 ctx.windResult = windResult;
                 const oceanResult = m.oceanCurrents.computeOceanCurrents(ctx.mesh, ctx.r_xyz, r_elevation, windResult);
                 ctx.oceanResult = oceanResult;
-                const precipResult = m.precip.computePrecipitation(ctx.mesh, ctx.r_xyz, r_elevation, windResult, oceanResult);
+                const precipResult = m.precip.computePrecipitation(ctx.mesh, ctx.r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage);
                 ctx.precipResult = precipResult;
                 debugLayers.precipSummer = precipResult.r_precip_summer;
                 debugLayers.precipWinter = precipResult.r_precip_winter;
                 debugLayers.rainShadowSummer = precipResult.r_rainshadow_summer;
                 debugLayers.rainShadowWinter = precipResult.r_rainshadow_winter;
-                const tempResult = m.temp.computeTemperature(ctx.mesh, ctx.r_xyz, r_elevation, windResult, oceanResult, precipResult);
+                const tempResult = m.temp.computeTemperature(ctx.mesh, ctx.r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset);
                 ctx.tempResult = tempResult;
                 debugLayers.tempSummer = tempResult.r_temperature_summer;
                 debugLayers.tempWinter = tempResult.r_temperature_winter;
@@ -850,22 +875,11 @@ export function generate(overrideSeed, toggledIndices = [], onProgress, skipClim
         return;
     }
 
-    const N = detailFromSlider(+document.getElementById('sN').value);
-    const P = +document.getElementById('sP').value;
-    const jitter = +document.getElementById('sJ').value;
-    const nMag = +document.getElementById('sNs').value;
-    const numContinents = +document.getElementById('sCn').value;
-    const terrainWarp = +document.getElementById('sTw').value;
-    const smoothing = +document.getElementById('sS').value;
-    const hydraulicErosion = +document.getElementById('sHEr').value;
-    const thermalErosion = +document.getElementById('sTEr').value;
-    const ridgeSharpening = +document.getElementById('sRs').value;
-    const glacialErosion = +document.getElementById('sGl').value;
+    const s = readSliders();
 
     worker.postMessage({
         cmd: 'generate',
-        N, P, jitter, nMag, numContinents,
-        terrainWarp, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion,
+        ...s,
         seed: overrideSeed,
         toggledIndices,
         skipClimate
@@ -881,14 +895,14 @@ export function reapplyViaWorker(onDone, skipClimate = false) {
     _onDone = onDone || null;
     _t0 = performance.now();
 
+    const s = readSlidersOptional();
+    const temperatureOffset = +(document.getElementById('sTmp')?.value ?? 0);
+    const precipitationOffset = +(document.getElementById('sPrc')?.value ?? 0);
+    const landCoverage = +(document.getElementById('sLc')?.value ?? 0.3);
+
     worker.postMessage({
         cmd: 'reapply',
-        terrainWarp: +document.getElementById('sTw').value,
-        smoothing: +document.getElementById('sS').value,
-        glacialErosion: +document.getElementById('sGl').value,
-        hydraulicErosion: +document.getElementById('sHEr').value,
-        thermalErosion: +document.getElementById('sTEr').value,
-        ridgeSharpening: +document.getElementById('sRs').value,
+        ...s, temperatureOffset, precipitationOffset, landCoverage,
         skipClimate
     });
 }
@@ -901,17 +915,14 @@ export function editRecomputeViaWorker(onDone, skipClimate = false) {
     _onDone = onDone || null;
     _t0 = performance.now();
 
+    const { nMag, terrainWarp, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, temperatureOffset, precipitationOffset, landCoverage } = readSliders();
+
     worker.postMessage({
         cmd: 'editRecompute',
         plateIsOcean: Array.from(d.plateIsOcean),
         plateDensity: d.plateDensity,
-        nMag: +document.getElementById('sNs').value,
-        terrainWarp: +document.getElementById('sTw').value,
-        smoothing: +document.getElementById('sS').value,
-        glacialErosion: +document.getElementById('sGl').value,
-        hydraulicErosion: +document.getElementById('sHEr').value,
-        thermalErosion: +document.getElementById('sTEr').value,
-        ridgeSharpening: +document.getElementById('sRs').value,
+        nMag, terrainWarp, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening,
+        temperatureOffset, precipitationOffset, landCoverage,
         skipClimate
     });
 }
@@ -921,5 +932,29 @@ export function computeClimateViaWorker(onProgress, onDone) {
     _onProgress = onProgress || (() => {});
     _onDone = onDone || null;
     _t0 = performance.now();
-    worker.postMessage({ cmd: 'computeClimate' });
+    const temperatureOffset = +(document.getElementById('sTmp')?.value ?? 0);
+    const precipitationOffset = +(document.getElementById('sPrc')?.value ?? 0);
+    const landCoverage = +(document.getElementById('sLc')?.value ?? 0.3);
+
+    worker.postMessage({
+        cmd: 'computeClimate',
+        temperatureOffset, precipitationOffset, landCoverage
+    });
+}
+
+export function importHeightmap(grayscale, imageWidth, imageHeight, onProgress, skipClimate = false) {
+    if (!worker) return;
+
+    _onProgress = onProgress || (() => {});
+    _t0 = performance.now();
+
+    const { N, jitter, terrainWarp, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion } = readSlidersOptional();
+
+    worker.postMessage({
+        cmd: 'importHeightmap',
+        N, jitter,
+        grayscale, imageWidth, imageHeight,
+        terrainWarp, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion,
+        skipClimate
+    }, [grayscale.buffer]);
 }

--- a/js/import-main.js
+++ b/js/import-main.js
@@ -1,0 +1,953 @@
+// Import page entry point — handles heightmap file upload, import dispatch,
+// terrain sculpting reapply, and all visualization wiring.
+
+import * as THREE from 'three';
+import { renderer, scene, camera, ctrl, waterMesh, atmosMesh, starsMesh,
+         mapCamera, updateMapCameraFrustum, mapCtrl, canvas,
+         tickZoom, tickMapZoom } from './scene.js';
+import { state } from './state.js';
+import { importHeightmap, reapplyViaWorker, computeClimateViaWorker } from './generate.js';
+import { buildMesh, updateMeshColors, buildMapMesh, rebuildGrids, exportMap, exportMapBatch, buildWindArrows, buildOceanCurrentArrows, updateKoppenHoverHighlight, updateMapKoppenHoverHighlight } from './planet-mesh.js';
+import { detailFromSlider } from './detail-scale.js';
+import { KOPPEN_CLASSES } from './koppen.js';
+import { elevationToColor } from './color-map.js';
+
+// ─── File Upload ──────────────────────────────────────────────────
+
+const fileInput = document.getElementById('heightmapFile');
+const fileNameEl = document.getElementById('importFileName');
+const previewCanvas = document.getElementById('importPreview');
+const importDimsEl = document.getElementById('importDims');
+const importBtn = document.getElementById('importBtn');
+
+let storedGrayscale = null;
+let storedWidth = 0;
+let storedHeight = 0;
+
+fileInput.addEventListener('change', (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    fileNameEl.textContent = file.name;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+        const img = new Image();
+        img.onload = () => {
+            storedWidth = img.width;
+            storedHeight = img.height;
+            // Draw full-res to offscreen canvas for grayscale extraction
+            const offscreen = document.createElement('canvas');
+            offscreen.width = img.width;
+            offscreen.height = img.height;
+            const offCtx = offscreen.getContext('2d');
+            offCtx.drawImage(img, 0, 0);
+            // Draw scaled preview to visible canvas
+            const previewW = Math.min(img.width, 400);
+            const previewH = Math.round(previewW * img.height / img.width);
+            previewCanvas.width = previewW;
+            previewCanvas.height = previewH;
+            const ctx = previewCanvas.getContext('2d');
+            ctx.drawImage(img, 0, 0, previewW, previewH);
+            previewCanvas.style.display = 'block';
+            importDimsEl.textContent = `${img.width} × ${img.height}`;
+            importDimsEl.style.display = 'block';
+            const expectEl = document.getElementById('importExpect');
+            if (expectEl) expectEl.style.display = 'block';
+            // Extract grayscale from RGBA via luminance — no normalization.
+            // Convention: black (0) = ocean, brighter = higher elevation.
+            const data = offCtx.getImageData(0, 0, img.width, img.height).data;
+            const numPx = img.width * img.height;
+            storedGrayscale = new Uint8Array(numPx);
+            for (let i = 0; i < numPx; i++) {
+                const r = data[i * 4], g = data[i * 4 + 1], b = data[i * 4 + 2];
+                storedGrayscale[i] = Math.round(0.299 * r + 0.587 * g + 0.114 * b);
+            }
+            importBtn.disabled = false;
+        };
+        img.src = ev.target.result;
+    };
+    reader.readAsDataURL(file);
+});
+
+// ─── Detail slider ────────────────────────────────────────────────
+
+const AUTO_CLIMATE_THRESHOLD = 300000;
+const WARN_ORANGE = state.isTouchDevice ? 200000 : 640000;
+const WARN_RED    = state.isTouchDevice ? 500000 : 1280000;
+
+function shouldSkipClimate() {
+    return detailFromSlider(+document.getElementById('sN').value) > AUTO_CLIMATE_THRESHOLD;
+}
+
+function updateDetailWarning(detail) {
+    const cg = document.getElementById('sN').closest('.cg');
+    const warn = document.getElementById('detailWarn');
+    cg.classList.remove('detail-orange', 'detail-red');
+    warn.className = 'detail-warn';
+    if (detail > WARN_RED) {
+        cg.classList.add('detail-red');
+        warn.classList.add('red');
+        warn.textContent = '\u26A0 Very high \u2014 generation may be slow and unstable';
+    } else if (detail > WARN_ORANGE) {
+        cg.classList.add('detail-orange');
+        warn.classList.add('orange');
+        warn.textContent = '\u26A0 High detail \u2014 generation may be slow and unstable';
+    } else {
+        warn.textContent = '';
+    }
+}
+
+// Slider tooltip
+function initSliderTooltip(slider) {
+    const cg = slider.closest('.cg');
+    if (!cg) return;
+    cg.style.position = 'relative';
+    const tip = document.createElement('div');
+    tip.className = 'slider-tooltip';
+    cg.appendChild(tip);
+    function positionTip() {
+        const pct = (+slider.value - +slider.min) / (+slider.max - +slider.min);
+        tip.style.left = (pct * slider.offsetWidth) + 'px';
+    }
+    slider.addEventListener('pointerdown', () => {
+        const vEl = document.getElementById(slider.id.replace('s', 'v'));
+        if (vEl) tip.textContent = vEl.textContent;
+        positionTip();
+        tip.classList.add('visible');
+    });
+    slider.addEventListener('input', () => {
+        const vEl = document.getElementById(slider.id.replace('s', 'v'));
+        if (vEl) tip.textContent = vEl.textContent;
+        positionTip();
+    });
+    const hide = () => tip.classList.remove('visible');
+    slider.addEventListener('pointerup', hide);
+    slider.addEventListener('pointercancel', hide);
+}
+
+// Wire sliders
+for (const [s, v] of [['sN','vN'],['sTw','vTw'],['sS','vS'],['sGl','vGl'],['sHEr','vHEr'],['sTEr','vTEr'],['sRs','vRs']]) {
+    const slider = document.getElementById(s);
+    if (!slider) continue;
+    initSliderTooltip(slider);
+    slider.addEventListener('input', e => {
+        if (s === 'sN') {
+            const detail = detailFromSlider(+e.target.value);
+            document.getElementById(v).textContent = detail.toLocaleString();
+            updateDetailWarning(detail);
+        } else {
+            document.getElementById(v).textContent = e.target.value;
+        }
+        if (s === 'sTw' || s === 'sS' || s === 'sGl' || s === 'sHEr' || s === 'sTEr' || s === 'sRs') {
+            markReapplyPending();
+        }
+    });
+}
+
+// ─── Reapply ──────────────────────────────────────────────────────
+
+const reapplyBtn = document.getElementById('reapplyBtn');
+
+function markReapplyPending() {
+    if (!state.curData) return; // only after first import
+    reapplyBtn.disabled = false;
+    reapplyBtn.classList.add('ready');
+}
+
+function clearReapplyPending() {
+    reapplyBtn.disabled = true;
+    reapplyBtn.classList.remove('ready');
+}
+
+function reapplyPostProcessing() {
+    const d = state.curData;
+    if (!d || !d.prePostElev) return;
+    const skipClimate = shouldSkipClimate();
+    reapplyViaWorker(() => {
+        reapplyBtn.classList.remove('spinning');
+        if (skipClimate && CLIMATE_LAYERS.has(state.debugLayer)) {
+            state.debugLayer = '';
+            if (debugLayerEl) debugLayerEl.value = '';
+            syncTabsToLayer('');
+            updateMeshColors();
+            updateLegend('');
+        }
+    }, skipClimate);
+}
+
+reapplyBtn.addEventListener('click', () => {
+    if (reapplyBtn.disabled) return;
+    clearReapplyPending();
+    reapplyBtn.classList.add('spinning');
+    reapplyPostProcessing();
+});
+
+// ─── Import button ────────────────────────────────────────────────
+
+importBtn.addEventListener('click', () => {
+    if (!storedGrayscale) return;
+    importBtn.disabled = true;
+    importBtn.textContent = 'Importing\u2026';
+    clearReapplyPending();
+    buildWindArrows(null);
+    buildOceanCurrentArrows(null);
+    showBuildOverlay();
+    // Collapse bottom sheet on mobile
+    const ui = document.getElementById('ui');
+    if (window.innerWidth <= 768 && ui) ui.classList.add('collapsed');
+    // Copy grayscale since the buffer will be transferred
+    const grayCopy = new Uint8Array(storedGrayscale);
+    importHeightmap(grayCopy, storedWidth, storedHeight, onProgress, shouldSkipClimate());
+});
+
+// Generate-done handler (fired from generate.js after 'done' message)
+const genBtn = document.getElementById('importBtn');
+// The generate.js dispatches 'generate-done' on #generate, but for import page
+// we use the same element ID pattern. Actually generate.js dispatches on
+// document.getElementById('generate'). Since import page has no #generate,
+// we need to listen on the actual element. Let me check...
+// Actually, generate.js does: document.getElementById('generate').dispatchEvent(...)
+// Since import page doesn't have a #generate element, we need a workaround.
+// The cleanest approach: add a hidden #generate element, or listen differently.
+
+// For now, we'll create a hidden generate button to receive the event
+const hiddenGenBtn = document.createElement('button');
+hiddenGenBtn.id = 'generate';
+hiddenGenBtn.style.display = 'none';
+document.body.appendChild(hiddenGenBtn);
+
+hiddenGenBtn.addEventListener('generate-done', () => {
+    hideBuildOverlay();
+    importBtn.disabled = false;
+    importBtn.textContent = 'Import';
+    state.importedHeightmap = true;
+    // Update info text
+    const infoEl = document.getElementById('info');
+    if (infoEl) infoEl.textContent = 'Drag to rotate \u00b7 Scroll to zoom';
+    // Sync view
+    if (!state.climateComputed && CLIMATE_LAYERS.has(state.debugLayer)) {
+        state.debugLayer = '';
+        if (debugLayerEl) debugLayerEl.value = '';
+        syncTabsToLayer('');
+        updateMeshColors();
+    }
+    syncTabsToLayer(state.debugLayer);
+    if (debugLayerEl) debugLayerEl.value = state.debugLayer;
+    updateLegend(state.debugLayer);
+    // Rebuild arrows if needed
+    const v = state.debugLayer;
+    const isWindLayer = v === 'pressureSummer' || v === 'pressureWinter' ||
+                        v === 'windSpeedSummer' || v === 'windSpeedWinter';
+    const isOceanLayer = v === 'oceanCurrentSummer' || v === 'oceanCurrentWinter';
+    if (isWindLayer) buildWindArrows(v.includes('Winter') ? 'winter' : 'summer');
+    else if (isOceanLayer) buildOceanCurrentArrows(v.includes('Winter') ? 'winter' : 'summer');
+});
+
+// ─── Climate layers ───────────────────────────────────────────────
+
+const CLIMATE_LAYERS = new Set([
+    'pressureSummer', 'pressureWinter',
+    'windSpeedSummer', 'windSpeedWinter',
+    'oceanCurrentSummer', 'oceanCurrentWinter',
+    'precipSummer', 'precipWinter',
+    'rainShadowSummer', 'rainShadowWinter',
+    'tempSummer', 'tempWinter',
+    'koppen', 'biome', 'continentality'
+]);
+
+// ─── Visualization (debug layers, tabs, legend) ───────────────────
+
+const mapTabs = document.getElementById('mapTabs');
+const vizLegend = document.getElementById('vizLegend');
+const debugLayerEl = document.getElementById('debugLayer');
+
+function switchVisualization(layer) {
+    if (CLIMATE_LAYERS.has(layer) && !state.climateComputed) {
+        showBuildOverlay();
+        computeClimateViaWorker(onProgress, () => {
+            hideBuildOverlay();
+            applyLayer(layer);
+        });
+        return;
+    }
+    applyLayer(layer);
+}
+
+function applyLayer(layer) {
+    state.debugLayer = layer;
+    state.hoveredKoppen = -1;
+    updateMeshColors();
+    const isWindLayer = layer === 'pressureSummer' || layer === 'pressureWinter' ||
+                        layer === 'windSpeedSummer' || layer === 'windSpeedWinter';
+    const isOceanLayer = layer === 'oceanCurrentSummer' || layer === 'oceanCurrentWinter';
+    if (isOceanLayer) {
+        buildWindArrows(null);
+        buildOceanCurrentArrows(layer.includes('Winter') ? 'winter' : 'summer');
+    } else if (isWindLayer) {
+        buildOceanCurrentArrows(null);
+        buildWindArrows(layer.includes('Winter') ? 'winter' : 'summer');
+    } else {
+        buildWindArrows(null);
+        buildOceanCurrentArrows(null);
+    }
+    updateLegend(layer);
+}
+
+function syncTabsToLayer(layer) {
+    mapTabs.querySelectorAll('.map-tab').forEach(tab => {
+        tab.classList.toggle('active', tab.dataset.layer === layer);
+    });
+    const mvs = document.getElementById('mobileViewSwitch');
+    if (mvs && [...mvs.options].some(o => o.value === layer)) {
+        mvs.value = layer;
+    }
+}
+
+mapTabs.addEventListener('click', (e) => {
+    const tab = e.target.closest('.map-tab');
+    if (!tab) return;
+    const layer = tab.dataset.layer;
+    mapTabs.querySelectorAll('.map-tab').forEach(t => t.classList.remove('active'));
+    tab.classList.add('active');
+    if (debugLayerEl) debugLayerEl.value = layer;
+    const mvs = document.getElementById('mobileViewSwitch');
+    if (mvs) mvs.value = layer;
+    switchVisualization(layer);
+});
+
+const mobileViewSwitch = document.getElementById('mobileViewSwitch');
+if (mobileViewSwitch) {
+    mobileViewSwitch.addEventListener('change', (e) => {
+        const layer = e.target.value;
+        syncTabsToLayer(layer);
+        if (debugLayerEl) debugLayerEl.value = layer;
+        switchVisualization(layer);
+    });
+}
+
+if (debugLayerEl) {
+    debugLayerEl.addEventListener('change', (e) => {
+        const layer = e.target.value;
+        syncTabsToLayer(layer);
+        switchVisualization(layer);
+    });
+}
+
+// ─── Legend ────────────────────────────────────────────────────────
+
+const KOPPEN_DESCRIPTIONS = {
+    Af:  'Tropical rainforest \u2014 Hot and wet year-round.',
+    Am:  'Tropical monsoon \u2014 Brief dry season offset by heavy monsoon rains.',
+    Aw:  'Tropical savanna \u2014 Distinct wet and dry seasons.',
+    BWh: 'Hot desert \u2014 Extremely dry with scorching summers.',
+    BWk: 'Cold desert \u2014 Arid with cold winters.',
+    BSh: 'Hot steppe \u2014 Semi-arid grassland with hot summers.',
+    BSk: 'Cold steppe \u2014 Semi-arid with cold winters.',
+    Cfa: 'Humid subtropical \u2014 Hot humid summers, mild winters.',
+    Cfb: 'Oceanic \u2014 Mild year-round, cool summers, frequent rain.',
+    Cfc: 'Subpolar oceanic \u2014 Cool year-round with short summers.',
+    Csa: 'Hot-summer Mediterranean \u2014 Dry hot summers, mild wet winters.',
+    Csb: 'Warm-summer Mediterranean \u2014 Dry warm summers, mild wet winters.',
+    Csc: 'Cold-summer Mediterranean \u2014 Cool dry summers, mild wet winters.',
+    Cwa: 'Humid subtropical monsoon \u2014 Warm with dry winters.',
+    Cwb: 'Subtropical highland \u2014 Mild with dry winters.',
+    Cwc: 'Cold subtropical highland \u2014 Cool with dry winters.',
+    Dfa: 'Hot-summer continental \u2014 Hot summers, cold snowy winters.',
+    Dfb: 'Warm-summer continental \u2014 Warm summers, cold winters.',
+    Dfc: 'Subarctic \u2014 Long cold winters, brief cool summers.',
+    Dfd: 'Extremely cold subarctic \u2014 Harshest winters on Earth.',
+    Dsa: 'Hot-summer continental, dry summer.',
+    Dsb: 'Warm-summer continental, dry summer.',
+    Dsc: 'Subarctic, dry summer.',
+    Dsd: 'Extremely cold subarctic, dry summer.',
+    Dwa: 'Hot-summer continental, monsoon.',
+    Dwb: 'Warm-summer continental, monsoon.',
+    Dwc: 'Subarctic monsoon \u2014 Brief wet summers, long frigid winters.',
+    Dwd: 'Extremely cold subarctic, monsoon.',
+    ET:  'Tundra \u2014 Permafrost, only warmest month above 0\u00b0C.',
+    EF:  'Ice cap \u2014 Permanent ice, never above 0\u00b0C.',
+};
+
+function updateLegend(layer) {
+    if (!vizLegend) return;
+    if (layer === '' || !layer) {
+        const stops = [
+            { e: -0.50 }, { e: -0.25 }, { e: -0.05 }, { e: 0.00 },
+            { e: 0.03 }, { e: 0.15 }, { e: 0.35 }, { e: 0.55 }, { e: 0.80 }
+        ];
+        const colors = stops.map(s => {
+            const [r, g, b] = elevationToColor(s.e);
+            return `rgb(${Math.round(r*255)},${Math.round(g*255)},${Math.round(b*255)})`;
+        });
+        const pcts = stops.map((_, i) => Math.round(i / (stops.length - 1) * 100));
+        const gradStr = colors.map((c, i) => `${c} ${pcts[i]}%`).join(', ');
+        vizLegend.innerHTML = `<div class="legend-gradient" style="background:linear-gradient(to right,${gradStr})"></div>` +
+            `<div class="legend-labels"><span>Deep Ocean</span><span>Sea Level</span><span>Peak</span></div>`;
+    } else if (layer === 'koppen') {
+        let html = '<div class="legend-koppen-header"><a href="https://en.wikipedia.org/wiki/K%C3%B6ppen_climate_classification" target="_blank" rel="noopener">K\u00f6ppen climate classification</a></div>';
+        html += '<div class="legend-koppen">';
+        for (let i = 1; i < KOPPEN_CLASSES.length; i++) {
+            const k = KOPPEN_CLASSES[i];
+            const [r, g, b] = k.color;
+            const hex = `rgb(${Math.round(r*255)},${Math.round(g*255)},${Math.round(b*255)})`;
+            html += `<div class="legend-koppen-item" data-code="${k.code}"><span class="legend-koppen-swatch" style="background:${hex}"></span>${k.code}</div>`;
+        }
+        html += '<div class="legend-koppen-tooltip" id="koppenTip"></div>';
+        html += '</div>';
+        vizLegend.innerHTML = html;
+        const tipEl = document.getElementById('koppenTip');
+        const container = vizLegend.querySelector('.legend-koppen');
+        vizLegend.querySelectorAll('.legend-koppen-item').forEach(item => {
+            item.addEventListener('mouseenter', () => {
+                const code = item.dataset.code;
+                tipEl.textContent = KOPPEN_DESCRIPTIONS[code] || '';
+                tipEl.classList.add('visible');
+                const itemRect = item.getBoundingClientRect();
+                const containerRect = container.getBoundingClientRect();
+                const tipWidth = 240;
+                let left = itemRect.left - containerRect.left + itemRect.width / 2 - tipWidth / 2;
+                left = Math.max(0, Math.min(left, containerRect.width - tipWidth));
+                tipEl.style.left = left + 'px';
+                tipEl.style.bottom = (containerRect.bottom - itemRect.top + 6) + 'px';
+                const classId = KOPPEN_CLASSES.findIndex(c => c.code === code);
+                if (classId >= 0) {
+                    state.hoveredKoppen = classId;
+                    updateKoppenHoverHighlight();
+                    updateMapKoppenHoverHighlight();
+                }
+            });
+            item.addEventListener('mouseleave', () => {
+                tipEl.classList.remove('visible');
+                state.hoveredKoppen = -1;
+                updateKoppenHoverHighlight();
+                updateMapKoppenHoverHighlight();
+            });
+        });
+    } else if (layer === 'biome') {
+        const biomeStops = [
+            { color: [0.82,0.72,0.50], label: 'Desert' },
+            { color: [0.72,0.62,0.30], label: 'Steppe' },
+            { color: [0.42,0.50,0.18], label: 'Savanna' },
+            { color: [0.12,0.38,0.10], label: 'Forest' },
+            { color: [0.06,0.22,0.08], label: 'Taiga' },
+            { color: [0.35,0.32,0.22], label: 'Tundra' },
+            { color: [0.78,0.80,0.84], label: 'Ice' },
+        ];
+        const biomeColors = biomeStops.map(s => `rgb(${Math.round(s.color[0]*255)},${Math.round(s.color[1]*255)},${Math.round(s.color[2]*255)})`);
+        const biomePcts = biomeStops.map((_, i) => Math.round(i / (biomeStops.length - 1) * 100));
+        const biomeGrad = biomeColors.map((c, i) => `${c} ${biomePcts[i]}%`).join(', ');
+        vizLegend.innerHTML = `<div class="legend-gradient" style="background:linear-gradient(to right,${biomeGrad})"></div>` +
+            `<div class="legend-labels"><span>${biomeStops[0].label}</span><span>${biomeStops[3].label}</span><span>${biomeStops[6].label}</span></div>`;
+    } else if (layer === 'rainShadowSummer' || layer === 'rainShadowWinter') {
+        vizLegend.innerHTML = `<div class="legend-gradient" style="background:linear-gradient(to right,rgb(230,51,33) 0%,rgb(140,140,148) 50%,rgb(38,102,243) 100%)"></div>` +
+            `<div class="legend-labels"><span>Rain Shadow</span><span>Neutral</span><span>Windward</span></div>`;
+    } else if (layer === 'landheightmap') {
+        vizLegend.innerHTML = `<div class="legend-gradient" style="background:linear-gradient(to right,#000 0%,#fff 100%)"></div>` +
+            `<div class="legend-labels"><span>Ocean / Sea Level</span><span>Peak</span></div>`;
+    } else {
+        vizLegend.innerHTML = '';
+    }
+}
+
+// ─── Build overlay ────────────────────────────────────────────────
+
+const buildOverlay  = document.getElementById('buildOverlay');
+const buildBarFill  = document.getElementById('buildBarFill');
+const buildBarLabel = document.getElementById('buildBarLabel');
+let overlayActive = false;
+
+function onProgress(pct, label) {
+    if (!overlayActive) return;
+    if (buildBarFill) buildBarFill.style.transform = 'scaleX(' + (pct / 100) + ')';
+    if (buildBarLabel) buildBarLabel.textContent = label;
+}
+
+function showBuildOverlay() {
+    if (!buildBarFill || !buildOverlay) return;
+    buildBarFill.style.transition = 'none';
+    buildBarFill.style.transform = 'scaleX(0)';
+    buildBarLabel.textContent = '';
+    buildBarFill.offsetWidth;
+    buildBarFill.style.transition = '';
+    overlayActive = true;
+    buildOverlay.classList.remove('hidden');
+}
+
+function hideBuildOverlay() {
+    setTimeout(() => {
+        overlayActive = false;
+        if (buildOverlay) {
+            buildOverlay.classList.add('hidden');
+            buildOverlay.classList.remove('initial');
+        }
+    }, 500);
+}
+
+// ─── View mode ────────────────────────────────────────────────────
+
+document.getElementById('chkWire').addEventListener('change', buildMesh);
+
+const gridSpacingGroup = document.getElementById('gridSpacingGroup');
+document.getElementById('chkGrid').addEventListener('change', (e) => {
+    state.gridEnabled = e.target.checked;
+    gridSpacingGroup.style.display = state.gridEnabled ? '' : 'none';
+    if (state.mapMode) {
+        if (state.mapGridMesh) state.mapGridMesh.visible = state.gridEnabled;
+        if (state.globeGridMesh) state.globeGridMesh.visible = false;
+    } else {
+        if (state.globeGridMesh) state.globeGridMesh.visible = state.gridEnabled;
+        if (state.mapGridMesh) state.mapGridMesh.visible = false;
+    }
+});
+
+document.getElementById('gridSpacing').addEventListener('change', (e) => {
+    state.gridSpacing = parseFloat(e.target.value);
+    rebuildGrids();
+});
+
+// Map center longitude
+const mapCenterLonGroup = document.getElementById('mapCenterLonGroup');
+const sMapCenterLon = document.getElementById('sMapCenterLon');
+const vMapCenterLon = document.getElementById('vMapCenterLon');
+
+sMapCenterLon.addEventListener('input', () => {
+    const lon = +sMapCenterLon.value;
+    const suffix = lon > 0 ? 'E' : lon < 0 ? 'W' : '';
+    vMapCenterLon.textContent = Math.abs(lon) + '\u00B0' + suffix;
+    state.mapCenterLon = lon * Math.PI / 180;
+    if (state.mapMode && state.mapMesh) {
+        const builtLon = state.mapMesh._builtCenterLon || 0;
+        const dx = (builtLon - state.mapCenterLon) * (2 / Math.PI);
+        state.mapMesh.position.x = dx;
+        if (state.mapGridMesh) state.mapGridMesh.position.x = dx;
+    }
+});
+
+sMapCenterLon.addEventListener('change', () => {
+    if (state.mapMode) {
+        buildMapMesh();
+        const layer = state.debugLayer;
+        const isWind = layer === 'pressureSummer' || layer === 'pressureWinter' ||
+                       layer === 'windSpeedSummer' || layer === 'windSpeedWinter';
+        const isOcean = layer === 'oceanCurrentSummer' || layer === 'oceanCurrentWinter';
+        if (isWind) buildWindArrows(layer.includes('Winter') ? 'winter' : 'summer');
+        if (isOcean) buildOceanCurrentArrows(layer.includes('Winter') ? 'winter' : 'summer');
+    }
+});
+
+// Globe / Map toggle
+document.getElementById('viewMode').addEventListener('change', (e) => {
+    state.mapMode = e.target.value === 'map';
+    if (state.mapMode) {
+        if (state.planetMesh) state.planetMesh.visible = false;
+        waterMesh.visible = false;
+        atmosMesh.visible = false;
+        starsMesh.visible = false;
+        if (state.wireMesh) state.wireMesh.visible = false;
+        if (state.arrowGroup) state.arrowGroup.visible = false;
+        if (!state.mapMesh) {
+            showBuildOverlay();
+            onProgress(0, 'Building map mesh\u2026');
+            setTimeout(() => {
+                buildMapMesh();
+                if (state.mapMesh) state.mapMesh.visible = true;
+                hideBuildOverlay();
+            }, 50);
+        }
+        if (state.mapMesh) state.mapMesh.visible = true;
+        if (state.mapGridMesh) state.mapGridMesh.visible = state.gridEnabled;
+        if (state.globeGridMesh) state.globeGridMesh.visible = false;
+        if (state.windArrowGroup) {
+            state.windArrowGroup.traverse(c => {
+                if (c.name === 'windGlobe') c.visible = false;
+                if (c.name === 'windMap') c.visible = true;
+            });
+        }
+        if (state.oceanCurrentArrowGroup) {
+            state.oceanCurrentArrowGroup.traverse(c => {
+                if (c.name === 'oceanGlobe') c.visible = false;
+                if (c.name === 'oceanMap') c.visible = true;
+            });
+        }
+        scene.background = new THREE.Color(0x1a1a2e);
+        ctrl.enabled = false;
+        mapCtrl.enabled = true;
+        mapCamera.position.set(0, 0, 5);
+        mapCamera.lookAt(0, 0, 0);
+        updateMapCameraFrustum();
+        mapCtrl.target.set(0, 0, 0);
+        mapCtrl.update();
+        mapCenterLonGroup.style.display = '';
+    } else {
+        if (state.planetMesh) state.planetMesh.visible = true;
+        atmosMesh.visible = true;
+        starsMesh.visible = true;
+        if (state.wireMesh) state.wireMesh.visible = true;
+        if (state.arrowGroup) state.arrowGroup.visible = true;
+        if (state.mapMesh) state.mapMesh.visible = false;
+        if (state.mapGridMesh) state.mapGridMesh.visible = false;
+        if (state.globeGridMesh) state.globeGridMesh.visible = state.gridEnabled;
+        if (state.windArrowGroup) {
+            state.windArrowGroup.traverse(c => {
+                if (c.name === 'windGlobe') c.visible = true;
+                if (c.name === 'windMap') c.visible = false;
+            });
+        }
+        if (state.oceanCurrentArrowGroup) {
+            state.oceanCurrentArrowGroup.traverse(c => {
+                if (c.name === 'oceanGlobe') c.visible = true;
+                if (c.name === 'oceanMap') c.visible = false;
+            });
+        }
+        waterMesh.visible = !state.debugLayer;
+        scene.background = new THREE.Color(0x030308);
+        mapCtrl.enabled = false;
+        ctrl.enabled = true;
+        mapCenterLonGroup.style.display = 'none';
+    }
+});
+
+// ─── Export modal ─────────────────────────────────────────────────
+
+(function initExport() {
+    const overlay   = document.getElementById('exportOverlay');
+    const closeBtn  = document.getElementById('exportClose');
+    const cancelBtn = document.getElementById('exportCancel');
+    const goBtn     = document.getElementById('exportGo');
+    const widthEl   = document.getElementById('exportWidth');
+    const dimsEl    = document.getElementById('exportDims');
+    const typeEl    = document.getElementById('exportType');
+    const openBtn   = document.getElementById('exportBtn');
+
+    function updateDims() {
+        const w = +widthEl.value;
+        dimsEl.textContent = w + ' \u00D7 ' + (w / 2);
+    }
+
+    function openModal() {
+        overlay.classList.remove('hidden');
+        updateDims();
+        for (const opt of typeEl.options) {
+            if (opt.value === 'biome' || opt.value === 'koppen') {
+                opt.disabled = !state.climateComputed;
+                if (opt.disabled && typeEl.value === opt.value) typeEl.value = 'color';
+            }
+        }
+    }
+    function closeModal() { overlay.classList.add('hidden'); }
+
+    openBtn.addEventListener('click', openModal);
+    closeBtn.addEventListener('click', closeModal);
+    cancelBtn.addEventListener('click', closeModal);
+    overlay.addEventListener('click', (e) => { if (e.target === overlay) closeModal(); });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && !overlay.classList.contains('hidden')) closeModal();
+    });
+    widthEl.addEventListener('change', updateDims);
+
+    goBtn.addEventListener('click', async () => {
+        const type = typeEl.value;
+        const w = +widthEl.value;
+        closeModal();
+        showBuildOverlay();
+        onProgress(0, 'Preparing export...');
+        await exportMap(type, w, onProgress);
+        hideBuildOverlay();
+    });
+
+    const exportAllBtn = document.getElementById('exportAllGo');
+    const EXPORT_ALL_TYPES = [
+        { type: 'biome',         label: 'Satellite' },
+        { type: 'koppen',        label: 'Climate' },
+        { type: 'landheightmap', label: 'Heightmap' },
+        { type: 'landmask',      label: 'Land Mask' },
+    ];
+
+    exportAllBtn.addEventListener('click', async () => {
+        const w = +widthEl.value;
+        closeModal();
+        showBuildOverlay();
+        if (!state.climateComputed) {
+            onProgress(0, 'Computing climate...');
+            await new Promise(resolve => computeClimateViaWorker(onProgress, resolve));
+        }
+        await exportMapBatch(EXPORT_ALL_TYPES, w, onProgress);
+        hideBuildOverlay();
+    });
+})();
+
+// ─── Sidebar toggle + bottom sheet ────────────────────────────────
+
+const sidebarToggle = document.getElementById('sidebarToggle');
+const uiPanel = document.getElementById('ui');
+const isMobileLayout = () => window.innerWidth <= 768;
+
+if (isMobileLayout()) {
+    uiPanel.classList.add('collapsed');
+}
+
+sidebarToggle.addEventListener('click', () => {
+    const collapsed = uiPanel.classList.toggle('collapsed');
+    sidebarToggle.innerHTML = collapsed ? '\u00BB' : '\u00AB';
+    sidebarToggle.title = collapsed ? 'Show panel' : 'Collapse panel';
+});
+
+(function initBottomSheet() {
+    const handle = document.getElementById('sheetHandle');
+    if (!handle) return;
+    let startY = 0, startTransform = 0, dragging = false;
+    let lastY = 0, lastTime = 0, velocity = 0;
+    let didDrag = false;
+    let rafId = 0, pendingY = null;
+
+    function getTranslateY() {
+        const st = getComputedStyle(uiPanel);
+        const m = new DOMMatrix(st.transform);
+        return m.m42;
+    }
+    function getCollapsedY() { return uiPanel.offsetHeight - 60; }
+    function applyTransform() {
+        if (pendingY !== null) { uiPanel.style.transform = `translateY(${pendingY}px)`; pendingY = null; }
+        rafId = 0;
+    }
+    function scheduleTransform(y) {
+        pendingY = y;
+        if (!rafId) rafId = requestAnimationFrame(applyTransform);
+    }
+    function cleanup() {
+        dragging = false;
+        uiPanel.style.transition = '';
+        uiPanel.classList.remove('dragging');
+        if (rafId) { cancelAnimationFrame(rafId); rafId = 0; }
+        pendingY = null;
+    }
+
+    handle.addEventListener('pointerdown', (e) => {
+        if (!isMobileLayout()) return;
+        e.preventDefault();
+        handle.setPointerCapture(e.pointerId);
+        dragging = true; didDrag = false;
+        startY = e.clientY; lastY = e.clientY;
+        lastTime = performance.now(); velocity = 0;
+        startTransform = uiPanel.classList.contains('collapsed') ? getTranslateY() : 0;
+        uiPanel.style.transition = 'none';
+        uiPanel.classList.add('dragging');
+    });
+    handle.addEventListener('pointermove', (e) => {
+        if (!dragging) return;
+        const y = e.clientY;
+        const now = performance.now();
+        const dt = now - lastTime;
+        if (dt > 0) velocity = (y - lastY) / dt;
+        lastY = y; lastTime = now;
+        const dy = y - startY;
+        if (Math.abs(dy) > 5) didDrag = true;
+        const collapsedY = getCollapsedY();
+        scheduleTransform(Math.max(0, Math.min(collapsedY, startTransform + dy)));
+    });
+    handle.addEventListener('pointerup', (e) => {
+        if (!dragging) return;
+        handle.releasePointerCapture(e.pointerId);
+        cleanup();
+        const curY = getTranslateY();
+        const collapsedY = getCollapsedY();
+        const progress = collapsedY > 0 ? 1 - curY / collapsedY : 0;
+        if (velocity > 0.3 || (velocity > -0.3 && progress < 0.3)) {
+            uiPanel.classList.add('collapsed');
+        } else {
+            uiPanel.classList.remove('collapsed');
+        }
+        uiPanel.style.transform = '';
+    });
+    handle.addEventListener('pointercancel', (e) => {
+        if (!dragging) return;
+        try { handle.releasePointerCapture(e.pointerId); } catch (_) {}
+        cleanup();
+        uiPanel.style.transform = '';
+    });
+    handle.addEventListener('click', () => {
+        if (!isMobileLayout()) return;
+        if (didDrag) { didDrag = false; return; }
+        uiPanel.classList.toggle('collapsed');
+    });
+})();
+
+// ─── Mobile info text ─────────────────────────────────────────────
+
+if (state.isTouchDevice) {
+    const infoEl = document.getElementById('info');
+    if (infoEl) infoEl.textContent = 'Import a heightmap to get started';
+}
+
+// Disable export widths > 8192 on touch devices
+if (state.isTouchDevice) {
+    const exportWidth = document.getElementById('exportWidth');
+    if (exportWidth) {
+        for (const opt of exportWidth.options) {
+            if (+opt.value > 8192) {
+                opt.disabled = true;
+                opt.textContent = opt.value + ' (too large for mobile)';
+            }
+        }
+    }
+}
+
+// ─── Orientation change ───────────────────────────────────────────
+
+window.addEventListener('orientationchange', () => {
+    setTimeout(() => {
+        camera.aspect = innerWidth / innerHeight;
+        camera.updateProjectionMatrix();
+        updateMapCameraFrustum();
+        renderer.setSize(innerWidth, innerHeight);
+    }, 100);
+});
+
+// ─── Animation loop ───────────────────────────────────────────────
+
+function animate() {
+    requestAnimationFrame(animate);
+    if (state.mapMode) { tickMapZoom(); mapCtrl.update(); } else { tickZoom(); ctrl.update(); }
+    if (!state.mapMode && state.planetMesh && document.getElementById('chkRotate').checked) {
+        state.planetMesh.rotation.y += 0.0008;
+        waterMesh.rotation.y = state.planetMesh.rotation.y;
+        if (state.wireMesh) state.wireMesh.rotation.y = state.planetMesh.rotation.y;
+        if (state.arrowGroup) state.arrowGroup.rotation.y = state.planetMesh.rotation.y;
+        if (state.windArrowGroup) state.windArrowGroup.rotation.y = state.planetMesh.rotation.y;
+        if (state.oceanCurrentArrowGroup) state.oceanCurrentArrowGroup.rotation.y = state.planetMesh.rotation.y;
+        if (state.globeGridMesh) state.globeGridMesh.rotation.y = state.planetMesh.rotation.y;
+    }
+    renderer.render(scene, state.mapMode ? mapCamera : camera);
+}
+
+// ─── Resize handler ───────────────────────────────────────────────
+
+window.addEventListener('resize', () => {
+    camera.aspect = innerWidth / innerHeight;
+    camera.updateProjectionMatrix();
+    updateMapCameraFrustum();
+    renderer.setSize(innerWidth, innerHeight);
+});
+
+// ─── Hover info (analytical ray-sphere, no mesh raycasting) ───────
+
+(function initHoverInfo() {
+    const hoverEl = document.getElementById('hoverInfo');
+    if (!hoverEl) return;
+    const raycaster = new THREE.Raycaster();
+    const mouse = new THREE.Vector2();
+    const _inverseMatrix = new THREE.Matrix4();
+    const _localRay = new THREE.Ray();
+
+    const HOVER_INTERVAL = 50; // ms throttle
+    let lastHoverTime = 0;
+    let lastRegion = -1;
+
+    /** Find nearest region to a unit-sphere direction (max dot product). */
+    function findNearestRegion(nx, ny, nz) {
+        const { mesh, r_xyz } = state.curData;
+        const N = mesh.numRegions;
+        let bestDot = -2, bestR = -1;
+        for (let r = 0; r < N; r++) {
+            const dot = nx * r_xyz[3 * r] + ny * r_xyz[3 * r + 1] + nz * r_xyz[3 * r + 2];
+            if (dot > bestDot) { bestDot = dot; bestR = r; }
+        }
+        return bestR;
+    }
+
+    function getHitRegionGlobe(e) {
+        if (!state.planetMesh) return -1;
+        const rect = canvas.getBoundingClientRect();
+        mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        raycaster.setFromCamera(mouse, camera);
+        _inverseMatrix.copy(state.planetMesh.matrixWorld).invert();
+        _localRay.copy(raycaster.ray).applyMatrix4(_inverseMatrix);
+        const ox = _localRay.origin.x, oy = _localRay.origin.y, oz = _localRay.origin.z;
+        const dx = _localRay.direction.x, dy = _localRay.direction.y, dz = _localRay.direction.z;
+        const R = 1.08;
+        const b = 2 * (ox * dx + oy * dy + oz * dz);
+        const c = ox * ox + oy * oy + oz * oz - R * R;
+        const disc = b * b - 4 * c;
+        if (disc < 0) return -1;
+        const t = (-b - Math.sqrt(disc)) * 0.5;
+        if (t < 0) return -1;
+        const hx = ox + t * dx, hy = oy + t * dy, hz = oz + t * dz;
+        const len = Math.sqrt(hx * hx + hy * hy + hz * hz) || 1;
+        return findNearestRegion(hx / len, hy / len, hz / len);
+    }
+
+    function getHitRegionMap(e) {
+        if (!state.mapMesh) return -1;
+        const rect = canvas.getBoundingClientRect();
+        mouse.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+        mouse.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+        raycaster.setFromCamera(mouse, mapCamera);
+        const o = raycaster.ray.origin, d = raycaster.ray.direction;
+        if (Math.abs(d.z) < 1e-10) return -1;
+        const t = -o.z / d.z;
+        const wx = o.x + t * d.x, wy = o.y + t * d.y;
+        const PI = Math.PI, sx = 2 / PI;
+        let lon = wx / sx + (state.mapCenterLon || 0);
+        const lat = wy / sx;
+        if (lat < -PI / 2 || lat > PI / 2) return -1;
+        if (lon > PI) lon -= 2 * PI;
+        else if (lon < -PI) lon += 2 * PI;
+        const cosLat = Math.cos(lat);
+        return findNearestRegion(cosLat * Math.sin(lon), Math.sin(lat), cosLat * Math.cos(lon));
+    }
+
+    function updateHoverInfo(e) {
+        if (!state.curData) return;
+        const now = performance.now();
+        if (now - lastHoverTime < HOVER_INTERVAL) return;
+        lastHoverTime = now;
+
+        const r = state.mapMode ? getHitRegionMap(e) : getHitRegionGlobe(e);
+        if (r === lastRegion) return; // no change
+        lastRegion = r;
+
+        if (r < 0) { hoverEl.style.display = 'none'; return; }
+        showRegionInfo(r);
+    }
+
+    function showRegionInfo(r) {
+        const d = state.curData;
+        if (!d || r < 0 || r >= d.mesh.numRegions) { hoverEl.style.display = 'none'; return; }
+        const x = d.r_xyz[3*r], y = d.r_xyz[3*r+1], z = d.r_xyz[3*r+2];
+        const lat = Math.asin(Math.max(-1, Math.min(1, y))) * 180 / Math.PI;
+        const lon = Math.atan2(x, z) * 180 / Math.PI;
+        const elev = d.r_elevation[r];
+        const heightKm = elev <= 0 ? (elev * 10).toFixed(1) : (6 * elev * elev).toFixed(1);
+        const isOcean = elev <= 0;
+
+        let html = `<span class="hi-label">Elev</span> ${heightKm} km (${isOcean ? 'ocean' : 'land'})<br>`;
+        html += `<span class="hi-label">Coord</span> ${Math.abs(lat).toFixed(1)}\u00b0${lat >= 0 ? 'N' : 'S'}, ${Math.abs(lon).toFixed(1)}\u00b0${lon >= 0 ? 'E' : 'W'}`;
+
+        if (d.r_temperature_summer && d.r_precip_summer) {
+            const ts = d.r_temperature_summer[r], tw = d.r_temperature_winter[r];
+            const ps = d.r_precip_summer[r], pw = d.r_precip_winter[r];
+            const tAvg = ((ts + tw) / 2).toFixed(1);
+            const pTotal = Math.round(ps + pw);
+            html += `<br><span class="hi-label">Temp</span> ${tAvg}\u00b0C avg (${ts.toFixed(1)} summer, ${tw.toFixed(1)} winter)`;
+            html += `<br><span class="hi-label">Prec</span> ${pTotal} mm/yr`;
+        }
+
+        if (d.debugLayers?.koppen) {
+            const kIdx = d.debugLayers.koppen[r];
+            if (kIdx > 0 && kIdx < KOPPEN_CLASSES.length) {
+                const k = KOPPEN_CLASSES[kIdx];
+                html += `<br><span class="hi-label">Clim</span> ${k.code} \u2014 ${k.name}`;
+            }
+        }
+
+        hoverEl.innerHTML = html;
+        hoverEl.style.display = 'block';
+    }
+
+    canvas.addEventListener('mousemove', updateHoverInfo);
+    canvas.addEventListener('mouseleave', () => { lastRegion = -1; hoverEl.style.display = 'none'; });
+})();
+
+// ─── Start ────────────────────────────────────────────────────────
+
+animate();

--- a/js/main.js
+++ b/js/main.js
@@ -14,7 +14,8 @@ import { KOPPEN_CLASSES } from './koppen.js';
 import { elevationToColor } from './color-map.js';
 
 // Slider value displays + stale tracking
-const sliderIds = ['sN','sP','sCn','sJ','sNs'];
+const sliderIds = ['sN','sP','sCn','sJ','sNs','sCsv','sLc'];
+const PLATE_SLIDERS = ['sP', 'sCn', 'sCsv', 'sLc'];
 let lastGenValues = {};
 
 function snapshotSliders() {
@@ -24,9 +25,8 @@ function snapshotSliders() {
 function checkStale() {
     const btn = document.getElementById('generate');
     if (btn.classList.contains('generating')) return;
-    const plateSliders = ['sP', 'sCn'];
     const detailSliders = ['sN', 'sJ', 'sNs'];
-    const plateChanged = plateSliders.some(id => document.getElementById(id).value !== lastGenValues[id]);
+    const plateChanged = PLATE_SLIDERS.some(id => document.getElementById(id).value !== lastGenValues[id]);
     const detailChanged = detailSliders.some(id => document.getElementById(id).value !== lastGenValues[id]);
     btn.classList.remove('stale', 'regen');
     if (plateChanged) {
@@ -133,7 +133,7 @@ function initSliderTooltip(slider) {
     slider.addEventListener('pointercancel', hide);
 }
 
-for (const [s,v] of [['sN','vN'],['sP','vP'],['sCn','vCn'],['sJ','vJ'],['sNs','vNs'],['sTw','vTw'],['sS','vS'],['sGl','vGl'],['sHEr','vHEr'],['sTEr','vTEr'],['sRs','vRs']]) {
+for (const [s,v] of [['sN','vN'],['sP','vP'],['sCn','vCn'],['sJ','vJ'],['sNs','vNs'],['sCsv','vCsv'],['sLc','vLc'],['sTw','vTw'],['sS','vS'],['sGl','vGl'],['sHEr','vHEr'],['sTEr','vTEr'],['sRs','vRs'],['sTmp','vTmp'],['sPrc','vPrc']]) {
     const slider = document.getElementById(s);
     initSliderTooltip(slider);
     slider.addEventListener('input', e => {
@@ -141,16 +141,52 @@ for (const [s,v] of [['sN','vN'],['sP','vP'],['sCn','vCn'],['sJ','vJ'],['sNs','v
             const detail = detailFromSlider(+e.target.value);
             document.getElementById(v).textContent = detail.toLocaleString();
             updateDetailWarning(detail);
+        } else if (s === 'sTmp') {
+            const val = +e.target.value;
+            document.getElementById(v).textContent = (val > 0 ? '+' : val === 0 ? '\u00b1' : '') + val + '\u00b0C';
+        } else if (s === 'sPrc') {
+            const val = +e.target.value;
+            const pct = Math.round(val * 50);
+            document.getElementById(v).textContent = (pct > 0 ? '+' : pct === 0 ? '\u00b1' : '') + pct + '%';
+        } else if (s === 'sLc') {
+            document.getElementById(v).textContent = Math.round(+e.target.value * 100) + '%';
         } else {
             document.getElementById(v).textContent = e.target.value;
         }
         if (s === 'sTw' || s === 'sS' || s === 'sGl' || s === 'sHEr' || s === 'sTEr' || s === 'sRs') {
             markReapplyPending();
+        } else if (s === 'sTmp' || s === 'sPrc') {
+            // Display-only update during drag; actual recompute on change (release)
         } else {
             checkStale();
         }
     });
+    // Climate sliders: recompute only on release (change), not every drag tick
+    if (s === 'sTmp' || s === 'sPrc') {
+        slider.addEventListener('change', () => {
+            if (!state.curData) return;
+            updatePlanetCode(false);
+            showBuildOverlay();
+            computeClimateViaWorker(onProgress, () => {
+                hideBuildOverlay();
+                updateMeshColors();
+                updateLegend(state.debugLayer);
+            });
+        });
+    }
 }
+
+// Force range input re-render when <details> sections are opened.
+// Browsers may not update the visual thumb position for sliders that were
+// hidden (inside a closed <details>) when their value was set via JS.
+document.querySelectorAll('details.section').forEach(det => {
+    det.addEventListener('toggle', () => {
+        if (!det.open) return;
+        det.querySelectorAll('input[type="range"]').forEach(s => {
+            const v = s.value; s.value = ''; s.value = v;
+        });
+    });
+});
 
 /** Returns true if climate should be skipped (detail above threshold). */
 function shouldSkipClimate() {
@@ -424,10 +460,9 @@ genBtn.addEventListener('click', () => {
     const ui = document.getElementById('ui');
     if (window.innerWidth <= 768 && ui) ui.classList.add('collapsed');
     // Rebuild: reuse seed + plate edits so only resolution/params change.
-    // If plate-affecting sliders (Plates, Continents) changed, force a fresh
-    // generation — the coarse plate grid is fully determined by seed + P + Cn.
-    const plateSliders = ['sP', 'sCn'];
-    const plateChanged = plateSliders.some(id => document.getElementById(id).value !== lastGenValues[id]);
+    // If plate-affecting sliders (Plates, Continents, Continent Size Variety, Land Coverage) changed,
+    // force a fresh generation — the coarse plate grid is fully determined by seed + P + Cn + Csv + Lc.
+    const plateChanged = PLATE_SLIDERS.some(id => document.getElementById(id).value !== lastGenValues[id]);
     const isRebuild = genBtn.classList.contains('stale') && state.curData && !plateChanged;
     const seed = isRebuild ? state.curData.seed : undefined;
     const toggles = isRebuild ? getToggledIndices() : [];
@@ -489,6 +524,10 @@ function updatePlanetCode(flash) {
         +document.getElementById('sTEr').value,
         +document.getElementById('sRs').value,
         0.75,
+        +document.getElementById('sCsv').value,
+        +document.getElementById('sTmp').value,
+        +document.getElementById('sPrc').value,
+        +document.getElementById('sLc').value,
         getToggledIndices()
     );
     currentCode = code;
@@ -553,6 +592,18 @@ seedInput.addEventListener('input', () => {
 
 const seedError = document.getElementById('seedError');
 
+function paramsToSliderMap(params) {
+    return {
+        sN: sliderFromDetail(params.N), sJ: params.jitter, sP: params.P,
+        sCn: params.numContinents, sNs: params.roughness,
+        sCsv: params.continentSizeVariety, sLc: params.landCoverage,
+        sTw: params.terrainWarp, sS: params.smoothing, sGl: params.glacialErosion,
+        sHEr: params.hydraulicErosion, sTEr: params.thermalErosion,
+        sRs: params.ridgeSharpening, sTmp: params.temperatureOffset,
+        sPrc: params.precipitationOffset,
+    };
+}
+
 function applyCode(code) {
     const params = decodePlanetCode(code);
     if (!params) {
@@ -563,7 +614,7 @@ function applyCode(code) {
     }
     seedError.classList.remove('visible');
     // Set slider values + fire input events to update displays
-    const map = { sN: sliderFromDetail(params.N), sJ: params.jitter, sP: params.P, sCn: params.numContinents, sNs: params.roughness, sTw: params.terrainWarp, sS: params.smoothing, sGl: params.glacialErosion, sHEr: params.hydraulicErosion, sTEr: params.thermalErosion, sRs: params.ridgeSharpening };
+    const map = paramsToSliderMap(params);
     for (const [id, val] of Object.entries(map)) {
         const el = document.getElementById(id);
         el.value = val;
@@ -1268,7 +1319,7 @@ window.takePreview = function(width = 1200, height = 630) {
 const hashCode = location.hash.replace(/^#/, '').trim();
 const hashParams = hashCode ? decodePlanetCode(hashCode) : null;
 if (hashParams) {
-    const map = { sN: sliderFromDetail(hashParams.N), sJ: hashParams.jitter, sP: hashParams.P, sCn: hashParams.numContinents, sNs: hashParams.roughness, sTw: hashParams.terrainWarp, sS: hashParams.smoothing, sGl: hashParams.glacialErosion, sHEr: hashParams.hydraulicErosion, sTEr: hashParams.thermalErosion, sRs: hashParams.ridgeSharpening };
+    const map = paramsToSliderMap(hashParams);
     for (const [id, val] of Object.entries(map)) {
         const el = document.getElementById(id);
         el.value = val;

--- a/js/ocean-land.js
+++ b/js/ocean-land.js
@@ -4,7 +4,7 @@
 
 import { makeRng } from './rng.js';
 
-export function assignOceanLand(mesh, r_plate, plateSeeds, r_xyz, seed, numContinents) {
+export function assignOceanLand(mesh, r_plate, plateSeeds, r_xyz, seed, numContinents, continentSizeVariety = 0, landCoverage = 0.3) {
     const rng = makeRng(seed + 42);
     const numRegions = mesh.numRegions;
     const plateIds = Array.from(plateSeeds);
@@ -62,7 +62,7 @@ export function assignOceanLand(mesh, r_plate, plateSeeds, r_xyz, seed, numConti
         for (const pid of plateIds) plateCompact[pid] /= maxCompact;
     }
 
-    const targetLandArea = 0.3 * numRegions;
+    const targetLandArea = landCoverage * numRegions;
 
     // 3. Pick continent seeds via farthest-point sampling
     const effectiveNum = Math.min(numContinents, numPlates);
@@ -85,7 +85,8 @@ export function assignOceanLand(mesh, r_plate, plateSeeds, r_xyz, seed, numConti
                 const d = dx*dx + dy*dy + dz*dz;
                 if (d < minDist) minDist = d;
             }
-            const areaFactor = Math.sqrt(numRegions / numPlates) / Math.sqrt(plateArea[pid] || 1);
+            const rawAreaFactor = Math.sqrt(numRegions / numPlates) / Math.sqrt(plateArea[pid] || 1);
+            const areaFactor = 1 + (rawAreaFactor - 1) * (1 - continentSizeVariety * 0.5);
             const compact = 0.3 + 0.7 * plateCompact[pid];
             candidates.push({ pid, score: minDist * areaFactor * compact });
         }
@@ -117,13 +118,40 @@ export function assignOceanLand(mesh, r_plate, plateSeeds, r_xyz, seed, numConti
     }
     let landArea = seedArea;
 
-    // 5. Round-robin growth
+    // 5. Round-robin growth with per-continent targets
     const growTarget = targetLandArea * 0.9;
+    const numC = continentSeeds.length;
+
+    // Per-continent growth targets: at variety=0 all equal, at variety=1 highly skewed
+    const continentTarget = new Float64Array(numC);
+    const continentArea = new Float64Array(numC);
+    for (let c = 0; c < numC; c++) {
+        continentArea[c] = plateArea[continentSeeds[c]];
+    }
+
+    if (continentSizeVariety > 0 && numC > 1) {
+        const weights = [];
+        for (let c = 0; c < numC; c++) {
+            // Log-normal-ish: at variety=1, weights span ~0.3x to ~3.5x (12:1 ratio)
+            const logWeight = (rng() - 0.5) * continentSizeVariety * 2.5;
+            weights.push(Math.exp(logWeight));
+        }
+        const totalWeight = weights.reduce((a, b) => a + b, 0);
+        for (let c = 0; c < numC; c++) {
+            continentTarget[c] = growTarget * weights[c] / totalWeight;
+        }
+    } else {
+        const equal = growTarget / Math.max(numC, 1);
+        for (let c = 0; c < numC; c++) continentTarget[c] = equal;
+    }
 
     let progress = true;
     while (progress && landArea < growTarget) {
         progress = false;
-        for (let c = 0; c < continentSeeds.length && landArea < growTarget; c++) {
+        for (let c = 0; c < numC && landArea < growTarget; c++) {
+            // Skip continents that have reached their individual target
+            if (continentArea[c] >= continentTarget[c]) continue;
+
             const candidates = [];
             for (const pid of plateIds) {
                 if (plateContinent[pid] !== undefined) continue;
@@ -145,6 +173,7 @@ export function assignOceanLand(mesh, r_plate, plateSeeds, r_xyz, seed, numConti
             const pick = candidates[Math.floor(rng() * topK)];
 
             plateContinent[pick.pid] = c;
+            continentArea[c] += plateArea[pick.pid];
             landArea += plateArea[pick.pid];
             progress = true;
         }

--- a/js/planet-code.js
+++ b/js/planet-code.js
@@ -15,12 +15,18 @@ const SLIDERS = [
     { min: 0,     step: 0.05, count: 21  }, // Ridge Sharpening
     { min: 0,     step: 0.05, count: 21  }, // Soil Creep
     { min: 0,     step: 0.05, count: 21  }, // Terrain Warp
+    { min: 0,     step: 0.05, count: 21  }, // 12: Continent Size Variety
+    { min: -15,   step: 1,    count: 31  }, // 13: Temperature
+    { min: -1,    step: 0.1,  count: 21  }, // 14: Precipitation
+    { min: 0,     step: 0.01, count: 101 }, // 15: Land Coverage
 ];
 
-// Mixed-radix bases (right-to-left): twIdx, scIdx, rsIdx, teIdx, heIdx, glIdx, smIdx, nsIdx, cnIdx, pIdx, jIdx, nIdx, seed
-const RADICES = [21, 21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2556];
+// Mixed-radix bases (right-to-left): lcIdx, prcIdx, tmpIdx, csvIdx, twIdx, scIdx, rsIdx, teIdx, heIdx, glIdx, smIdx, nsIdx, cnIdx, pIdx, jIdx, nIdx, seed
+const RADICES = [101, 21, 31, 21, 21, 21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2556];
 const SEED_MAX = 16777216; // 2^24
-const BASE_LEN = 18; // base code length (no toggles)
+const BASE_LEN = 22; // base code length (no toggles)
+const PREV5_LEN = 21; // previous 21-char codes (before land coverage)
+const PREV4_LEN = 18; // previous 18-char codes (before continent variety/temp/precip)
 const PREV3_LEN = 17; // previous 17-char codes (before terrain warp)
 const PREV2_LEN = 16; // previous 16-char codes (before glacial erosion)
 const PREV_LEN = 14; // previous 14-char codes (before ridge/creep)
@@ -38,6 +44,12 @@ const PREV2_RADICES = [21, 21, 21, 21, 21, 51, 10, 117, 21, 2559];
 
 // Previous3-gen radices for decoding 17-char codes (no terrain warp)
 const PREV3_RADICES = [21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2559];
+
+// Previous5-gen radices for decoding 21-char codes (before land coverage)
+const PREV5_RADICES = [21, 31, 21, 21, 21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2556];
+
+// Previous4-gen radices for decoding 18-char codes (before continent variety/temp/precip)
+const PREV4_RADICES = [21, 21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2556];
 
 function toIndex(value, slider) {
     return Math.round((value - slider.min) / slider.step);
@@ -59,6 +71,107 @@ function parseBase36(str) {
     }, 0n);
 }
 
+// Decode format configs: one entry per code length.
+// fields: [fieldName, SLIDERS_index] in LSB-first extraction order.
+// defaults: field values not encoded in this format.
+const DECODE_FORMATS = {
+    [LEGACY_LEN]: {
+        radices: LEGACY_RADICES,
+        fields: [
+            ['hydraulicErosion', 7], ['smoothing', 5], ['roughness', 4],
+            ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
+        ],
+        defaults: { terrainWarp: 0.5, glacialErosion: 0, thermalErosion: 0.1,
+                    ridgeSharpening: 0.35, soilCreep: 0.05, continentSizeVariety: 0,
+                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+    },
+    [PREV_LEN]: {
+        radices: PREV_RADICES,
+        fields: [
+            ['thermalErosion', 8], ['hydraulicErosion', 7], ['smoothing', 5], ['roughness', 4],
+            ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
+        ],
+        defaults: { terrainWarp: 0.5, glacialErosion: 0, ridgeSharpening: 0.35,
+                    soilCreep: 0.05, continentSizeVariety: 0,
+                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+    },
+    [PREV2_LEN]: {
+        radices: PREV2_RADICES,
+        fields: [
+            ['soilCreep', 10], ['ridgeSharpening', 9], ['thermalErosion', 8], ['hydraulicErosion', 7],
+            ['smoothing', 5], ['roughness', 4], ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
+        ],
+        defaults: { terrainWarp: 0.5, glacialErosion: 0, continentSizeVariety: 0,
+                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+    },
+    [PREV3_LEN]: {
+        radices: PREV3_RADICES,
+        fields: [
+            ['soilCreep', 10], ['ridgeSharpening', 9], ['thermalErosion', 8], ['hydraulicErosion', 7],
+            ['glacialErosion', 6], ['smoothing', 5], ['roughness', 4],
+            ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
+        ],
+        defaults: { terrainWarp: 0.5, continentSizeVariety: 0,
+                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+    },
+    [PREV4_LEN]: {
+        radices: PREV4_RADICES,
+        fields: [
+            ['terrainWarp', 11], ['soilCreep', 10], ['ridgeSharpening', 9],
+            ['thermalErosion', 8], ['hydraulicErosion', 7], ['glacialErosion', 6],
+            ['smoothing', 5], ['roughness', 4], ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
+        ],
+        defaults: { continentSizeVariety: 0, temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+    },
+    [PREV5_LEN]: {
+        radices: PREV5_RADICES,
+        fields: [
+            ['precipitationOffset', 14], ['temperatureOffset', 13], ['continentSizeVariety', 12],
+            ['terrainWarp', 11], ['soilCreep', 10], ['ridgeSharpening', 9],
+            ['thermalErosion', 8], ['hydraulicErosion', 7], ['glacialErosion', 6],
+            ['smoothing', 5], ['roughness', 4], ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
+        ],
+        defaults: { landCoverage: 0.3 }
+    },
+    [BASE_LEN]: {
+        radices: RADICES,
+        fields: [
+            ['landCoverage', 15], ['precipitationOffset', 14], ['temperatureOffset', 13],
+            ['continentSizeVariety', 12], ['terrainWarp', 11], ['soilCreep', 10], ['ridgeSharpening', 9],
+            ['thermalErosion', 8], ['hydraulicErosion', 7], ['glacialErosion', 6],
+            ['smoothing', 5], ['roughness', 4], ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
+        ],
+        defaults: {}
+    },
+};
+
+/** Generic mixed-radix decode: extract fields LSB-first, validate, convert, apply defaults. */
+function decodeFormat(packed, config, toggleStr) {
+    const { radices, fields, defaults } = config;
+    const result = {};
+    for (let i = 0; i < radices.length; i++) {
+        const [name, si] = fields[i];
+        const idx = Number(packed % BigInt(radices[i]));
+        packed = packed / BigInt(radices[i]);
+        if (idx >= SLIDERS[si].count) return null;
+        result[name] = fromIndex(idx, SLIDERS[si]);
+    }
+    result.seed = Number(packed);
+    if (result.seed < 0 || result.seed >= SEED_MAX) return null;
+    Object.assign(result, defaults);
+
+    const toggledIndices = [];
+    if (toggleStr) {
+        for (let i = 0; i < toggleStr.length; i += IDX_CHARS) {
+            const idx = parseInt(toggleStr.slice(i, i + IDX_CHARS), 36);
+            if (isNaN(idx) || idx >= result.P) return null;
+            toggledIndices.push(idx);
+        }
+    }
+    result.toggledIndices = toggledIndices;
+    return result;
+}
+
 /**
  * Encode planet parameters into a base36 planet code.
  * @param {number} seed - Integer seed 0–16777215
@@ -74,10 +187,14 @@ function parseBase36(str) {
  * @param {number} thermalErosion - Thermal Erosion (0–1, step 0.05)
  * @param {number} ridgeSharpening - Ridge Sharpening (0–1, step 0.05)
  * @param {number} soilCreep - Soil Creep (0–1, step 0.05)
+ * @param {number} continentSizeVariety - Continent Size Variety (0–1, step 0.05)
+ * @param {number} temperatureOffset - Temperature offset (-15–15, step 1)
+ * @param {number} precipitationOffset - Precipitation offset (-1–1, step 0.1)
+ * @param {number} landCoverage - Land Coverage (0–1, step 0.05)
  * @param {number[]} [toggledIndices=[]] - Sorted array of toggled plate indices
- * @returns {string} base36 code (18 chars without edits, 18 + '-' + 2*k with k edits)
+ * @returns {string} base36 code (22 chars without edits, 22 + '-' + 2*k with k edits)
  */
-export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, terrainWarp, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, soilCreep, toggledIndices = []) {
+export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, terrainWarp, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, soilCreep, continentSizeVariety, temperatureOffset, precipitationOffset, landCoverage, toggledIndices = []) {
     const nIdx  = toIndex(N, SLIDERS[0]);
     const jIdx  = toIndex(jitter, SLIDERS[1]);
     const pIdx  = toIndex(P, SLIDERS[2]);
@@ -90,21 +207,29 @@ export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, t
     const rsIdx = toIndex(ridgeSharpening, SLIDERS[9]);
     const scIdx = toIndex(soilCreep, SLIDERS[10]);
     const twIdx = toIndex(terrainWarp, SLIDERS[11]);
+    const csvIdx = toIndex(continentSizeVariety, SLIDERS[12]);
+    const tmpIdx = toIndex(temperatureOffset, SLIDERS[13]);
+    const prcIdx = toIndex(precipitationOffset, SLIDERS[14]);
+    const lcIdx  = toIndex(landCoverage, SLIDERS[15]);
 
-    // Mixed-radix packing (least-significant first: twIdx, scIdx, rsIdx, teIdx, ...)
+    // Mixed-radix packing (least-significant first: lcIdx, prcIdx, tmpIdx, csvIdx, twIdx, ...)
     let packed = BigInt(seed);
-    packed = packed * BigInt(RADICES[11]) + BigInt(nIdx);   // * 2559
-    packed = packed * BigInt(RADICES[10]) + BigInt(jIdx);   // * 21
-    packed = packed * BigInt(RADICES[9])  + BigInt(pIdx);   // * 117
-    packed = packed * BigInt(RADICES[8])  + BigInt(cnIdx);  // * 10
-    packed = packed * BigInt(RADICES[7])  + BigInt(nsIdx);  // * 51
-    packed = packed * BigInt(RADICES[6])  + BigInt(smIdx);  // * 21
-    packed = packed * BigInt(RADICES[5])  + BigInt(glIdx);  // * 21
-    packed = packed * BigInt(RADICES[4])  + BigInt(heIdx);  // * 21
-    packed = packed * BigInt(RADICES[3])  + BigInt(teIdx);  // * 21
-    packed = packed * BigInt(RADICES[2])  + BigInt(rsIdx);  // * 21
-    packed = packed * BigInt(RADICES[1])  + BigInt(scIdx);  // * 21
-    packed = packed * BigInt(RADICES[0])  + BigInt(twIdx);  // * 21
+    packed = packed * BigInt(RADICES[15]) + BigInt(nIdx);    // * 2556
+    packed = packed * BigInt(RADICES[14]) + BigInt(jIdx);    // * 21
+    packed = packed * BigInt(RADICES[13]) + BigInt(pIdx);    // * 117
+    packed = packed * BigInt(RADICES[12]) + BigInt(cnIdx);   // * 10
+    packed = packed * BigInt(RADICES[11]) + BigInt(nsIdx);   // * 51
+    packed = packed * BigInt(RADICES[10]) + BigInt(smIdx);   // * 21
+    packed = packed * BigInt(RADICES[9])  + BigInt(glIdx);   // * 21
+    packed = packed * BigInt(RADICES[8])  + BigInt(heIdx);   // * 21
+    packed = packed * BigInt(RADICES[7])  + BigInt(teIdx);   // * 21
+    packed = packed * BigInt(RADICES[6])  + BigInt(rsIdx);   // * 21
+    packed = packed * BigInt(RADICES[5])  + BigInt(scIdx);   // * 21
+    packed = packed * BigInt(RADICES[4])  + BigInt(twIdx);   // * 21
+    packed = packed * BigInt(RADICES[3])  + BigInt(csvIdx);  // * 21
+    packed = packed * BigInt(RADICES[2])  + BigInt(tmpIdx);  // * 31
+    packed = packed * BigInt(RADICES[1])  + BigInt(prcIdx);  // * 21
+    packed = packed * BigInt(RADICES[0])  + BigInt(lcIdx);   // * 21
 
     let code = packed.toString(36).padStart(BASE_LEN, '0');
 
@@ -120,9 +245,9 @@ export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, t
 
 /**
  * Decode a base36 planet code back into planet parameters.
- * Supports 18-char (current), 17-char (prev3), 16-char (prev2), 14-char (previous-gen), and 13-char (legacy) codes.
- * @param {string} code - base36 code (13, 14, 16, 17, or 18 chars, optionally followed by "-" + toggle indices)
- * @returns {{ seed: number, N: number, jitter: number, P: number, numContinents: number, roughness: number, terrainWarp: number, smoothing: number, glacialErosion: number, hydraulicErosion: number, thermalErosion: number, ridgeSharpening: number, soilCreep: number, toggledIndices: number[] } | null}
+ * Supports 22-char (current), 21-char (prev5), 18-char (prev4), 17-char (prev3), 16-char (prev2), 14-char (previous-gen), and 13-char (legacy) codes.
+ * @param {string} code - base36 code (13, 14, 16, 17, 18, 21, or 22 chars, optionally followed by "-" + toggle indices)
+ * @returns {{ seed: number, N: number, jitter: number, P: number, numContinents: number, roughness: number, terrainWarp: number, smoothing: number, glacialErosion: number, hydraulicErosion: number, thermalErosion: number, ridgeSharpening: number, soilCreep: number, continentSizeVariety: number, temperatureOffset: number, precipitationOffset: number, landCoverage: number, toggledIndices: number[] } | null}
  */
 export function decodePlanetCode(code) {
     if (typeof code !== 'string') return null;
@@ -133,12 +258,8 @@ export function decodePlanetCode(code) {
     const base = dashIdx === -1 ? code : code.slice(0, dashIdx);
     const toggleStr = dashIdx === -1 ? '' : code.slice(dashIdx + 1);
 
-    const isLegacy = base.length === LEGACY_LEN;
-    const isPrev = base.length === PREV_LEN;
-    const isPrev2 = base.length === PREV2_LEN;
-    const isPrev3 = base.length === PREV3_LEN;
-    const isNew = base.length === BASE_LEN;
-    if (!isLegacy && !isPrev && !isPrev2 && !isPrev3 && !isNew) return null;
+    const config = DECODE_FORMATS[base.length];
+    if (!config) return null;
     if (!/^[0-9a-z]+$/.test(base)) return null;
     if (toggleStr && !/^[0-9a-z]+$/.test(toggleStr)) return null;
     if (toggleStr && toggleStr.length % IDX_CHARS !== 0) return null;
@@ -150,347 +271,5 @@ export function decodePlanetCode(code) {
         return null;
     }
 
-    if (isLegacy) {
-        // Legacy 13-char decode: single erosion slider
-        const erIdx = Number(packed % BigInt(LEGACY_RADICES[0]));
-        packed = packed / BigInt(LEGACY_RADICES[0]);
-
-        const smIdx = Number(packed % BigInt(LEGACY_RADICES[1]));
-        packed = packed / BigInt(LEGACY_RADICES[1]);
-
-        const nsIdx = Number(packed % BigInt(LEGACY_RADICES[2]));
-        packed = packed / BigInt(LEGACY_RADICES[2]);
-
-        const cnIdx = Number(packed % BigInt(LEGACY_RADICES[3]));
-        packed = packed / BigInt(LEGACY_RADICES[3]);
-
-        const pIdx = Number(packed % BigInt(LEGACY_RADICES[4]));
-        packed = packed / BigInt(LEGACY_RADICES[4]);
-
-        const jIdx = Number(packed % BigInt(LEGACY_RADICES[5]));
-        packed = packed / BigInt(LEGACY_RADICES[5]);
-
-        const nIdx = Number(packed % BigInt(LEGACY_RADICES[6]));
-        packed = packed / BigInt(LEGACY_RADICES[6]);
-
-        const seed = Number(packed);
-
-        if (seed < 0 || seed >= SEED_MAX) return null;
-        if (nIdx >= SLIDERS[0].count || jIdx >= SLIDERS[1].count ||
-            pIdx >= SLIDERS[2].count || cnIdx >= SLIDERS[3].count ||
-            nsIdx >= SLIDERS[4].count || smIdx >= SLIDERS[5].count ||
-            erIdx >= SLIDERS[7].count) return null;
-
-        const P = fromIndex(pIdx, SLIDERS[2]);
-
-        const toggledIndices = [];
-        if (toggleStr) {
-            for (let i = 0; i < toggleStr.length; i += IDX_CHARS) {
-                const idx = parseInt(toggleStr.slice(i, i + IDX_CHARS), 36);
-                if (isNaN(idx) || idx >= P) return null;
-                toggledIndices.push(idx);
-            }
-        }
-
-        return {
-            seed,
-            N:                fromIndex(nIdx, SLIDERS[0]),
-            jitter:           fromIndex(jIdx, SLIDERS[1]),
-            P,
-            numContinents:    fromIndex(cnIdx, SLIDERS[3]),
-            roughness:        fromIndex(nsIdx, SLIDERS[4]),
-            terrainWarp:      0.5,
-            smoothing:        fromIndex(smIdx, SLIDERS[5]),
-            glacialErosion:   0,
-            hydraulicErosion: fromIndex(erIdx, SLIDERS[7]), // map old erosion → hydraulic
-            thermalErosion:   0.1,                          // default for legacy codes
-            ridgeSharpening:  0.35,
-            soilCreep:        0.05,
-            toggledIndices,
-        };
-    }
-
-    if (isPrev) {
-        // Previous-gen 14-char decode: two erosion sliders, no ridge/creep/glacial
-        const teIdx = Number(packed % BigInt(PREV_RADICES[0]));
-        packed = packed / BigInt(PREV_RADICES[0]);
-
-        const heIdx = Number(packed % BigInt(PREV_RADICES[1]));
-        packed = packed / BigInt(PREV_RADICES[1]);
-
-        const smIdx = Number(packed % BigInt(PREV_RADICES[2]));
-        packed = packed / BigInt(PREV_RADICES[2]);
-
-        const nsIdx = Number(packed % BigInt(PREV_RADICES[3]));
-        packed = packed / BigInt(PREV_RADICES[3]);
-
-        const cnIdx = Number(packed % BigInt(PREV_RADICES[4]));
-        packed = packed / BigInt(PREV_RADICES[4]);
-
-        const pIdx = Number(packed % BigInt(PREV_RADICES[5]));
-        packed = packed / BigInt(PREV_RADICES[5]);
-
-        const jIdx = Number(packed % BigInt(PREV_RADICES[6]));
-        packed = packed / BigInt(PREV_RADICES[6]);
-
-        const nIdx = Number(packed % BigInt(PREV_RADICES[7]));
-        packed = packed / BigInt(PREV_RADICES[7]);
-
-        const seed = Number(packed);
-
-        if (seed < 0 || seed >= SEED_MAX) return null;
-        if (nIdx >= SLIDERS[0].count || jIdx >= SLIDERS[1].count ||
-            pIdx >= SLIDERS[2].count || cnIdx >= SLIDERS[3].count ||
-            nsIdx >= SLIDERS[4].count || smIdx >= SLIDERS[5].count ||
-            heIdx >= SLIDERS[7].count || teIdx >= SLIDERS[8].count) return null;
-
-        const P = fromIndex(pIdx, SLIDERS[2]);
-
-        const toggledIndices = [];
-        if (toggleStr) {
-            for (let i = 0; i < toggleStr.length; i += IDX_CHARS) {
-                const idx = parseInt(toggleStr.slice(i, i + IDX_CHARS), 36);
-                if (isNaN(idx) || idx >= P) return null;
-                toggledIndices.push(idx);
-            }
-        }
-
-        return {
-            seed,
-            N:                fromIndex(nIdx, SLIDERS[0]),
-            jitter:           fromIndex(jIdx, SLIDERS[1]),
-            P,
-            numContinents:    fromIndex(cnIdx, SLIDERS[3]),
-            roughness:        fromIndex(nsIdx, SLIDERS[4]),
-            terrainWarp:      0.5,
-            smoothing:        fromIndex(smIdx, SLIDERS[5]),
-            glacialErosion:   0,
-            hydraulicErosion: fromIndex(heIdx, SLIDERS[7]),
-            thermalErosion:   fromIndex(teIdx, SLIDERS[8]),
-            ridgeSharpening:  0.35,
-            soilCreep:        0.05,
-            toggledIndices,
-        };
-    }
-
-    if (isPrev2) {
-        // Previous2-gen 16-char decode: all sliders except glacial erosion
-        const scIdx = Number(packed % BigInt(PREV2_RADICES[0]));
-        packed = packed / BigInt(PREV2_RADICES[0]);
-
-        const rsIdx = Number(packed % BigInt(PREV2_RADICES[1]));
-        packed = packed / BigInt(PREV2_RADICES[1]);
-
-        const teIdx = Number(packed % BigInt(PREV2_RADICES[2]));
-        packed = packed / BigInt(PREV2_RADICES[2]);
-
-        const heIdx = Number(packed % BigInt(PREV2_RADICES[3]));
-        packed = packed / BigInt(PREV2_RADICES[3]);
-
-        const smIdx = Number(packed % BigInt(PREV2_RADICES[4]));
-        packed = packed / BigInt(PREV2_RADICES[4]);
-
-        const nsIdx = Number(packed % BigInt(PREV2_RADICES[5]));
-        packed = packed / BigInt(PREV2_RADICES[5]);
-
-        const cnIdx = Number(packed % BigInt(PREV2_RADICES[6]));
-        packed = packed / BigInt(PREV2_RADICES[6]);
-
-        const pIdx = Number(packed % BigInt(PREV2_RADICES[7]));
-        packed = packed / BigInt(PREV2_RADICES[7]);
-
-        const jIdx = Number(packed % BigInt(PREV2_RADICES[8]));
-        packed = packed / BigInt(PREV2_RADICES[8]);
-
-        const nIdx = Number(packed % BigInt(PREV2_RADICES[9]));
-        packed = packed / BigInt(PREV2_RADICES[9]);
-
-        const seed = Number(packed);
-
-        if (seed < 0 || seed >= SEED_MAX) return null;
-        if (nIdx >= SLIDERS[0].count || jIdx >= SLIDERS[1].count ||
-            pIdx >= SLIDERS[2].count || cnIdx >= SLIDERS[3].count ||
-            nsIdx >= SLIDERS[4].count || smIdx >= SLIDERS[5].count ||
-            heIdx >= SLIDERS[7].count || teIdx >= SLIDERS[8].count ||
-            rsIdx >= SLIDERS[9].count || scIdx >= SLIDERS[10].count) return null;
-
-        const P = fromIndex(pIdx, SLIDERS[2]);
-
-        const toggledIndices = [];
-        if (toggleStr) {
-            for (let i = 0; i < toggleStr.length; i += IDX_CHARS) {
-                const idx = parseInt(toggleStr.slice(i, i + IDX_CHARS), 36);
-                if (isNaN(idx) || idx >= P) return null;
-                toggledIndices.push(idx);
-            }
-        }
-
-        return {
-            seed,
-            N:                fromIndex(nIdx, SLIDERS[0]),
-            jitter:           fromIndex(jIdx, SLIDERS[1]),
-            P,
-            numContinents:    fromIndex(cnIdx, SLIDERS[3]),
-            roughness:        fromIndex(nsIdx, SLIDERS[4]),
-            terrainWarp:      0.5,
-            smoothing:        fromIndex(smIdx, SLIDERS[5]),
-            glacialErosion:   0,
-            hydraulicErosion: fromIndex(heIdx, SLIDERS[7]),
-            thermalErosion:   fromIndex(teIdx, SLIDERS[8]),
-            ridgeSharpening:  fromIndex(rsIdx, SLIDERS[9]),
-            soilCreep:        fromIndex(scIdx, SLIDERS[10]),
-            toggledIndices,
-        };
-    }
-
-    if (isPrev3) {
-        // Previous3-gen 17-char decode: all sliders except terrain warp
-        const scIdx = Number(packed % BigInt(PREV3_RADICES[0]));
-        packed = packed / BigInt(PREV3_RADICES[0]);
-
-        const rsIdx = Number(packed % BigInt(PREV3_RADICES[1]));
-        packed = packed / BigInt(PREV3_RADICES[1]);
-
-        const teIdx = Number(packed % BigInt(PREV3_RADICES[2]));
-        packed = packed / BigInt(PREV3_RADICES[2]);
-
-        const heIdx = Number(packed % BigInt(PREV3_RADICES[3]));
-        packed = packed / BigInt(PREV3_RADICES[3]);
-
-        const glIdx = Number(packed % BigInt(PREV3_RADICES[4]));
-        packed = packed / BigInt(PREV3_RADICES[4]);
-
-        const smIdx = Number(packed % BigInt(PREV3_RADICES[5]));
-        packed = packed / BigInt(PREV3_RADICES[5]);
-
-        const nsIdx = Number(packed % BigInt(PREV3_RADICES[6]));
-        packed = packed / BigInt(PREV3_RADICES[6]);
-
-        const cnIdx = Number(packed % BigInt(PREV3_RADICES[7]));
-        packed = packed / BigInt(PREV3_RADICES[7]);
-
-        const pIdx = Number(packed % BigInt(PREV3_RADICES[8]));
-        packed = packed / BigInt(PREV3_RADICES[8]);
-
-        const jIdx = Number(packed % BigInt(PREV3_RADICES[9]));
-        packed = packed / BigInt(PREV3_RADICES[9]);
-
-        const nIdx = Number(packed % BigInt(PREV3_RADICES[10]));
-        packed = packed / BigInt(PREV3_RADICES[10]);
-
-        const seed = Number(packed);
-
-        if (seed < 0 || seed >= SEED_MAX) return null;
-        if (nIdx >= SLIDERS[0].count || jIdx >= SLIDERS[1].count ||
-            pIdx >= SLIDERS[2].count || cnIdx >= SLIDERS[3].count ||
-            nsIdx >= SLIDERS[4].count || smIdx >= SLIDERS[5].count ||
-            glIdx >= SLIDERS[6].count || heIdx >= SLIDERS[7].count ||
-            teIdx >= SLIDERS[8].count || rsIdx >= SLIDERS[9].count ||
-            scIdx >= SLIDERS[10].count) return null;
-
-        const P = fromIndex(pIdx, SLIDERS[2]);
-
-        const toggledIndices = [];
-        if (toggleStr) {
-            for (let i = 0; i < toggleStr.length; i += IDX_CHARS) {
-                const idx = parseInt(toggleStr.slice(i, i + IDX_CHARS), 36);
-                if (isNaN(idx) || idx >= P) return null;
-                toggledIndices.push(idx);
-            }
-        }
-
-        return {
-            seed,
-            N:                fromIndex(nIdx, SLIDERS[0]),
-            jitter:           fromIndex(jIdx, SLIDERS[1]),
-            P,
-            numContinents:    fromIndex(cnIdx, SLIDERS[3]),
-            roughness:        fromIndex(nsIdx, SLIDERS[4]),
-            terrainWarp:      0.5,
-            smoothing:        fromIndex(smIdx, SLIDERS[5]),
-            glacialErosion:   fromIndex(glIdx, SLIDERS[6]),
-            hydraulicErosion: fromIndex(heIdx, SLIDERS[7]),
-            thermalErosion:   fromIndex(teIdx, SLIDERS[8]),
-            ridgeSharpening:  fromIndex(rsIdx, SLIDERS[9]),
-            soilCreep:        fromIndex(scIdx, SLIDERS[10]),
-            toggledIndices,
-        };
-    }
-
-    // New 18-char decode: all sliders including terrain warp
-    const twIdx = Number(packed % BigInt(RADICES[0]));
-    packed = packed / BigInt(RADICES[0]);
-
-    const scIdx = Number(packed % BigInt(RADICES[1]));
-    packed = packed / BigInt(RADICES[1]);
-
-    const rsIdx = Number(packed % BigInt(RADICES[2]));
-    packed = packed / BigInt(RADICES[2]);
-
-    const teIdx = Number(packed % BigInt(RADICES[3]));
-    packed = packed / BigInt(RADICES[3]);
-
-    const heIdx = Number(packed % BigInt(RADICES[4]));
-    packed = packed / BigInt(RADICES[4]);
-
-    const glIdx = Number(packed % BigInt(RADICES[5]));
-    packed = packed / BigInt(RADICES[5]);
-
-    const smIdx = Number(packed % BigInt(RADICES[6]));
-    packed = packed / BigInt(RADICES[6]);
-
-    const nsIdx = Number(packed % BigInt(RADICES[7]));
-    packed = packed / BigInt(RADICES[7]);
-
-    const cnIdx = Number(packed % BigInt(RADICES[8]));
-    packed = packed / BigInt(RADICES[8]);
-
-    const pIdx = Number(packed % BigInt(RADICES[9]));
-    packed = packed / BigInt(RADICES[9]);
-
-    const jIdx = Number(packed % BigInt(RADICES[10]));
-    packed = packed / BigInt(RADICES[10]);
-
-    const nIdx = Number(packed % BigInt(RADICES[11]));
-    packed = packed / BigInt(RADICES[11]);
-
-    const seed = Number(packed);
-
-    // Validate ranges
-    if (seed < 0 || seed >= SEED_MAX) return null;
-    if (nIdx >= SLIDERS[0].count || jIdx >= SLIDERS[1].count ||
-        pIdx >= SLIDERS[2].count || cnIdx >= SLIDERS[3].count ||
-        nsIdx >= SLIDERS[4].count || smIdx >= SLIDERS[5].count ||
-        glIdx >= SLIDERS[6].count || heIdx >= SLIDERS[7].count ||
-        teIdx >= SLIDERS[8].count || rsIdx >= SLIDERS[9].count ||
-        scIdx >= SLIDERS[10].count || twIdx >= SLIDERS[11].count) return null;
-
-    const P = fromIndex(pIdx, SLIDERS[2]);
-
-    // Decode toggled plate indices
-    const toggledIndices = [];
-    if (toggleStr) {
-        for (let i = 0; i < toggleStr.length; i += IDX_CHARS) {
-            const idx = parseInt(toggleStr.slice(i, i + IDX_CHARS), 36);
-            if (isNaN(idx) || idx >= P) return null;
-            toggledIndices.push(idx);
-        }
-    }
-
-    return {
-        seed,
-        N:                fromIndex(nIdx, SLIDERS[0]),
-        jitter:           fromIndex(jIdx, SLIDERS[1]),
-        P,
-        numContinents:    fromIndex(cnIdx, SLIDERS[3]),
-        roughness:        fromIndex(nsIdx, SLIDERS[4]),
-        terrainWarp:      fromIndex(twIdx, SLIDERS[11]),
-        smoothing:        fromIndex(smIdx, SLIDERS[5]),
-        glacialErosion:   fromIndex(glIdx, SLIDERS[6]),
-        hydraulicErosion: fromIndex(heIdx, SLIDERS[7]),
-        thermalErosion:   fromIndex(teIdx, SLIDERS[8]),
-        ridgeSharpening:  fromIndex(rsIdx, SLIDERS[9]),
-        soilCreep:        fromIndex(scIdx, SLIDERS[10]),
-        toggledIndices,
-    };
+    return decodeFormat(packed, config, toggleStr);
 }

--- a/js/planet-worker.js
+++ b/js/planet-worker.js
@@ -36,14 +36,14 @@ function computeTriangleElevations(mesh, r_elevation) {
 }
 
 // Run terrain post-processing with per-step timing
-function runPostProcessing(mesh, r_xyz, r_elevation, params, neighborDist, seed) {
+function runPostProcessing(mesh, r_xyz, r_elevation, params, neighborDist, seed, r_hotspot) {
     const { smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, terrainWarp } = params;
     const timing = [];
 
     // Terrain warp — first step, before ocean detection or smoothing
     if (terrainWarp > 0) {
         const t0 = performance.now();
-        warpTerrain(mesh, r_elevation, r_xyz, seed, terrainWarp);
+        warpTerrain(mesh, r_elevation, r_xyz, seed, terrainWarp, r_hotspot);
         timing.push({ stage: `Terrain warp (strength=${terrainWarp.toFixed(2)})`, ms: performance.now() - t0 });
     }
 
@@ -65,7 +65,7 @@ function runPostProcessing(mesh, r_xyz, r_elevation, params, neighborDist, seed)
     if (glacialErosion > 0 || hydraulicErosion > 0 || thermalErosion > 0) {
         const gIters = Math.round(glacialErosion * 10);
         const hIters = Math.round(hydraulicErosion * 20);
-        const hK = hydraulicErosion * 0.001;
+        const hK = hydraulicErosion * 0.0006;
         const tIters = Math.round(thermalErosion * 10);
         const talusSlope = 1.2 - thermalErosion * 0.4;
         const kThermal = thermalErosion * 0.15;
@@ -100,8 +100,40 @@ function runPostProcessing(mesh, r_xyz, r_elevation, params, neighborDist, seed)
     return { dl_erosionDelta, postTiming: timing };
 }
 
+function getClimateParams(data) {
+    const temperatureOffset = data?.temperatureOffset ?? W?.temperatureOffset ?? 0;
+    const precipitationOffset = data?.precipitationOffset ?? W?.precipitationOffset ?? 0;
+    const landCoverage = data?.landCoverage ?? W?.landCoverage ?? 0.3;
+    if (W) { W.temperatureOffset = temperatureOffset; W.precipitationOffset = precipitationOffset; W.landCoverage = landCoverage; }
+    return { temperatureOffset, precipitationOffset, landCoverage };
+}
+
+function buildClimateFields(windResult, oceanResult, precipResult, tempResult) {
+    return {
+        r_wind_east_summer: windResult?.r_wind_east_summer ?? null,
+        r_wind_north_summer: windResult?.r_wind_north_summer ?? null,
+        r_wind_east_winter: windResult?.r_wind_east_winter ?? null,
+        r_wind_north_winter: windResult?.r_wind_north_winter ?? null,
+        itczLons: windResult?.itczLons ?? null,
+        itczLatsSummer: windResult?.itczLatsSummer ?? null,
+        itczLatsWinter: windResult?.itczLatsWinter ?? null,
+        r_ocean_current_east_summer: oceanResult?.r_ocean_current_east_summer ?? null,
+        r_ocean_current_north_summer: oceanResult?.r_ocean_current_north_summer ?? null,
+        r_ocean_current_east_winter: oceanResult?.r_ocean_current_east_winter ?? null,
+        r_ocean_current_north_winter: oceanResult?.r_ocean_current_north_winter ?? null,
+        r_ocean_speed_summer: oceanResult?.r_ocean_speed_summer ?? null,
+        r_ocean_speed_winter: oceanResult?.r_ocean_speed_winter ?? null,
+        r_ocean_warmth_summer: oceanResult?.r_ocean_warmth_summer ?? null,
+        r_ocean_warmth_winter: oceanResult?.r_ocean_warmth_winter ?? null,
+        r_precip_summer: precipResult?.r_precip_summer ?? null,
+        r_precip_winter: precipResult?.r_precip_winter ?? null,
+        r_temperature_summer: tempResult?.r_temperature_summer ?? null,
+        r_temperature_winter: tempResult?.r_temperature_winter ?? null,
+    };
+}
+
 function handleGenerate(data) {
-    const { N, P, jitter, nMag, numContinents, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, terrainWarp, seed: overrideSeed, toggledIndices, skipClimate } = data;
+    const { N, P, jitter, nMag, numContinents, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, terrainWarp, continentSizeVariety = 0, temperatureOffset = 0, precipitationOffset = 0, landCoverage = 0.3, seed: overrideSeed, toggledIndices, skipClimate } = data;
     const spread = 5;
     const timing = []; // top-level pipeline timing
 
@@ -127,12 +159,12 @@ function handleGenerate(data) {
         progress(10, 'Generating coarse plates\u2026');
         t0 = performance.now();
         const { coarseMesh, coarse_xyz, coarse_r_plate, coarsePlateSeeds, coarsePlateVec, coarsePlateIsOcean } =
-            generateCoarsePlates(seed, P, numContinents);
+            generateCoarsePlates(seed, P, numContinents, continentSizeVariety, landCoverage);
         timing.push({ stage: `Coarse plates (${P} plates, ${numContinents} continents)`, ms: performance.now() - t0 });
 
         progress(20, 'Projecting plates\u2026');
         t0 = performance.now();
-        const r_plate = projectCoarsePlates(mesh, r_xyz, coarseMesh, coarse_xyz, coarse_r_plate, seed);
+        const r_plate = projectCoarsePlates(mesh, r_xyz, coarseMesh, coarse_xyz, coarse_r_plate, seed, P);
         timing.push({ stage: 'Project coarse → hi-res', ms: performance.now() - t0 });
 
         progress(25, 'Smoothing boundaries\u2026');
@@ -179,7 +211,7 @@ function handleGenerate(data) {
 
         progress(60, 'Eroding terrain\u2026');
         t0 = performance.now();
-        const { dl_erosionDelta, postTiming } = runPostProcessing(mesh, r_xyz, r_elevation, { smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, terrainWarp }, neighborDist, seed);
+        const { dl_erosionDelta, postTiming } = runPostProcessing(mesh, r_xyz, r_elevation, { smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, terrainWarp }, neighborDist, seed, debugLayers.hotspot);
         timing.push({ stage: 'Terrain post-processing (total)', ms: performance.now() - t0 });
         debugLayers.erosionDelta = dl_erosionDelta;
 
@@ -205,7 +237,7 @@ function handleGenerate(data) {
 
             progress(82, 'Computing precipitation\u2026');
             t0 = performance.now();
-            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult);
+            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage);
             timing.push({ stage: 'Precipitation', ms: performance.now() - t0 });
             if (precipResult._precipTiming) timing.push(...precipResult._precipTiming);
             debugLayers.precipSummer = precipResult.r_precip_summer;
@@ -215,7 +247,7 @@ function handleGenerate(data) {
 
             progress(86, 'Computing temperature\u2026');
             t0 = performance.now();
-            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult);
+            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset);
             timing.push({ stage: 'Temperature', ms: performance.now() - t0 });
             if (tempResult._tempTiming) timing.push(...tempResult._tempTiming);
             debugLayers.tempSummer = tempResult.r_temperature_summer;
@@ -245,7 +277,8 @@ function handleGenerate(data) {
             r_elevation_final: new Float32Array(r_elevation),
             seed, nMag, noise,
             mountain_r: new Set(mountain_r), coastline_r: new Set(coastline_r), ocean_r: new Set(ocean_r),
-            r_stress: new Float32Array(r_stress)
+            r_stress: new Float32Array(r_stress),
+            temperatureOffset, precipitationOffset, landCoverage
         };
         timing.push({ stage: 'Clone state for retention', ms: performance.now() - t0 });
 
@@ -270,25 +303,7 @@ function handleGenerate(data) {
             coastline_r: Array.from(coastline_r),
             ocean_r: Array.from(ocean_r),
             r_stress,
-            r_wind_east_summer: windResult ? windResult.r_wind_east_summer : null,
-            r_wind_north_summer: windResult ? windResult.r_wind_north_summer : null,
-            r_wind_east_winter: windResult ? windResult.r_wind_east_winter : null,
-            r_wind_north_winter: windResult ? windResult.r_wind_north_winter : null,
-            itczLons: windResult ? windResult.itczLons : null,
-            itczLatsSummer: windResult ? windResult.itczLatsSummer : null,
-            itczLatsWinter: windResult ? windResult.itczLatsWinter : null,
-            r_ocean_current_east_summer: oceanResult ? oceanResult.r_ocean_current_east_summer : null,
-            r_ocean_current_north_summer: oceanResult ? oceanResult.r_ocean_current_north_summer : null,
-            r_ocean_current_east_winter: oceanResult ? oceanResult.r_ocean_current_east_winter : null,
-            r_ocean_current_north_winter: oceanResult ? oceanResult.r_ocean_current_north_winter : null,
-            r_ocean_speed_summer: oceanResult ? oceanResult.r_ocean_speed_summer : null,
-            r_ocean_speed_winter: oceanResult ? oceanResult.r_ocean_speed_winter : null,
-            r_ocean_warmth_summer: oceanResult ? oceanResult.r_ocean_warmth_summer : null,
-            r_ocean_warmth_winter: oceanResult ? oceanResult.r_ocean_warmth_winter : null,
-            r_precip_summer: precipResult ? precipResult.r_precip_summer : null,
-            r_precip_winter: precipResult ? precipResult.r_precip_winter : null,
-            r_temperature_summer: tempResult ? tempResult.r_temperature_summer : null,
-            r_temperature_winter: tempResult ? tempResult.r_temperature_winter : null,
+            ...buildClimateFields(windResult, oceanResult, precipResult, tempResult),
             skipClimate: !!skipClimate,
             seed, nMag,
             debugLayers,
@@ -296,7 +311,7 @@ function handleGenerate(data) {
             _pipelineTiming: timing,          // top-level pipeline stages
             _postTiming: postTiming,          // post-processing sub-stages
             _workerTotal: tWorkerTotal,
-            _params: { N, P, jitter, nMag, numContinents, smoothing, terrainWarp, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, seed }
+            _params: { N, P, jitter, nMag, numContinents, smoothing, terrainWarp, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, continentSizeVariety, temperatureOffset, precipitationOffset, landCoverage, seed }
         };
 
         // Transfer arrays the worker no longer needs (cloned copies kept in W)
@@ -317,6 +332,7 @@ function handleReapply(data) {
     if (!W) { self.postMessage({ type: 'error', message: 'No retained state for reapply' }); return; }
 
     const skipClimate = !!data.skipClimate;
+    const { temperatureOffset, precipitationOffset, landCoverage } = getClimateParams(data);
 
     try {
         const tTotal0 = performance.now();
@@ -351,12 +367,12 @@ function handleReapply(data) {
 
             progress(80, 'Computing precipitation\u2026');
             t0 = performance.now();
-            precipResult = computePrecipitation(W.mesh, W.r_xyz, r_elevation, windResult, oceanResult);
+            precipResult = computePrecipitation(W.mesh, W.r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage);
             tPrecip = performance.now() - t0;
 
             progress(85, 'Computing temperature\u2026');
             t0 = performance.now();
-            tempResult = computeTemperature(W.mesh, W.r_xyz, r_elevation, windResult, oceanResult, precipResult);
+            tempResult = computeTemperature(W.mesh, W.r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset);
             tTemp = performance.now() - t0;
         }
 
@@ -373,25 +389,7 @@ function handleReapply(data) {
             r_elevation,
             t_elevation,
             erosionDelta: dl_erosionDelta,
-            r_wind_east_summer: windResult ? windResult.r_wind_east_summer : null,
-            r_wind_north_summer: windResult ? windResult.r_wind_north_summer : null,
-            r_wind_east_winter: windResult ? windResult.r_wind_east_winter : null,
-            r_wind_north_winter: windResult ? windResult.r_wind_north_winter : null,
-            itczLons: windResult ? windResult.itczLons : null,
-            itczLatsSummer: windResult ? windResult.itczLatsSummer : null,
-            itczLatsWinter: windResult ? windResult.itczLatsWinter : null,
-            r_ocean_current_east_summer: oceanResult ? oceanResult.r_ocean_current_east_summer : null,
-            r_ocean_current_north_summer: oceanResult ? oceanResult.r_ocean_current_north_summer : null,
-            r_ocean_current_east_winter: oceanResult ? oceanResult.r_ocean_current_east_winter : null,
-            r_ocean_current_north_winter: oceanResult ? oceanResult.r_ocean_current_north_winter : null,
-            r_ocean_speed_summer: oceanResult ? oceanResult.r_ocean_speed_summer : null,
-            r_ocean_speed_winter: oceanResult ? oceanResult.r_ocean_speed_winter : null,
-            r_ocean_warmth_summer: oceanResult ? oceanResult.r_ocean_warmth_summer : null,
-            r_ocean_warmth_winter: oceanResult ? oceanResult.r_ocean_warmth_winter : null,
-            r_precip_summer: precipResult ? precipResult.r_precip_summer : null,
-            r_precip_winter: precipResult ? precipResult.r_precip_winter : null,
-            r_temperature_summer: tempResult ? tempResult.r_temperature_summer : null,
-            r_temperature_winter: tempResult ? tempResult.r_temperature_winter : null,
+            ...buildClimateFields(windResult, oceanResult, precipResult, tempResult),
             windDebugLayers: windResult ? {
                 pressureSummer: windResult.r_pressure_summer,
                 pressureWinter: windResult.r_pressure_winter,
@@ -429,6 +427,7 @@ function handleEditRecompute(data) {
     if (!W) { self.postMessage({ type: 'error', message: 'No retained state for editRecompute' }); return; }
 
     const skipClimate = !!data.skipClimate;
+    const { temperatureOffset, precipitationOffset, landCoverage } = getClimateParams(data);
 
     try {
         const tTotal0 = performance.now();
@@ -452,7 +451,7 @@ function handleEditRecompute(data) {
 
         progress(50, 'Eroding terrain\u2026');
         t0 = performance.now();
-        const { dl_erosionDelta, postTiming } = runPostProcessing(mesh, r_xyz, r_elevation, data, W.neighborDist, W.seed);
+        const { dl_erosionDelta, postTiming } = runPostProcessing(mesh, r_xyz, r_elevation, data, W.neighborDist, W.seed, debugLayers.hotspot);
         const tPost = performance.now() - t0;
         debugLayers.erosionDelta = dl_erosionDelta;
 
@@ -480,7 +479,7 @@ function handleEditRecompute(data) {
 
             progress(82, 'Computing precipitation\u2026');
             t0 = performance.now();
-            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult);
+            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage);
             tPrecip = performance.now() - t0;
             debugLayers.precipSummer = precipResult.r_precip_summer;
             debugLayers.precipWinter = precipResult.r_precip_winter;
@@ -489,7 +488,7 @@ function handleEditRecompute(data) {
 
             progress(86, 'Computing temperature\u2026');
             t0 = performance.now();
-            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult);
+            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset);
             tTemp = performance.now() - t0;
             debugLayers.tempSummer = tempResult.r_temperature_summer;
             debugLayers.tempWinter = tempResult.r_temperature_winter;
@@ -523,25 +522,7 @@ function handleEditRecompute(data) {
             coastline_r: Array.from(coastline_r),
             ocean_r: Array.from(ocean_r),
             r_stress,
-            r_wind_east_summer: windResult ? windResult.r_wind_east_summer : null,
-            r_wind_north_summer: windResult ? windResult.r_wind_north_summer : null,
-            r_wind_east_winter: windResult ? windResult.r_wind_east_winter : null,
-            r_wind_north_winter: windResult ? windResult.r_wind_north_winter : null,
-            itczLons: windResult ? windResult.itczLons : null,
-            itczLatsSummer: windResult ? windResult.itczLatsSummer : null,
-            itczLatsWinter: windResult ? windResult.itczLatsWinter : null,
-            r_ocean_current_east_summer: oceanResult ? oceanResult.r_ocean_current_east_summer : null,
-            r_ocean_current_north_summer: oceanResult ? oceanResult.r_ocean_current_north_summer : null,
-            r_ocean_current_east_winter: oceanResult ? oceanResult.r_ocean_current_east_winter : null,
-            r_ocean_current_north_winter: oceanResult ? oceanResult.r_ocean_current_north_winter : null,
-            r_ocean_speed_summer: oceanResult ? oceanResult.r_ocean_speed_summer : null,
-            r_ocean_speed_winter: oceanResult ? oceanResult.r_ocean_speed_winter : null,
-            r_ocean_warmth_summer: oceanResult ? oceanResult.r_ocean_warmth_summer : null,
-            r_ocean_warmth_winter: oceanResult ? oceanResult.r_ocean_warmth_winter : null,
-            r_precip_summer: precipResult ? precipResult.r_precip_summer : null,
-            r_precip_winter: precipResult ? precipResult.r_precip_winter : null,
-            r_temperature_summer: tempResult ? tempResult.r_temperature_summer : null,
-            r_temperature_winter: tempResult ? tempResult.r_temperature_winter : null,
+            ...buildClimateFields(windResult, oceanResult, precipResult, tempResult),
             debugLayers,
             _editTiming: {
                 elevation: tElev,
@@ -567,8 +548,10 @@ function handleEditRecompute(data) {
     }
 }
 
-function handleComputeClimate() {
+function handleComputeClimate(data) {
     if (!W) { self.postMessage({ type: 'error', message: 'No retained state for computeClimate' }); return; }
+
+    const { temperatureOffset, precipitationOffset, landCoverage } = getClimateParams(data);
 
     try {
         const tTotal0 = performance.now();
@@ -586,12 +569,12 @@ function handleComputeClimate() {
 
         progress(50, 'Computing precipitation\u2026');
         t0 = performance.now();
-        const precipResult = computePrecipitation(mesh, r_xyz, r_elevation_final, windResult, oceanResult);
+        const precipResult = computePrecipitation(mesh, r_xyz, r_elevation_final, windResult, oceanResult, precipitationOffset, landCoverage);
         const tPrecip = performance.now() - t0;
 
         progress(70, 'Computing temperature\u2026');
         t0 = performance.now();
-        const tempResult = computeTemperature(mesh, r_xyz, r_elevation_final, windResult, oceanResult, precipResult);
+        const tempResult = computeTemperature(mesh, r_xyz, r_elevation_final, windResult, oceanResult, precipResult, temperatureOffset);
         const tTemp = performance.now() - t0;
 
         progress(88, 'Classifying climates\u2026');
@@ -655,13 +638,278 @@ function handleComputeClimate() {
     }
 }
 
+// ─── Heightmap import ───────────────────────────────────────────────
+
+/** Bilinear interpolation with equirectangular wrapping. */
+function sampleBilinear(pixels, imgW, imgH, px, py) {
+    // Clamp vertically, wrap horizontally
+    py = Math.max(0, Math.min(py, imgH - 1));
+    const x0 = Math.floor(px), y0 = Math.floor(py);
+    const x1 = (x0 + 1) % imgW;     // horizontal wrap
+    const y1 = Math.min(y0 + 1, imgH - 1); // vertical clamp
+    const fx = px - x0, fy = py - y0;
+    const v00 = pixels[y0 * imgW + ((x0 % imgW) + imgW) % imgW];
+    const v10 = pixels[y0 * imgW + x1];
+    const v01 = pixels[y1 * imgW + ((x0 % imgW) + imgW) % imgW];
+    const v11 = pixels[y1 * imgW + x1];
+    return (v00 * (1 - fx) * (1 - fy) +
+            v10 * fx * (1 - fy) +
+            v01 * (1 - fx) * fy +
+            v11 * fx * fy);
+}
+
+/**
+ * Convert grayscale 0–255 to internal elevation.
+ * 0 → -0.5 (ocean floor)
+ * 1–255 → inverse of 6·t² so grayscale maps linearly to km.
+ * Simple sqrt inversion: t = sqrt((v-1) / 254).
+ */
+function grayscaleToElevation(v) {
+    if (v < 1) return -0.5; // ocean (black pixels; catches interpolated fractional values too)
+    return Math.sqrt((v - 1) / 254);
+}
+
+/**
+ * Sample an equirectangular grayscale heightmap onto sphere mesh regions.
+ * Returns r_elevation (Float32Array).
+ */
+function sampleHeightmap(mesh, r_xyz, imageData, imgW, imgH) {
+    const r_elevation = new Float32Array(mesh.numRegions);
+    for (let r = 0; r < mesh.numRegions; r++) {
+        const x = r_xyz[3 * r], y = r_xyz[3 * r + 1], z = r_xyz[3 * r + 2];
+        const lat = Math.asin(Math.max(-1, Math.min(1, y)));
+        const lon = Math.atan2(x, z);
+        // Map lat/lon → pixel coords (equirectangular)
+        const px = (lon / Math.PI + 1) * 0.5 * imgW; // 0..W
+        const py = (0.5 - lat / Math.PI) * imgH;     // 0..H
+        const gray = sampleBilinear(imageData, imgW, imgH, px, py);
+        r_elevation[r] = grayscaleToElevation(gray);
+    }
+    return r_elevation;
+}
+
+/**
+ * BFS flood fill to derive synthetic plates from elevation.
+ * Creates one "plate" per connected land mass and one per connected ocean basin.
+ */
+function deriveSyntheticPlates(mesh, r_elevation) {
+    const N = mesh.numRegions;
+    const r_plate = new Int32Array(N).fill(-1);
+    const plateSeeds = new Set();
+    const plateIsOcean = new Set();
+    const plateVec = {};
+    const { adjOffset, adjList } = mesh;
+
+    let plateId = 0;
+    for (let r = 0; r < N; r++) {
+        if (r_plate[r] >= 0) continue;
+        const isOcean = r_elevation[r] <= 0;
+        // BFS from this region
+        r_plate[r] = r; // use r as the plate seed
+        plateSeeds.add(r);
+        plateVec[r] = [0, 0, 0]; // zero velocity
+        if (isOcean) plateIsOcean.add(r);
+        const queue = [r];
+        let head = 0;
+        while (head < queue.length) {
+            const cur = queue[head++];
+            const end = adjOffset[cur + 1];
+            for (let ni = adjOffset[cur]; ni < end; ni++) {
+                const nb = adjList[ni];
+                if (r_plate[nb] >= 0) continue;
+                const nbOcean = r_elevation[nb] <= 0;
+                if (nbOcean === isOcean) {
+                    r_plate[nb] = r;
+                    queue.push(nb);
+                }
+            }
+        }
+        plateId++;
+    }
+
+    return { r_plate, plateSeeds, plateIsOcean, plateVec };
+}
+
+function handleImportHeightmap(data) {
+    const { N, jitter, grayscale, imageWidth, imageHeight, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, terrainWarp, temperatureOffset = 0, precipitationOffset = 0, landCoverage = 0.3, seed: overrideSeed, skipClimate } = data;
+    const timing = [];
+
+    try {
+        const tTotal0 = performance.now();
+
+        progress(0, 'Building sphere mesh\u2026');
+        const seed = overrideSeed ?? Math.floor(Math.random() * 16777216);
+        const rng = makeRng(seed);
+
+        let t0 = performance.now();
+        const { mesh, r_xyz } = buildSphere(N, jitter, rng);
+        timing.push({ stage: 'Sphere mesh', ms: performance.now() - t0 });
+
+        t0 = performance.now();
+        const neighborDist = computeNeighborDist(mesh, r_xyz);
+        timing.push({ stage: 'Neighbor distances', ms: performance.now() - t0 });
+
+        t0 = performance.now();
+        const t_xyz = generateTriangleCenters(mesh, r_xyz);
+        timing.push({ stage: 'Triangle centers', ms: performance.now() - t0 });
+
+        progress(20, 'Sampling heightmap\u2026');
+        t0 = performance.now();
+        const r_elevation = sampleHeightmap(mesh, r_xyz, grayscale, imageWidth, imageHeight);
+        timing.push({ stage: 'Sample heightmap', ms: performance.now() - t0 });
+
+        const prePostElev = new Float32Array(r_elevation);
+
+        progress(35, 'Processing terrain\u2026');
+        t0 = performance.now();
+        const { dl_erosionDelta, postTiming } = runPostProcessing(mesh, r_xyz, r_elevation, { smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, terrainWarp }, neighborDist, seed);
+        timing.push({ stage: 'Terrain post-processing', ms: performance.now() - t0 });
+
+        progress(50, 'Deriving plates\u2026');
+        t0 = performance.now();
+        const { r_plate, plateSeeds, plateIsOcean, plateVec } = deriveSyntheticPlates(mesh, r_elevation);
+        timing.push({ stage: 'Synthetic plates', ms: performance.now() - t0 });
+
+        // Classify regions
+        const mountain_r = new Set();
+        const coastline_r = new Set();
+        const ocean_r = new Set();
+        for (let r = 0; r < mesh.numRegions; r++) {
+            if (r_elevation[r] <= 0) {
+                ocean_r.add(r);
+            } else if (r_elevation[r] > 0.5) {
+                mountain_r.add(r);
+            }
+            // Coastline: land cell adjacent to ocean
+            if (r_elevation[r] > 0) {
+                const end = mesh.adjOffset[r + 1];
+                for (let ni = mesh.adjOffset[r]; ni < end; ni++) {
+                    if (r_elevation[mesh.adjList[ni]] <= 0) {
+                        coastline_r.add(r);
+                        break;
+                    }
+                }
+            }
+        }
+
+        const r_stress = new Float32Array(mesh.numRegions); // no stress for imports
+        const debugLayers = { erosionDelta: dl_erosionDelta };
+        const nMag = 0;
+
+        let windResult = null, oceanResult = null, precipResult = null, tempResult = null;
+
+        if (!skipClimate) {
+            const noise = new SimplexNoise(seed);
+
+            progress(60, 'Simulating wind patterns\u2026');
+            t0 = performance.now();
+            windResult = computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noise);
+            timing.push({ stage: 'Wind simulation', ms: performance.now() - t0 });
+            debugLayers.pressureSummer = windResult.r_pressure_summer;
+            debugLayers.pressureWinter = windResult.r_pressure_winter;
+            debugLayers.windSpeedSummer = windResult.r_wind_speed_summer;
+            debugLayers.windSpeedWinter = windResult.r_wind_speed_winter;
+            debugLayers.continentality = windResult.r_continentality;
+
+            progress(72, 'Computing ocean currents\u2026');
+            t0 = performance.now();
+            oceanResult = computeOceanCurrents(mesh, r_xyz, r_elevation, windResult);
+            timing.push({ stage: 'Ocean currents', ms: performance.now() - t0 });
+
+            progress(80, 'Computing precipitation\u2026');
+            t0 = performance.now();
+            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage);
+            timing.push({ stage: 'Precipitation', ms: performance.now() - t0 });
+            debugLayers.precipSummer = precipResult.r_precip_summer;
+            debugLayers.precipWinter = precipResult.r_precip_winter;
+            debugLayers.rainShadowSummer = precipResult.r_rainshadow_summer;
+            debugLayers.rainShadowWinter = precipResult.r_rainshadow_winter;
+
+            progress(88, 'Computing temperature\u2026');
+            t0 = performance.now();
+            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset);
+            timing.push({ stage: 'Temperature', ms: performance.now() - t0 });
+            debugLayers.tempSummer = tempResult.r_temperature_summer;
+            debugLayers.tempWinter = tempResult.r_temperature_winter;
+
+            t0 = performance.now();
+            debugLayers.koppen = classifyKoppen(mesh, r_elevation, tempResult, precipResult);
+            timing.push({ stage: 'Köppen classification', ms: performance.now() - t0 });
+        }
+
+        progress(skipClimate ? 75 : 92, 'Computing triangle elevations\u2026');
+        t0 = performance.now();
+        const t_elevation = computeTriangleElevations(mesh, r_elevation);
+        timing.push({ stage: 'Triangle elevations', ms: performance.now() - t0 });
+
+        // Retain state for reapply
+        t0 = performance.now();
+        W = {
+            mesh, r_xyz: new Float32Array(r_xyz), t_xyz: new Float32Array(t_xyz),
+            neighborDist,
+            r_plate: new Int32Array(r_plate), plateSeeds: new Set(plateSeeds), plateVec,
+            plateIsOcean: new Set(plateIsOcean), originalPlateIsOcean: new Set(plateIsOcean),
+            plateDensity: {}, plateDensityLand: {}, plateDensityOcean: {},
+            prePostElev: new Float32Array(prePostElev),
+            r_elevation_final: new Float32Array(r_elevation),
+            seed, nMag, noise: new SimplexNoise(seed),
+            mountain_r: new Set(mountain_r), coastline_r: new Set(coastline_r), ocean_r: new Set(ocean_r),
+            r_stress: new Float32Array(r_stress)
+        };
+        timing.push({ stage: 'Clone state for retention', ms: performance.now() - t0 });
+
+        const tWorkerTotal = performance.now() - tTotal0;
+
+        // Build result — same shape as handleGenerate's 'done' message
+        const result = {
+            type: 'done',
+            triangles: mesh.triangles,
+            halfedges: mesh.halfedges,
+            numRegions: mesh.numRegions,
+            r_xyz, t_xyz, r_plate,
+            plateSeeds: Array.from(plateSeeds),
+            plateVec,
+            plateIsOcean: Array.from(plateIsOcean),
+            originalPlateIsOcean: Array.from(plateIsOcean),
+            plateDensity: {}, plateDensityLand: {}, plateDensityOcean: {},
+            prePostElev,
+            r_elevation, t_elevation,
+            mountain_r: Array.from(mountain_r),
+            coastline_r: Array.from(coastline_r),
+            ocean_r: Array.from(ocean_r),
+            r_stress,
+            ...buildClimateFields(windResult, oceanResult, precipResult, tempResult),
+            skipClimate: !!skipClimate,
+            seed, nMag,
+            debugLayers,
+            _timing: [],
+            _pipelineTiming: timing,
+            _postTiming: postTiming,
+            _workerTotal: tWorkerTotal,
+            _params: { N, P: 0, jitter, nMag, numContinents: 0, smoothing, terrainWarp, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, seed }
+        };
+
+        const transferList = [
+            r_xyz.buffer, t_xyz.buffer, r_plate.buffer,
+            prePostElev.buffer, r_elevation.buffer, t_elevation.buffer,
+            r_stress.buffer
+        ];
+
+        self.postMessage(result, transferList);
+
+    } catch (err) {
+        self.postMessage({ type: 'error', message: err.message, stack: err.stack });
+    }
+}
+
 self.onmessage = (e) => {
     const { cmd } = e.data;
     switch (cmd) {
         case 'generate': handleGenerate(e.data); break;
         case 'reapply': handleReapply(e.data); break;
         case 'editRecompute': handleEditRecompute(e.data); break;
-        case 'computeClimate': handleComputeClimate(); break;
+        case 'computeClimate': handleComputeClimate(e.data); break;
+        case 'importHeightmap': handleImportHeightmap(e.data); break;
         default: self.postMessage({ type: 'error', message: `Unknown command: ${cmd}` });
     }
 };

--- a/js/plates.js
+++ b/js/plates.js
@@ -86,13 +86,21 @@ export function generatePlates(mesh, r_xyz, numPlates, seed) {
         }
     }
 
+    // Interpolation factor: more cragginess at low plate counts
+    const lowPlateT = Math.max(0, Math.min(1, (80 - numPlates) / 60));
+
     // Per-plate growth properties
     const plateGrowthRate = {};
     const plateGrowthDir = {};
     const plateDirStrength = {};
 
+    const rateMin = 0.7 - 0.4 * lowPlateT;   // 0.7 → 0.3
+    const rateRange = 2.3 + 2.4 * lowPlateT;  // 2.3 → 4.7
+    const dirBase = 0.15 + 0.25 * lowPlateT;  // 0.15 → 0.4
+    const dirScale = 0.25 + 0.25 * lowPlateT; // 0.25 → 0.5
+
     for (const center of plateSeeds) {
-        plateGrowthRate[center] = 0.7 + rng() * rng() * 2.3;
+        plateGrowthRate[center] = rateMin + rng() * rng() * rateRange;
 
         const px = r_xyz[3*center], py = r_xyz[3*center+1], pz = r_xyz[3*center+2];
         const pLen = Math.sqrt(px*px + py*py + pz*pz) || 1;
@@ -103,7 +111,7 @@ export function generatePlates(mesh, r_xyz, numPlates, seed) {
         const tLen = Math.sqrt(tx*tx + ty*ty + tz*tz) || 1;
         plateGrowthDir[center] = [tx/tLen, ty/tLen, tz/tLen];
 
-        plateDirStrength[center] = rng() * (0.15 + 0.25 / plateGrowthRate[center]);
+        plateDirStrength[center] = Math.min(0.85, rng() * (dirBase + dirScale / plateGrowthRate[center]));
     }
 
     // Per-plate frontiers — round-robin ensures every plate advances
@@ -118,8 +126,9 @@ export function generatePlates(mesh, r_xyz, numPlates, seed) {
 
     const { adjOffset, adjList } = mesh;
     let remaining = numRegions - plateIds.length;
-    const COMPACT_WEIGHT = 0.3;
+    const COMPACT_WEIGHT = 0.3 - 0.22 * lowPlateT; // 0.3 → 0.08
     const expectedArea = Math.max(1, (numRegions - plateIds.length) / numPlates);
+    const areaGovernorMult = 2.0 + 2.0 * lowPlateT; // 2.0 → 4.0
     const invNumRegions = 1 / numRegions;
 
     while (remaining > 0) {
@@ -135,8 +144,8 @@ export function generatePlates(mesh, r_xyz, numPlates, seed) {
             const dirStrHalf = dirStr * 0.5;
             let steps = Math.max(1, Math.ceil(rate * (0.5 + rng())));
 
-            // Governor: halve steps for plates exceeding 2x expected area
-            if (plateAreaCount[pid] > expectedArea * 2.0) {
+            // Governor: halve steps for plates exceeding threshold
+            if (plateAreaCount[pid] > expectedArea * areaGovernorMult) {
                 steps = Math.max(1, Math.ceil(steps * 0.5));
             }
 
@@ -204,7 +213,7 @@ export function generatePlates(mesh, r_xyz, numPlates, seed) {
         }
     }
 
-    smoothAndReconnectPlates(mesh, r_plate, plateSeeds, 3);
+    smoothAndReconnectPlates(mesh, r_plate, plateSeeds, Math.round(3 - 2 * lowPlateT));
 
     // Assign an Euler pole + angular velocity per plate
     const plateVec = {};

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -193,7 +193,7 @@ function advectMoisture(mesh, r_xyz, r_heightKm, r_isLand,
  * @param {object} oceanResult - output from computeOceanCurrents()
  * @returns {{ r_precip_summer, r_precip_winter }} normalized 0–1 arrays
  */
-export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult) {
+export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset = 0, landCoverage = 0.3) {
     console.log('[precipitation.js] computePrecipitation called, numRegions:', mesh.numRegions);
     const numRegions = mesh.numRegions;
     const timing = [];
@@ -477,7 +477,13 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
                 }
             }
 
-            precip[r] = Math.max(0, p);
+            const precipMult = 1 + precipitationOffset * 0.5;
+            let finalPrecip = p * precipMult;
+            if (landCoverage > 0.4) {
+                const t = (landCoverage - 0.4) / 0.6;
+                finalPrecip *= 1 - t * t * 0.98;
+            }
+            precip[r] = Math.max(0, finalPrecip);
         }
 
         const tMechanisms = performance.now() - t0;

--- a/js/state.js
+++ b/js/state.js
@@ -31,4 +31,5 @@ export const state = {
     pendingToggles: new Set(),
     _pendingBackup: null,
     _mapPendingBackup: null,
+    importedHeightmap: false,
 };

--- a/js/temperature.js
+++ b/js/temperature.js
@@ -66,7 +66,7 @@ function diffuseOceanWarmth(mesh, r_oceanWarmth, r_isLand, r_plateContinentality
  * @param {object} precipResult - output from computePrecipitation()
  * @returns {{ r_temperature_summer, r_temperature_winter, _tempTiming }}
  */
-export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult) {
+export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset = 0) {
     const numRegions = mesh.numRegions;
     const timing = [];
 
@@ -207,6 +207,7 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
                 T = T_ann_adj + boostedDeviation * maritimeFactor;
             }
 
+            T += temperatureOffset;
             temp[r] = T;
         }
 

--- a/js/terrain-post.js
+++ b/js/terrain-post.js
@@ -230,7 +230,7 @@ function priorityFloodCarve(mesh, r_elevation, r_isOcean, carveStrength) {
  *     toward the displaced point to find the closest region
  *  5. Copy that source region's elevation to the output
  */
-export function warpTerrain(mesh, r_elevation, r_xyz, seed, strength) {
+export function warpTerrain(mesh, r_elevation, r_xyz, seed, strength, r_hotspot) {
     if (strength <= 0) return;
 
     const N = mesh.numRegions;
@@ -290,14 +290,20 @@ export function warpTerrain(mesh, r_elevation, r_xyz, seed, strength) {
 
     // Weighted max: pick whichever is larger, biased by strength
     // At strength≈0 → 75% original, at strength=1 → 75% warped
+    // Dampen near hotspots so volcanic peaks keep their sculpted shape
     const warpBias = 0.25 + 0.5 * strength;
     for (let r = 0; r < N; r++) {
         const orig = r_elevation[r];
         const warped = out[r];
+        let bias = warpBias;
+        if (r_hotspot) {
+            const hotFrac = Math.min(1, Math.abs(r_hotspot[r]) / (Math.abs(orig) || 1));
+            bias *= 1 - 0.8 * hotFrac;
+        }
         if (warped > orig) {
-            r_elevation[r] = orig + (warped - orig) * warpBias;
+            r_elevation[r] = orig + (warped - orig) * bias;
         } else {
-            r_elevation[r] = warped + (orig - warped) * (1 - warpBias);
+            r_elevation[r] = warped + (orig - warped) * (1 - bias);
         }
     }
 }
@@ -625,7 +631,7 @@ export function erodeComposite(mesh, r_elevation, r_xyz, r_isOcean,
                     if (drainOfTarget >= 0 && cellDist[target] > 0) {
                         receiverSlope = Math.abs(r_elevation[target] - r_elevation[drainOfTarget]) / cellDist[target];
                     }
-                    const depositFrac = 0.3 / (1 + receiverSlope * 50);
+                    const depositFrac = 0.5 / (1 + receiverSlope * 50);
                     const deposit = eroded * depositFrac;
                     r_elevation[target] += deposit;
                     if (r_elevation[target] > h_new) r_elevation[target] = h_new;

--- a/llms.txt
+++ b/llms.txt
@@ -12,6 +12,7 @@ World Orogen generates realistic procedural planets shaped by tectonic plate sim
 - Simulates seasonal climate: wind patterns, ocean currents, precipitation, and Köppen classification
 - Creates hotspot volcanism with drift-trail island chains (like Hawaii)
 - Allows interactive editing — select multiple tectonic plates for batch reshaping with visual preview before rebuild
+- Import your own equirectangular B&W heightmaps (Earth, Mars, hand-drawn) onto a 3D globe with automatic climate simulation
 
 ## Who it's for
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,8 +2,14 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://orogen.studio/</loc>
-        <lastmod>2026-03-01</lastmod>
+        <lastmod>2026-03-04</lastmod>
         <changefreq>monthly</changefreq>
         <priority>1.0</priority>
+    </url>
+    <url>
+        <loc>https://orogen.studio/import</loc>
+        <lastmod>2026-03-04</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.8</priority>
     </url>
 </urlset>

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,30 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { background: #000; overflow: hidden; font-family: 'Segoe UI', system-ui, sans-serif; color: #fff; }
 #canvas { display: block; }
+
+/* ─── Top navigation bar ─── */
+#topNav {
+    position: fixed; top: 0; left: 0; right: 0;
+    height: 40px; z-index: 60;
+    background: rgba(8,8,28,0.92); backdrop-filter: blur(12px);
+    border-bottom: 1px solid rgba(255,255,255,0.08);
+    display: flex; align-items: center;
+    padding: 0 16px; gap: 4px;
+}
+.nav-tab {
+    display: inline-flex; align-items: center;
+    padding: 6px 16px; border-radius: 6px;
+    font-size: 13px; font-weight: 500;
+    color: #889; text-decoration: none;
+    transition: background 0.2s, color 0.2s;
+}
+.nav-tab:hover { color: #bcd; background: rgba(255,255,255,0.06); }
+.nav-tab.active {
+    color: #8bf; background: rgba(68,136,255,0.15);
+}
+
 #ui {
-    position: absolute; top: 16px; left: 16px;
+    position: absolute; top: 56px; left: 16px;
     background: rgba(8,8,28,0.88); backdrop-filter: blur(12px);
     padding: 20px; border-radius: 12px;
     border: 1px solid rgba(255,255,255,0.08);
@@ -10,7 +32,7 @@ body { background: #000; overflow: hidden; font-family: 'Segoe UI', system-ui, s
     transition: min-width 0.25s ease, padding 0.25s ease;
     overflow: visible;
     display: flex; flex-direction: column;
-    max-height: calc(100vh - 32px);
+    max-height: calc(100vh - 72px);
 }
 #sidebarContent {
     overflow-y: auto; overflow-x: hidden; flex: 1; min-height: 0;
@@ -57,6 +79,24 @@ body { background: #000; overflow: hidden; font-family: 'Segoe UI', system-ui, s
 }
 .section[open] > summary::before { transform: rotate(90deg); }
 .section-body { padding: 8px 0 2px; }
+.climate-live-badge {
+    font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em;
+    padding: 1px 5px; border-radius: 4px;
+    background: rgba(100,200,255,0.15); color: #6cf;
+    vertical-align: middle; margin-left: 2px;
+}
+.climate-hint {
+    font-size: 11px; color: #678; line-height: 1.4;
+    margin-bottom: 8px;
+}
+.import-expect {
+    font-size: 11px; color: #8ab; line-height: 1.5;
+    background: rgba(68,136,255,0.08);
+    border: 1px solid rgba(68,136,255,0.15);
+    border-radius: 6px; padding: 8px 10px;
+    margin-bottom: 10px;
+    max-width: 250px;
+}
 .section[open] > summary { border-bottom-color: rgba(255,255,255,0.06); margin-bottom: 2px; }
 .cg { margin-bottom: 10px; }
 .cg label { display: block; font-size: 14px; color: #aab; margin-bottom: 3px; }
@@ -328,7 +368,7 @@ button#generate.generating {
 .detail-warn.orange { color: #e8a020; }
 .detail-warn.red { color: #d04030; }
 #topInfo {
-    position: absolute; top: 16px; left: 50%; transform: translateX(-50%);
+    position: absolute; top: 52px; left: 50%; transform: translateX(-50%);
     font-size: 13px; color: #889;
     background: rgba(8,8,28,0.85); backdrop-filter: blur(8px);
     padding: 6px 14px; border-radius: 8px;
@@ -362,7 +402,7 @@ button#generate.generating {
 
 /* Help button */
 #helpBtn {
-    position: absolute; top: 16px; right: 16px;
+    position: absolute; top: 52px; right: 16px;
     width: 36px; height: 36px; border-radius: 50%;
     background: rgba(40,60,120,0.7); backdrop-filter: blur(12px);
     border: 1px solid rgba(100,160,255,0.25);
@@ -644,8 +684,64 @@ button#generate.generating {
     50% { box-shadow: 0 4px 24px rgba(34,170,90,0.55); }
 }
 
+/* ─── Import page ─── */
+.import-upload-area {
+    display: flex; align-items: center; gap: 8px;
+    margin-bottom: 8px;
+}
+.import-file-label {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 8px 14px; border-radius: 8px;
+    background: rgba(255,255,255,0.06);
+    border: 1px solid rgba(255,255,255,0.12);
+    color: #9ab; font-size: 13px; font-weight: 500;
+    cursor: pointer; white-space: nowrap;
+    transition: background 0.2s, color 0.2s, border-color 0.2s;
+}
+.import-file-label:hover {
+    background: rgba(255,255,255,0.10);
+    border-color: rgba(255,255,255,0.20);
+    color: #cde;
+}
+.import-file-label svg { flex-shrink: 0; width: 16px; height: 16px; }
+.import-file-name {
+    font-size: 12px; color: #667;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    min-width: 0; flex: 1;
+}
+.import-preview {
+    width: 100%; max-height: 120px;
+    object-fit: contain;
+    border-radius: 6px;
+    border: 1px solid rgba(255,255,255,0.08);
+    margin-bottom: 6px;
+    background: #0a0a1a;
+}
+.import-dims {
+    font-size: 11px; color: #667;
+    text-align: center; margin-bottom: 8px;
+}
+.import-hint {
+    font-size: 11px; color: #556;
+    line-height: 1.4; margin-bottom: 10px;
+}
+.import-btn {
+    width: 100%; padding: 10px; margin-top: 6px;
+    background: linear-gradient(135deg, #2255cc, #3366ee);
+    color: white; border: none; border-radius: 8px;
+    font-size: 15px; font-weight: 500; font-family: inherit; cursor: pointer;
+    transition: background 0.3s ease, opacity 0.3s ease;
+}
+.import-btn:hover:not(:disabled) { filter: brightness(1.15); }
+.import-btn:disabled {
+    background: linear-gradient(135deg, #333, #444);
+    cursor: default; opacity: 0.5;
+}
+
 /* ───── Mobile: tablets + phones ───── */
 @media (max-width: 768px) {
+    #topNav { height: 36px; padding: 0 8px; }
+    .nav-tab { padding: 4px 12px; font-size: 12px; min-height: 32px; }
     #topInfo { display: none; }
 
     /* Bottom sheet */
@@ -712,7 +808,7 @@ button#generate.generating {
     /* Mobile view switcher — to the left of the help button */
     .mobile-view-switch {
         display: block;
-        position: fixed; top: 16px; left: 16px;
+        position: fixed; top: 44px; left: 16px;
         width: calc(100vw - 16px - 44px - 16px - 12px);
         background: rgba(40,60,120,0.7); backdrop-filter: blur(12px);
         border: 1px solid rgba(100,160,255,0.25);
@@ -779,6 +875,11 @@ button#generate.generating {
         padding: 12px 24px;
         font-size: 16px;
     }
+
+    /* Import page touch targets */
+    .import-file-label { padding: 12px 18px; font-size: 14px; min-height: 44px; }
+    .import-btn { padding: 14px; font-size: 16px; min-height: 48px; }
+    .import-hint { font-size: 12px; }
 
     /* Touch targets */
     .map-tab { padding: 12px 0; font-size: 13px; min-height: 44px; }


### PR DESCRIPTION
## Summary

- **Heightmap import page** (`/import`) — upload an equirectangular B&W heightmap (Earth, Mars, hand-drawn) onto a 3D sphere with full climate simulation (wind, precipitation, temperature, Köppen classification). Includes terrain sculpting sliders, all visualization modes, export, and hover info.
- **New generation sliders** — Continent Size Variety (equal vs. mixed landmass sizes), Land Coverage (ocean world to supercontinent), and a Climate section with live Temperature and Precipitation offsets that recompute instantly on release without full rebuild.
- **Terrain quality improvements** — orogenic power noise for varied mountain ranges, summit peaks on ridgelines, improved elevation-to-height S-curve for more extensive flatlands, dampened terrain warp near hotspots, tuned erosion/deposition coefficients, craggier plate boundaries at low plate counts.
- **Planet code refactor** — table-driven decode system replacing ~340 lines of repetitive per-format decode logic; 4 new parameters encoded (code length 18→22 chars, full backward compatibility).
- **UI polish** — top navigation bar between Generate/Import Heightmap, "instant" badge on Climate section, improved slider value labels (±0°C, ±0%), import page "what to expect" hint, sidebar width constraint.
- **Bug fixes** — fixed NaN holes from bilinear interpolation at ocean-land boundaries in import, fixed Newton's method divergence for near-black pixels (switched to simple sqrt inversion for imports), replaced expensive Three.js mesh raycasting with analytical ray-sphere intersection + 50ms throttle on import hover, fixed null crashes when import page calls readSliders for missing generate-only DOM elements.

## Test plan

- [ ] Generate a planet on the main page — verify new Continent Size Variety, Land Coverage, and Climate sliders work
- [ ] Adjust Temperature/Precipitation sliders — verify instant recompute without rebuild
- [ ] Share a planet code — verify 22-char codes encode/decode correctly and old codes still load
- [ ] Navigate to `/import` — upload an equirectangular heightmap, verify globe renders without holes or spurious peaks
- [ ] On import page, switch visualization layers (Satellite, Climate) — verify climate computes without errors
- [ ] On import page, adjust Terrain Sculpting sliders and click Reapply — verify no crashes
- [ ] Hover over the imported globe — verify smooth performance, no lag
- [ ] Test on mobile (≤768px) — verify nav bar, import page layout, and touch targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)