### PR TITLE
Add rock type classification and mineral deposit system

### DIFF
--- a/index.html
+++ b/index.html
@@ -304,6 +304,20 @@
                             <option value="uniformNoise">Uniform Land Noise</option>
                             <option value="dynamicTopo">Dynamic Topography</option>
                             <option value="erosionDelta">Erosion Delta</option>
+                            <option value="rockType">Rock Type</option>
+                            <option value="dep_copperCu">Copper Age &mdash; Copper</option>
+                            <option value="dep_copperAu">Copper Age &mdash; Gold</option>
+                            <option value="dep_bronzeCu">Bronze Age &mdash; Copper</option>
+                            <option value="dep_bronzeAu">Bronze Age &mdash; Gold</option>
+                            <option value="dep_bronzeSn">Bronze Age &mdash; Tin</option>
+                            <option value="dep_bronzePbZn">Bronze Age &mdash; Lead-Zinc</option>
+                            <option value="dep_bronzeGems">Bronze Age &mdash; Gems</option>
+                            <option value="dep_ironCu">Iron Age &mdash; Copper</option>
+                            <option value="dep_ironAu">Iron Age &mdash; Gold</option>
+                            <option value="dep_ironSn">Iron Age &mdash; Tin</option>
+                            <option value="dep_ironPbZn">Iron Age &mdash; Lead-Zinc</option>
+                            <option value="dep_ironGems">Iron Age &mdash; Gems</option>
+                            <option value="dep_ironFe">Iron Age &mdash; Iron</option>
                         </optgroup>
                         <optgroup label="Plate Physics">
                             <option value="continentalDrag">Continental Drag</option>
@@ -427,6 +441,7 @@
                     <option value="heightmap">Heightmap (B&amp;W)</option>
                     <option value="landheightmap">Land Heightmap (B&amp;W)</option>
                     <option value="landmask">Land Mask (B&amp;W)</option>
+                    <option value="rockType">Rock Type</option>
                 </select>
             </div>
             <div class="cg">

--- a/js/color-map.js
+++ b/js/color-map.js
@@ -123,3 +123,20 @@ export function elevationToColor(e) {
     if (e <  0.75) { const t=(e-0.50)/0.25;  return [0.44+t*0.16,0.28+t*0.12,0.14+t*0.18]; }
     { const t=Math.min(1,(e-0.75)/0.20);      return [0.60+t*0.35,0.40+t*0.50,0.32+t*0.60]; }
 }
+
+// Rock type → RGB colour.
+// Indexed by ROCK_TYPES enum from geology.js (7 types).
+const ROCK_COLORS = [
+    [0.502, 0.612, 0.478],  // 0 Metamorphic  — #809C7A green
+    [0.910, 0.722, 0.773],  // 1 Granitic     — #E8B8C5 pink
+    [0.694, 0.576, 0.718],  // 2 Andesitic    — #B193B7 purple
+    [0.290, 0.290, 0.290],  // 3 Basaltic     — #4A4A4A dark gray
+    [0.961, 0.820, 0.553],  // 4 Sandstone    — #F5D18D orange/yellow
+    [0.992, 0.949, 0.820],  // 5 Carbonate    — #FDF2D1 light yellow
+    [0.992, 0.973, 0.902],  // 6 Sediments    — #FDF8E6 pale yellow/white
+    [0.150, 0.300, 0.550],  // 7 Ocean        — #264D8C blue
+];
+
+export function rockTypeColor(typeId) {
+    return ROCK_COLORS[typeId] || [0.5, 0.5, 0.5];
+}

--- a/js/deposits.js
+++ b/js/deposits.js
@@ -1,0 +1,392 @@
+// Mineral deposit placement based on rock types, tectonic setting, erosion, and climate.
+// Each region gets a bitmask of all deposits present. Visualization shows the
+// highest-priority deposit per region.
+//
+// References:
+//   Madeline James — "Deposits and Gemology Extended"
+//   Artifexian — mineral deposit mapping methodology
+
+import { ROCK_TYPES } from './geology.js';
+import { SimplexNoise } from './simplex-noise.js';
+
+// ── Deposit Bitmask ──
+export const DEPOSIT = {
+    NATIVE_COPPER:   1 << 0,
+    PLACER_GOLD:     1 << 1,
+    GOSSANS:         1 << 2,
+    TIN:             1 << 3,
+    VMS_COPPER_ZINC: 1 << 4,
+    SKARN:           1 << 5,
+    PORPHYRY_COPPER: 1 << 6,
+    SEDEX_LEAD_ZINC: 1 << 7,
+    MVT_LEAD_ZINC:   1 << 8,
+    BOG_IRON:        1 << 9,
+    LATERITE_IRON:   1 << 10,
+    BIF_IRON:        1 << 11,
+    DIAMOND:         1 << 12,
+    PEGMATITE_GEMS:  1 << 13,
+    EPITHERMAL_GOLD: 1 << 14,
+};
+
+// ── Deposit Metadata ──
+// Each deposit has an era (copper/bronze/iron) and display priority (higher index = rarer = shown on top).
+export const DEPOSIT_INFO = [
+    // — Copper Age: surface/weathering deposits —
+    { bit: DEPOSIT.NATIVE_COPPER,   name: 'Native Copper',     era: 'copper', color: [0.72, 0.45, 0.22], description: 'Surface copper from weathered basaltic rock' },
+    { bit: DEPOSIT.GOSSANS,         name: 'Gossans',           era: 'copper', color: [0.70, 0.50, 0.18], description: 'Oxidized sulfide caps — copper, gold, silver' },
+    { bit: DEPOSIT.PLACER_GOLD,     name: 'Placer Gold',       era: 'copper', color: [0.85, 0.75, 0.22], description: 'Alluvial gold downstream of eroded highlands' },
+    // — Bronze Age: alloy metals & advanced smelting —
+    { bit: DEPOSIT.TIN,             name: 'Tin (Cassiterite)', era: 'bronze', color: [0.60, 0.58, 0.55], description: 'Granitic intrusions — essential for bronze' },
+    { bit: DEPOSIT.VMS_COPPER_ZINC, name: 'VMS Cu-Zn',         era: 'bronze', color: [0.65, 0.38, 0.22], description: 'Volcanogenic massive sulfide — rifts and arcs' },
+    { bit: DEPOSIT.SKARN,           name: 'Skarn',             era: 'bronze', color: [0.50, 0.48, 0.28], description: 'Contact metamorphic — carbonate meets igneous' },
+    { bit: DEPOSIT.PORPHYRY_COPPER, name: 'Porphyry Cu-Mo',   era: 'bronze', color: [0.58, 0.42, 0.35], description: 'Large tonnage copper at subduction zones' },
+    { bit: DEPOSIT.SEDEX_LEAD_ZINC, name: 'SEDEX Pb-Zn',      era: 'bronze', color: [0.48, 0.48, 0.55], description: 'Sediment-hosted lead-zinc in rift basins' },
+    { bit: DEPOSIT.MVT_LEAD_ZINC,   name: 'MVT Pb-Zn',        era: 'bronze', color: [0.52, 0.50, 0.48], description: 'Mississippi Valley lead-zinc in carbonate' },
+    { bit: DEPOSIT.EPITHERMAL_GOLD, name: 'Epithermal Au-Ag',  era: 'bronze', color: [0.82, 0.68, 0.30], description: 'Shallow vein gold-silver near volcanoes' },
+    { bit: DEPOSIT.PEGMATITE_GEMS,  name: 'Pegmatite Gems',    era: 'bronze', color: [0.65, 0.52, 0.72], description: 'Rare gems and lithium in granitic pegmatites' },
+    { bit: DEPOSIT.DIAMOND,         name: 'Diamond',           era: 'bronze', color: [0.80, 0.85, 0.92], description: 'Kimberlite pipes in Archean cratons' },
+    // — Iron Age: iron sources —
+    { bit: DEPOSIT.BOG_IRON,        name: 'Bog Iron',          era: 'iron', color: [0.50, 0.38, 0.25], description: 'Wetland iron precipitate — easy to smelt' },
+    { bit: DEPOSIT.LATERITE_IRON,   name: 'Laterite Iron',     era: 'iron', color: [0.62, 0.32, 0.20], description: 'Tropical weathering residual iron' },
+    { bit: DEPOSIT.BIF_IRON,        name: 'Banded Iron (BIF)', era: 'iron', color: [0.55, 0.28, 0.28], description: 'Ancient marine iron in craton shields' },
+];
+
+// Era bitmasks: combine all deposit bits belonging to each era
+export const ERA_MASK = {
+    copper: DEPOSIT.NATIVE_COPPER | DEPOSIT.GOSSANS | DEPOSIT.PLACER_GOLD,
+    bronze: DEPOSIT.TIN | DEPOSIT.VMS_COPPER_ZINC | DEPOSIT.SKARN | DEPOSIT.PORPHYRY_COPPER |
+            DEPOSIT.SEDEX_LEAD_ZINC | DEPOSIT.MVT_LEAD_ZINC | DEPOSIT.EPITHERMAL_GOLD |
+            DEPOSIT.PEGMATITE_GEMS | DEPOSIT.DIAMOND,
+    iron:   DEPOSIT.BOG_IRON | DEPOSIT.LATERITE_IRON | DEPOSIT.BIF_IRON,
+};
+
+// Era display info for legends
+export const ERA_INFO = {
+    copper: { label: 'Copper Age', deposits: DEPOSIT_INFO.filter(d => d.era === 'copper') },
+    bronze: { label: 'Bronze Age', deposits: DEPOSIT_INFO.filter(d => d.era === 'bronze') },
+    iron:   { label: 'Iron Age',   deposits: DEPOSIT_INFO.filter(d => d.era === 'iron') },
+};
+
+// ── Helper: check if a neighbor has a given rock type ──
+function hasNeighborRockType(mesh, r_rockType, region, targetType) {
+    const off = mesh.adjOffset[region];
+    const end = mesh.adjOffset[region + 1];
+    for (let i = off; i < end; i++) {
+        if (r_rockType[mesh.adjList[i]] === targetType) return true;
+    }
+    return false;
+}
+
+// ── Helper: check if any neighbor has high oroGrade ──
+function hasNeighborOrogen(mesh, r_stress, dl_foldRidge, dl_orogenicPower, region, threshold) {
+    const off = mesh.adjOffset[region];
+    const end = mesh.adjOffset[region + 1];
+    for (let i = off; i < end; i++) {
+        const nb = mesh.adjList[i];
+        const grade = r_stress[nb]
+            + (dl_foldRidge ? Math.max(0, dl_foldRidge[nb]) * 2.0 : 0)
+            + (dl_orogenicPower ? Math.max(0, dl_orogenicPower[nb]) * 1.5 : 0);
+        if (grade > threshold) return true;
+    }
+    return false;
+}
+
+// ── Main Classification ──
+export function assignDeposits(
+    mesh, r_xyz, r_elevation, r_rockType, r_plate, plateIsOcean,
+    r_boundaryType, r_stress, r_basinFactor,
+    dl_hotspot, dl_lip, dl_erosionDelta, dl_coastal,
+    dl_foldRidge, dl_orogenicPower, dl_backArc,
+    koppenArr, noise, seed
+) {
+    const N = mesh.numRegions;
+    const r_deposits = new Uint32Array(N);
+    const depositNoise = new SimplexNoise(seed + 5501);
+
+    for (let r = 0; r < N; r++) {
+        const elev    = r_elevation[r];
+        if (elev <= 0) continue;  // no deposits on ocean floor
+
+        const rock    = r_rockType[r];
+        if (rock === ROCK_TYPES.OCEAN) continue;
+
+        const stress  = r_stress[r];
+        const bType   = r_boundaryType ? r_boundaryType[r] : 0;
+        const basin   = r_basinFactor ? r_basinFactor[r] : 0.5;
+        const hotspot = dl_hotspot ? dl_hotspot[r] : 0;
+        const lip     = dl_lip ? dl_lip[r] : 0;
+        const erosion = dl_erosionDelta ? dl_erosionDelta[r] : 0;
+        const coastal = dl_coastal ? dl_coastal[r] : 0;
+        const foldRidge = dl_foldRidge ? dl_foldRidge[r] : 0;
+        const orogPower = dl_orogenicPower ? dl_orogenicPower[r] : 0;
+        const backArc = dl_backArc ? dl_backArc[r] : 0;
+        const kId     = koppenArr ? koppenArr[r] : -1;
+        const hasOcean = mesh.numRegions > 0 ? (plateIsOcean.has ? plateIsOcean.has(r_plate[r]) : false) : false;
+
+        const oroGrade = stress + Math.max(0, foldRidge) * 2.0 + Math.max(0, orogPower) * 1.5;
+        const isErosional = erosion < -0.003 || elev > 0.35;
+        const isDepositional = erosion > 0.002 || basin > 0.6;
+
+        // Spatial noise for deposit scatter (prevents uniform distribution)
+        const px = r_xyz[r * 3], py = r_xyz[r * 3 + 1], pz = r_xyz[r * 3 + 2];
+        const n1 = depositNoise.noise3D(px * 8, py * 8, pz * 8);
+        const n2 = depositNoise.noise3D(px * 14 + 100, py * 14 + 100, pz * 14 + 100);
+
+        // Climate helpers
+        const isTropical = kId >= 1 && kId <= 3;
+        const isTemperate = kId >= 8 && kId <= 16;
+        const isBoreal = kId >= 17 && kId <= 28;
+        const isArid = kId >= 4 && kId <= 7;
+
+        // ════════════════════════════════════════
+        //  SURFACE / WEATHERING DEPOSITS
+        // ════════════════════════════════════════
+
+        // Native Copper: weathered basaltic/LIP rock exposed by erosion
+        if (rock === ROCK_TYPES.BASALTIC && isErosional && n1 > 0.0) {
+            r_deposits[r] |= DEPOSIT.NATIVE_COPPER;
+        }
+
+        // Gossans: oxidized tops of buried sulfide deposits at eroded orogens
+        if (oroGrade > 0.5 && erosion < -0.008 && n1 > -0.1) {
+            r_deposits[r] |= DEPOSIT.GOSSANS;
+        }
+
+        // Placer Gold: alluvial gold deposited downstream of eroded mountain ranges
+        // Look for depositional regions adjacent to orogenic belts
+        if (isDepositional && elev < 0.15 && n2 > 0.05) {
+            if (oroGrade > 0.3 || hasNeighborOrogen(mesh, r_stress, dl_foldRidge, dl_orogenicPower, r, 0.4)) {
+                r_deposits[r] |= DEPOSIT.PLACER_GOLD;
+            }
+        }
+
+        // Laterite Iron: intense tropical weathering of hydrothermal deposits
+        if (isTropical && isErosional && elev < 0.20 && n1 > -0.2) {
+            r_deposits[r] |= DEPOSIT.LATERITE_IRON;
+        }
+
+        // Bog Iron: chemical precipitation in wetlands
+        if ((isTemperate || isBoreal) && isDepositional && elev < 0.06 && n2 > -0.1) {
+            r_deposits[r] |= DEPOSIT.BOG_IRON;
+        }
+
+        // ════════════════════════════════════════
+        //  VOLCANIC / MAGMATIC DEPOSITS
+        // ════════════════════════════════════════
+
+        // Epithermal Gold-Silver: shallow veins near subduction volcanoes
+        if ((rock === ROCK_TYPES.ANDESITIC || rock === ROCK_TYPES.GRANITIC) &&
+            bType === 1 && stress > 0.15 && n1 > 0.1) {
+            r_deposits[r] |= DEPOSIT.EPITHERMAL_GOLD;
+        }
+
+        // Porphyry Copper: large tonnage Cu-Mo in felsic/intermediate intrusions at subduction
+        // These are mountain deposits — require significant stress and elevation
+        if ((rock === ROCK_TYPES.GRANITIC || rock === ROCK_TYPES.ANDESITIC) &&
+            bType === 1 && stress > 0.25 && elev > 0.08 && n2 > 0.0) {
+            r_deposits[r] |= DEPOSIT.PORPHYRY_COPPER;
+        }
+
+        // VMS Copper-Zinc: ancient submarine volcanic sulfides uplifted onto continents
+        // Only accessible where uplift/orogeny has brought them to the surface —
+        // requires mountains or orogenic belts, not lowland rifts
+        if ((bType === 1 || (backArc < -0.02 && stress > 0.15)) &&
+            elev > 0.08 && oroGrade > 0.2 && n1 > -0.1) {
+            r_deposits[r] |= DEPOSIT.VMS_COPPER_ZINC;
+        }
+
+        // ════════════════════════════════════════
+        //  INTRUSIVE / DEEP DEPOSITS
+        // ════════════════════════════════════════
+
+        // Tin (Cassiterite): exclusively in highly evolved granitic magmas, exposed by erosion
+        if (rock === ROCK_TYPES.GRANITIC && isErosional && n2 > 0.15) {
+            r_deposits[r] |= DEPOSIT.TIN;
+        }
+
+        // Pegmatite Gems: deep granitic intrusions with rare elements
+        if (rock === ROCK_TYPES.GRANITIC && isErosional && n1 > 0.4 && n2 > 0.2) {
+            r_deposits[r] |= DEPOSIT.PEGMATITE_GEMS;
+        }
+
+        // Skarn: contact metamorphism where magma intrudes carbonate
+        // Requires some stress or elevation — flat basin carbonate doesn't have
+        // exposed igneous contacts, only uplifted/deformed margins do
+        if (rock === ROCK_TYPES.CARBONATE && (stress > 0.08 || elev > 0.10) && n2 > -0.1) {
+            if (hasNeighborRockType(mesh, r_rockType, r, ROCK_TYPES.GRANITIC) ||
+                hasNeighborRockType(mesh, r_rockType, r, ROCK_TYPES.ANDESITIC)) {
+                r_deposits[r] |= DEPOSIT.SKARN;
+            }
+        }
+
+        // ════════════════════════════════════════
+        //  SEDIMENTARY DEPOSITS
+        // ════════════════════════════════════════
+
+        // SEDEX Lead-Zinc: sediment-hosted in fault-bounded rift basins
+        if (rock === ROCK_TYPES.SEDIMENTS && (bType === 2 || basin > 0.6) && n1 > 0.0) {
+            r_deposits[r] |= DEPOSIT.SEDEX_LEAD_ZINC;
+        }
+
+        // MVT Lead-Zinc: hydrothermal fluids through carbonate at basin margins
+        if (rock === ROCK_TYPES.CARBONATE && basin > 0.25 && basin < 0.65 && n2 > 0.0) {
+            r_deposits[r] |= DEPOSIT.MVT_LEAD_ZINC;
+        }
+
+        // BIF Iron: ancient marine iron in Archean craton shields
+        if (rock === ROCK_TYPES.METAMORPHIC && basin < 0.20 && stress < 0.05 && n1 > -0.3) {
+            r_deposits[r] |= DEPOSIT.BIF_IRON;
+        }
+
+        // ════════════════════════════════════════
+        //  ULTRA-RARE
+        // ════════════════════════════════════════
+
+        // Diamond (Kimberlite pipes): exclusively in deep Archean cratons
+        if ((rock === ROCK_TYPES.METAMORPHIC || rock === ROCK_TYPES.GRANITIC) &&
+            basin < 0.12 && stress < 0.03 && n1 > 0.6 && n2 > 0.5) {
+            r_deposits[r] |= DEPOSIT.DIAMOND;
+        }
+    }
+
+    // ── Per-metal richness with individual noise functions ──
+    // Each metal gets its own noise so deposit patterns are independent.
+    // Noise is sparse: only regions above threshold show any richness.
+
+    // Metal channels per era.
+    // Carry-forward rules: only 1 age back, unless no newer source exists.
+    // New sources contribute 3× more than inherited.
+    const METAL_CHANNELS = {
+        // ── Copper Age: native/surface sources only ──
+        copperCu:   { sources: [
+            { bits: DEPOSIT.NATIVE_COPPER, weight: 1.0 },
+        ], thresh: 0.38 },
+        copperAu:   { sources: [
+            { bits: DEPOSIT.PLACER_GOLD | DEPOSIT.GOSSANS, weight: 1.0 },
+        ], thresh: 0.65 },
+
+        // ── Bronze Age: carry Copper (1 age back) + new at 3× ──
+        // Gold: new source (epithermal) exists → Copper Age gold does NOT carry
+        bronzeCu:   { sources: [
+            { bits: DEPOSIT.NATIVE_COPPER, weight: 1.0 },                              // carried from Copper
+            { bits: DEPOSIT.VMS_COPPER_ZINC | DEPOSIT.SKARN | DEPOSIT.PORPHYRY_COPPER, weight: 3.0 }, // new
+        ], thresh: 0.38 },
+        bronzeAu:   { sources: [
+            { bits: DEPOSIT.EPITHERMAL_GOLD, weight: 1.0 },                            // new (supersedes Copper Age gold)
+        ], thresh: 0.65 },
+        bronzeSn:   { sources: [
+            { bits: DEPOSIT.TIN, weight: 1.0 },                                        // new
+        ], thresh: 0.72 },
+        bronzePbZn: { sources: [
+            { bits: DEPOSIT.SEDEX_LEAD_ZINC | DEPOSIT.MVT_LEAD_ZINC, weight: 1.0 },   // new
+        ], thresh: 0.3 },
+        bronzeGems: { sources: [
+            { bits: DEPOSIT.PEGMATITE_GEMS | DEPOSIT.DIAMOND, weight: 1.0 },           // new
+        ], thresh: 0.7 },
+
+        // ── Iron Age: carry Bronze (1 age back) only, NOT Copper (2 ages back) ──
+        // Copper: native copper drops off (2 ages back), only Bronze sources carry
+        // Gold: epithermal carries (1 age back, no new Iron Age gold source)
+        // Tin/PbZn/Gems: carry from Bronze (no new sources)
+        ironCu:     { sources: [
+            { bits: DEPOSIT.VMS_COPPER_ZINC | DEPOSIT.SKARN | DEPOSIT.PORPHYRY_COPPER, weight: 1.0 }, // carried from Bronze
+        ], thresh: 0.38 },
+        ironAu:     { sources: [
+            { bits: DEPOSIT.EPITHERMAL_GOLD, weight: 1.0 },                            // carried from Bronze (no new source)
+        ], thresh: 0.65 },
+        ironSn:     { sources: [
+            { bits: DEPOSIT.TIN, weight: 1.0 },                                        // carried from Bronze
+        ], thresh: 0.72 },
+        ironPbZn:   { sources: [
+            { bits: DEPOSIT.SEDEX_LEAD_ZINC | DEPOSIT.MVT_LEAD_ZINC, weight: 1.0 },   // carried from Bronze
+        ], thresh: 0.3 },
+        ironGems:   { sources: [
+            { bits: DEPOSIT.PEGMATITE_GEMS | DEPOSIT.DIAMOND, weight: 1.0 },           // carried from Bronze
+        ], thresh: 0.7 },
+        ironFe:     { sources: [
+            { bits: DEPOSIT.BOG_IRON | DEPOSIT.LATERITE_IRON | DEPOSIT.BIF_IRON, weight: 1.0 }, // new
+        ], thresh: 0.2 },
+    };
+
+    const richArrays = {};
+    const noisePerMetal = {};
+    let noiseSeed = seed + 5600;
+    for (const key of Object.keys(METAL_CHANNELS)) {
+        richArrays[key] = new Float32Array(N);
+        noisePerMetal[key] = new SimplexNoise(noiseSeed++);
+    }
+
+    for (let r = 0; r < N; r++) {
+        const mask = r_deposits[r];
+        if (mask === 0) continue;
+        const px = r_xyz[r * 3], py = r_xyz[r * 3 + 1], pz = r_xyz[r * 3 + 2];
+
+        for (const key of Object.keys(METAL_CHANNELS)) {
+            const ch = METAL_CHANNELS[key];
+
+            // Sum weighted contributions from all source groups
+            let weightedScore = 0;
+            for (const src of ch.sources) {
+                const overlap = mask & src.bits;
+                if (overlap === 0) continue;
+                let count = 0;
+                let tmp = overlap;
+                while (tmp) { count++; tmp &= (tmp - 1); }
+                weightedScore += count * src.weight;
+            }
+            if (weightedScore <= 0) continue;
+
+            // Per-metal noise with per-channel sparsity threshold
+            const thr = ch.thresh;
+            const n = noisePerMetal[key].noise3D(px * 18, py * 18, pz * 18) * 0.5 + 0.5;
+            if (n < thr) continue;
+
+            const intensity = Math.min(1.0, weightedScore * 0.3) * ((n - thr) / (1.0 - thr));
+            richArrays[key][r] = intensity;
+        }
+    }
+
+    return { r_deposits, richArrays };
+}
+
+// ── Metal channel display info (for legend + dropdown labels) ──
+export const METAL_CHANNEL_INFO = {
+    copperCu:   { label: 'Copper',    era: 'Copper Age', color: [0.92, 0.62, 0.28] },
+    copperAu:   { label: 'Gold',      era: 'Copper Age', color: [1.00, 0.88, 0.30] },
+    bronzeCu:   { label: 'Copper',    era: 'Bronze Age', color: [0.92, 0.62, 0.28] },
+    bronzeAu:   { label: 'Gold',      era: 'Bronze Age', color: [1.00, 0.88, 0.30] },
+    bronzeSn:   { label: 'Tin',       era: 'Bronze Age', color: [0.78, 0.76, 0.70] },
+    bronzePbZn: { label: 'Lead-Zinc', era: 'Bronze Age', color: [0.65, 0.65, 0.80] },
+    bronzeGems: { label: 'Gems',      era: 'Bronze Age', color: [0.82, 0.65, 0.95] },
+    ironCu:     { label: 'Copper',    era: 'Iron Age',   color: [0.92, 0.62, 0.28] },
+    ironAu:     { label: 'Gold',      era: 'Iron Age',   color: [1.00, 0.88, 0.30] },
+    ironSn:     { label: 'Tin',       era: 'Iron Age',   color: [0.78, 0.76, 0.70] },
+    ironPbZn:   { label: 'Lead-Zinc', era: 'Iron Age',   color: [0.65, 0.65, 0.80] },
+    ironGems:   { label: 'Gems',      era: 'Iron Age',   color: [0.82, 0.65, 0.95] },
+    ironFe:     { label: 'Iron',      era: 'Iron Age',   color: [0.90, 0.42, 0.30] },
+};
+
+// ── Visualization ──
+
+const OCEAN_COLOR = [0.08, 0.12, 0.22];
+const LAND_BASE = [0.04, 0.04, 0.04]; // near-black land baseline
+
+export function depositRichnessColor(richness, elevation, rampColor) {
+    if (elevation <= 0) return OCEAN_COLOR;
+    if (richness <= 0) return LAND_BASE;
+    const t = Math.min(1, richness);
+    return [
+        LAND_BASE[0] + t * (rampColor[0] - LAND_BASE[0]),
+        LAND_BASE[1] + t * (rampColor[1] - LAND_BASE[1]),
+        LAND_BASE[2] + t * (rampColor[2] - LAND_BASE[2]),
+    ];
+}
+
+// List all deposit names present in a bitmask
+export function listDeposits(mask) {
+    const names = [];
+    for (const info of DEPOSIT_INFO) {
+        if (mask & info.bit) names.push(info.name);
+    }
+    return names;
+}

--- a/js/edit-mode.js
+++ b/js/edit-mode.js
@@ -7,6 +7,8 @@ import { canvas, camera, mapCamera } from './scene.js';
 import { state } from './state.js';
 import { updateHoverHighlight, updateMapHoverHighlight, updatePendingHighlight, updateMapPendingHighlight } from './planet-mesh.js';
 import { KOPPEN_CLASSES } from './koppen.js';
+import { ROCK_TYPE_INFO } from './geology.js';
+import { listDeposits } from './deposits.js';
 import { elevToHeightKm } from './color-map.js';
 
 const raycaster = new THREE.Raycaster();
@@ -156,6 +158,26 @@ function buildHoverHTML(region, plate) {
                     lines.push(`<span class="hi-label">Clima</span> <span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:${hex};vertical-align:middle;margin-right:4px"></span>${kc.code} — ${kc.name}`);
                 }
             }
+        }
+    }
+
+    // Rock type (always shown when available, for land and ocean)
+    if (d.debugLayers && d.debugLayers.rockType) {
+        const rtIdx = d.debugLayers.rockType[region];
+        const rt = ROCK_TYPE_INFO[rtIdx];
+        if (rt) {
+            const [r, g, b] = rt.color;
+            const hex = '#' + [r, g, b].map(v => Math.round(v * 255).toString(16).padStart(2, '0')).join('');
+            lines.push(`<span class="hi-label">Rock</span> <span style="display:inline-block;width:10px;height:10px;border-radius:2px;background:${hex};vertical-align:middle;margin-right:4px"></span>${rt.name}`);
+        }
+    }
+
+    // Deposits (shown when computed)
+    if (d.debugLayers && d.debugLayers.deposits && elev > 0) {
+        const names = listDeposits(d.debugLayers.deposits[region]);
+        if (names.length > 0) {
+            const display = names.length > 3 ? names.slice(0, 3).join(', ') + ` +${names.length - 3}` : names.join(', ');
+            lines.push(`<span class="hi-label">Deps</span> ${display}`);
         }
     }
 

--- a/js/elevation.js
+++ b/js/elevation.js
@@ -2237,7 +2237,7 @@ export function assignElevation(mesh, r_xyz, plateIsOcean, r_plate, plateVec, pl
 
     _timing.push({ stage: 'Fill interior seas', ms: performance.now() - _t0 });
 
-    const debugLayers = { base: dl_base, tectonic: dl_tectonic, noise: dl_noise, interior: dl_interior, coastal: dl_coastal, ocean: dl_ocean, hotspot: dl_hotspot, lip: dl_lip, tecActivity: dl_tecActivity, margins: dl_margins, backArc: dl_backArc, foldRidge: dl_foldRidge, orogenicPower: dl_orogenicPower, basin: r_basinFactor, uniformNoise: dl_uniformNoise, dynamicTopo: dl_dynamicTopo };
+    const debugLayers = { base: dl_base, tectonic: dl_tectonic, noise: dl_noise, interior: dl_interior, coastal: dl_coastal, ocean: dl_ocean, hotspot: dl_hotspot, lip: dl_lip, tecActivity: dl_tecActivity, margins: dl_margins, backArc: dl_backArc, foldRidge: dl_foldRidge, orogenicPower: dl_orogenicPower, basin: r_basinFactor, uniformNoise: dl_uniformNoise, dynamicTopo: dl_dynamicTopo, boundaryType: r_boundaryType, subductFactor: r_subductFactor, bothOcean: r_bothOcean, hasOcean: r_hasOcean };
     if (hasSuperPlates) {
         debugLayers.superPlates = new Float32Array(superPlateData.r_superPlate);
     }

--- a/js/generate.js
+++ b/js/generate.js
@@ -10,6 +10,9 @@ import { computeOceanCurrents } from './ocean.js';
 import { computePrecipitation } from './precipitation.js';
 import { computeTemperature } from './temperature.js';
 import { classifyKoppen } from './koppen.js';
+import { assignRockTypes } from './geology.js';
+import { assignDeposits } from './deposits.js';
+import { SimplexNoise } from './simplex-noise.js';
 
 // Main thread still needs Delaunator for SphereMesh reconstruction
 setDelaunator(Delaunator);
@@ -306,6 +309,23 @@ if (worker) {
                         d.debugLayers.koppen = classifyKoppen(mesh, d.r_elevation,
                             { r_temperature_summer: d.r_temperature_summer, r_temperature_winter: d.r_temperature_winter },
                             { r_precip_summer: d.r_precip_summer, r_precip_winter: d.r_precip_winter });
+                    }
+                    // Re-classify rock types with Köppen data for climate-dependent types (evaporite)
+                    if (state.curData.debugLayers && state.curData.debugLayers.koppen && state.curData.debugLayers.rockType) {
+                        const d = state.curData;
+                        const dl = d.debugLayers;
+                        const noise = new SimplexNoise(d.seed);
+                        const { r_rockType } = assignRockTypes(
+                            mesh, d.r_xyz, d.r_elevation, d.r_plate, d.plateIsOcean,
+                            dl.boundaryType, d.r_stress, dl.subductFactor,
+                            dl.bothOcean, dl.hasOcean,
+                            dl.hotspot, dl.lip, dl.basin,
+                            noise, d.seed, dl.koppen,
+                            dl.erosionDelta, dl.coastal, dl.foldRidge,
+                            dl.orogenicPower, dl.backArc, dl.margins,
+                            dl.dynamicTopo
+                        );
+                        dl.rockType = r_rockType;
                     }
                 }
 
@@ -658,6 +678,43 @@ if (worker) {
                     // Merge climate debug layers
                     if (msg.climateDebugLayers && d.debugLayers) {
                         Object.assign(d.debugLayers, msg.climateDebugLayers);
+                    }
+
+                    // Re-classify rock types and compute deposits with Köppen
+                    if (d.debugLayers && d.debugLayers.koppen) {
+                        try {
+                            const dl = d.debugLayers;
+                            const mesh = d.mesh;
+                            const noise = new SimplexNoise(d.seed);
+
+                            if (dl.rockType) {
+                                const { r_rockType } = assignRockTypes(
+                                    mesh, d.r_xyz, d.r_elevation, d.r_plate, d.plateIsOcean,
+                                    dl.boundaryType, d.r_stress, dl.subductFactor,
+                                    dl.bothOcean, dl.hasOcean,
+                                    dl.hotspot, dl.lip, dl.basin,
+                                    noise, d.seed, dl.koppen,
+                                    dl.erosionDelta, dl.coastal, dl.foldRidge,
+                                    dl.orogenicPower, dl.backArc, dl.margins,
+                                    dl.dynamicTopo
+                                );
+                                dl.rockType = r_rockType;
+
+                                const depResult = assignDeposits(
+                                    mesh, d.r_xyz, d.r_elevation, r_rockType, d.r_plate, d.plateIsOcean,
+                                    dl.boundaryType, d.r_stress, dl.basin,
+                                    dl.hotspot, dl.lip, dl.erosionDelta,
+                                    dl.coastal, dl.foldRidge, dl.orogenicPower,
+                                    dl.backArc, dl.koppen, noise, d.seed
+                                );
+                                dl.deposits = depResult.r_deposits;
+                                for (const [key, arr] of Object.entries(depResult.richArrays)) {
+                                    dl['dep_' + key] = arr;
+                                }
+                            }
+                        } catch (e) {
+                            console.error('[World Orogen] Failed to compute deposits on climate done:', e);
+                        }
                     }
                 }
                 state.climateComputed = true;

--- a/js/geology.js
+++ b/js/geology.js
@@ -1,0 +1,355 @@
+// Rock type classification based on tectonic setting.
+// Assigns one of 16 rock types to each region using boundary type,
+// stress, volcanism, basin factor, and elevation data.
+//
+// Reference: Madeline James — "Mineralogy" & "Deposits and Gemology"
+// https://www.madelinejameswrites.com/blog/minerology
+
+import { SimplexNoise } from './simplex-noise.js';
+
+// ── Rock Type Enum (7 land types + ocean) ──
+export const ROCK_TYPES = {
+    METAMORPHIC: 0,   // shields, collision zones (Himalayan/Ural)
+    GRANITIC:    1,   // basement rock, shields, Andean-style mountains
+    ANDESITIC:   2,   // island arcs, Laramide/Andean ranges
+    BASALTIC:    3,   // LIPs, hotspots, mid-ocean ridges, rifts
+    SANDSTONE:   4,   // non-marine platform environments, basins
+    CARBONATE:   5,   // uplifted marine sediments, ancient shallow seas
+    SEDIMENTS:   6,   // unconsolidated material in lowlands, foreland basins
+    OCEAN:       7,   // ocean — rendered as blue, no geology
+};
+
+// ── Rock Type Metadata ──
+//                                                     hex → [r,g,b] normalized
+export const ROCK_TYPE_INFO = [
+    { name: 'Metamorphic',  code: 'Met', color: [0.502, 0.612, 0.478], category: 'metamorphic',  description: 'Shields and collision zones (Himalayan/Ural)' },           // #809C7A
+    { name: 'Granitic',     code: 'Grt', color: [0.910, 0.722, 0.773], category: 'igneous',      description: 'Basement rock for shields and Andean-style mountains' },    // #E8B8C5
+    { name: 'Andesitic',    code: 'And', color: [0.694, 0.576, 0.718], category: 'igneous',      description: 'Dominant in island arcs and Laramide/Andean ranges' },      // #B193B7
+    { name: 'Basaltic',     code: 'Bas', color: [0.290, 0.290, 0.290], category: 'igneous',      description: 'Large Igneous Provinces (LIPs) and hotspots' },             // #4A4A4A
+    { name: 'Sandstone',    code: 'Sst', color: [0.961, 0.820, 0.553], category: 'sedimentary',  description: 'Non-marine platform environments and basins' },             // #F5D18D
+    { name: 'Carbonate',    code: 'Crb', color: [0.992, 0.949, 0.820], category: 'sedimentary',  description: 'Uplifted marine sediments and ancient shallow seas' },      // #FDF2D1
+    { name: 'Sediments',    code: 'Sed', color: [0.992, 0.973, 0.902], category: 'sedimentary',  description: 'Unconsolidated material in lowlands and foreland basins' }, // #FDF8E6
+    { name: 'Ocean',        code: 'Ocn', color: [0.150, 0.300, 0.550], category: 'ocean',        description: 'Ocean floor' },                                            // #264D8C
+];
+
+// ── Classification Thresholds ──
+const OCEAN_DIVERGENT_STRESS  = 0.03;  // stress threshold for basalt at mid-ocean ridges
+const HOTSPOT_THRESHOLD       = 0.02;  // dl_hotspot value for volcanic rock
+const LIP_THRESHOLD           = 0.005; // dl_lip value for flood basalt
+const LIP_CONTACT_FRAC        = 0.3;   // fraction of LIP_THRESHOLD for contact metamorphism aureole
+const HIGH_STRESS             = 0.40;  // gneiss/schist boundary
+const VERY_HIGH_STRESS        = 0.60;  // gneiss threshold
+const MODERATE_STRESS         = 0.15;  // slate/andesite boundary
+const LOW_STRESS              = 0.05;  // craton vs active interior
+const CRATON_BASIN_THRESH     = 0.30;  // basinFactor below this = craton
+const BASIN_THRESH            = 0.55;  // basinFactor above this = basin
+const SHALLOW_SEA_ELEV        = 0.035; // ~200m — ancient shallow sea limit (high sea level +150-200m)
+const SHALE_ELEV              = 0.10;  // below this in basins → shale
+const GREENSTONE_PROB         = 0.12;  // probability of greenstone in deep cratons
+const RIFT_STRESS             = 0.05;  // stress threshold for rift basalt on land
+const CONVERGENT_OCEAN_STRESS = 0.25;  // stress for diorite vs andesite split
+const FORELAND_STRESS         = 0.08;  // stress indicating foreland basin proximity to orogen
+
+// ── Classification Function ──
+// Uses multi-frequency noise to perturb all thresholds, creating organic
+// transitions between rock types instead of geometric boundaries.
+export function assignRockTypes(
+    mesh, r_xyz, r_elevation, r_plate, plateIsOcean,
+    r_boundaryType, r_stress, r_subductFactor, r_bothOcean, r_hasOcean,
+    dl_hotspot, dl_lip, r_basinFactor, noise, seed,
+    koppenArr,
+    // Extended terrain detail layers (all optional)
+    dl_erosionDelta, dl_coastal, dl_foldRidge, dl_orogenicPower,
+    dl_backArc, dl_margins, dl_dynamicTopo
+) {
+    const N = mesh.numRegions;
+    const NUM_TYPES = ROCK_TYPE_INFO.length;  // 7
+    const r_rockType = new Uint8Array(N);
+
+    // Blend noise: used to modulate between top-3 rock types.
+    // Domain-warped for organic, flowing province boundaries.
+    const blendNoise = new SimplexNoise(seed + 9901);
+    const warpNoise  = new SimplexNoise(seed + 9905);  // warps the blend lookup coords
+
+    // Reusable score array (one per rock type), cleared each region
+    const scores = new Float64Array(NUM_TYPES);
+
+    for (let r = 0; r < N; r++) {
+        const elev    = r_elevation[r];
+        const stress  = r_stress[r];
+        const bType   = r_boundaryType[r];
+        const hotspot = dl_hotspot ? dl_hotspot[r] : 0;
+        const lip     = dl_lip ? dl_lip[r] : 0;
+        const basin   = r_basinFactor ? r_basinFactor[r] : 0.5;
+        const pid     = r_plate[r];
+        const isOceanPlate = plateIsOcean.has ? plateIsOcean.has(pid) : false;
+        const bothOcean = r_bothOcean ? r_bothOcean[r] : 0;
+        const hasOcean  = r_hasOcean ? r_hasOcean[r] : 0;
+
+        // Extended terrain detail
+        const erosion    = dl_erosionDelta ? dl_erosionDelta[r] : 0;
+        const coastal    = dl_coastal ? dl_coastal[r] : 0;
+        const foldRidge  = dl_foldRidge ? dl_foldRidge[r] : 0;
+        const orogPower  = dl_orogenicPower ? dl_orogenicPower[r] : 0;
+        const backArc    = dl_backArc ? dl_backArc[r] : 0;
+        const margin     = dl_margins ? dl_margins[r] : 0;
+
+        // Derived signals
+        const oroGrade = stress + Math.max(0, foldRidge) * 2.0 + Math.max(0, orogPower) * 1.5;
+        const isErosional = erosion < -0.003 || elev > 0.35;
+        const isDepositional = erosion > 0.002 || basin > 0.6;
+        const lipStrength = lip / LIP_THRESHOLD;  // >1 = above threshold
+
+        // ── Clear scores ──
+        scores.fill(0);
+
+        // ════════════════════════════════════════
+        //  OCEAN — just mark as ocean, skip scoring
+        // ════════════════════════════════════════
+        if (elev <= 0) {
+            r_rockType[r] = ROCK_TYPES.OCEAN;
+            continue;
+        } else {
+            // ════════════════════════════════════════
+            //  LAND — Score every signal additively
+            // ════════════════════════════════════════
+
+            // ── VOLCANIC: LIPs ──
+            // lipStrength is the key modulator:
+            //   ~1.0 = barely above threshold (old/eroded LIP) → mostly sediment, some basalt
+            //   ~2-3 = moderate LIP → basalt dominant, sediment at edges
+            //   ~4+  = strong/young LIP → solid basalt
+            if (lipStrength > 1.0) {
+                const ls = lipStrength - 1.0;  // 0 at threshold, ramps up
+                scores[ROCK_TYPES.BASALTIC]  += ls * ls * 1.5;  // quadratic: weak LIPs get little basalt
+                scores[ROCK_TYPES.SANDSTONE] += Math.max(0, 1.5 - ls * 0.8);  // sediment fills gaps in old LIPs
+                scores[ROCK_TYPES.SEDIMENTS] += Math.max(0, 1.0 - ls * 0.6);
+                // Context: subduction nearby → andesite blends in
+                if (bType === 1 && hasOcean) scores[ROCK_TYPES.ANDESITIC] += 1.5;
+                // Context: hotspot nearby → granitic blends in
+                if (hotspot > HOTSPOT_THRESHOLD * 0.5 && !isOceanPlate) {
+                    scores[ROCK_TYPES.GRANITIC] += 1.2;
+                }
+            }
+            // Contact metamorphism aureole around LIPs
+            if (lipStrength > LIP_CONTACT_FRAC && lipStrength <= 1.0) {
+                const aurStr = (lipStrength - LIP_CONTACT_FRAC) / (1.0 - LIP_CONTACT_FRAC);
+                scores[ROCK_TYPES.METAMORPHIC] += aurStr * 3.0;
+            }
+
+            // ── VOLCANIC: Hotspot ──
+            if (hotspot > HOTSPOT_THRESHOLD) {
+                const hStr = hotspot / HOTSPOT_THRESHOLD;
+                if (!isOceanPlate) {
+                    scores[ROCK_TYPES.GRANITIC] += hStr * 1.2;
+                    if (isErosional) scores[ROCK_TYPES.GRANITIC] += 0.8;
+                } else {
+                    scores[ROCK_TYPES.BASALTIC] += hStr * 2.5;
+                }
+            }
+
+            // ── OROGENIC BELTS: Subduction mountains ──
+            if (bType === 1 && hasOcean && stress > MODERATE_STRESS) {
+                const arcStress = stress / MODERATE_STRESS;
+                if (oroGrade > HIGH_STRESS) {
+                    // Andean-style: granite + andesite + metamorphic
+                    scores[ROCK_TYPES.GRANITIC]    += 1.5;
+                    scores[ROCK_TYPES.ANDESITIC]   += 2.5;
+                    scores[ROCK_TYPES.METAMORPHIC] += 1.0;
+                    if (isErosional) scores[ROCK_TYPES.GRANITIC] += 1.5;
+                } else {
+                    // Laramide-style: heavily andesitic
+                    scores[ROCK_TYPES.ANDESITIC] += arcStress * 3.0;
+                    scores[ROCK_TYPES.GRANITIC]  += arcStress * 0.6;
+                }
+            }
+
+            // ── OROGENIC BELTS: Continental collision ──
+            // Even continent-continent collisions often involve remnant
+            // subduction-zone andesitic rock from prior oceanic closure.
+            if (bType === 1 && stress > MODERATE_STRESS && !hasOcean) {
+                if (oroGrade > HIGH_STRESS) {
+                    scores[ROCK_TYPES.METAMORPHIC] += 3.0;
+                    scores[ROCK_TYPES.ANDESITIC]   += 1.0; // remnant arc material
+                    scores[ROCK_TYPES.CARBONATE]   += 0.8;
+                } else {
+                    scores[ROCK_TYPES.METAMORPHIC] += 2.0;
+                    scores[ROCK_TYPES.ANDESITIC]   += 0.8;
+                    scores[ROCK_TYPES.SANDSTONE]   += 1.0;
+                    scores[ROCK_TYPES.CARBONATE]   += 0.5;
+                }
+            }
+
+            // ── OROGENIC BELTS: Island arcs ──
+            if (bType === 1 && bothOcean && stress > MODERATE_STRESS) {
+                scores[ROCK_TYPES.ANDESITIC] += 4.0;
+                scores[ROCK_TYPES.BASALTIC]  += 0.8;
+            }
+
+            // ── Fold belts (broad orogenic influence) ──
+            // Mountain ranges contain andesitic rock from past subduction
+            // alongside metamorphic from pressure/heat.
+            if (oroGrade > HIGH_STRESS * 0.7 && foldRidge > 0.01) {
+                const foldStr = Math.min(3, oroGrade / HIGH_STRESS);
+                scores[ROCK_TYPES.METAMORPHIC] += foldStr * 1.5;
+                scores[ROCK_TYPES.ANDESITIC]   += foldStr * 1.0;
+                scores[ROCK_TYPES.SANDSTONE]   += foldStr * 0.3;
+            }
+
+            // ── Back-arc basin ──
+            if (backArc < -0.02) {
+                const baStr = Math.min(3, Math.abs(backArc) * 30);
+                scores[ROCK_TYPES.BASALTIC]  += baStr * 0.5;
+                scores[ROCK_TYPES.SANDSTONE] += baStr * 0.8;
+                scores[ROCK_TYPES.SEDIMENTS] += baStr * 1.2;
+            }
+
+            // ── Rift zone ──
+            if (bType === 2 && stress > RIFT_STRESS) {
+                scores[ROCK_TYPES.BASALTIC]  += 2.5;
+                scores[ROCK_TYPES.SEDIMENTS] += 0.5;
+            }
+
+            // ── Transform fault ──
+            if (bType === 3 && stress > MODERATE_STRESS) {
+                scores[ROCK_TYPES.METAMORPHIC] += 1.5;
+                scores[ROCK_TYPES.SANDSTONE]   += 0.5;
+            }
+
+            // ── CRATONS: Shield vs Platform ──
+            // Shields only where erosion is strong AND it's a deep craton (low basin).
+            // Most craton surface is platform (sedimentary cover).
+            if (basin < CRATON_BASIN_THRESH && stress < LOW_STRESS) {
+                if (isErosional && basin < 0.15) {
+                    // Deep shield: exposed basement (granitic + metamorphic)
+                    scores[ROCK_TYPES.GRANITIC]    += 2.2;
+                    scores[ROCK_TYPES.METAMORPHIC] += 1.0;
+                } else if (isErosional) {
+                    // Moderate erosion on craton edge: mostly sedimentary, some basement
+                    scores[ROCK_TYPES.GRANITIC]    += 0.6;
+                    scores[ROCK_TYPES.SANDSTONE]   += 1.5;
+                } else {
+                    // Platform: sedimentary cover
+                    if (elev < SHALLOW_SEA_ELEV) scores[ROCK_TYPES.CARBONATE] += 2.5;
+                    else { scores[ROCK_TYPES.SANDSTONE] += 2.0; scores[ROCK_TYPES.SEDIMENTS] += 0.8; }
+                }
+            }
+
+            // ── Ancient shallow seas ──
+            if (elev < SHALLOW_SEA_ELEV && elev > 0 && !isErosional) {
+                scores[ROCK_TYPES.CARBONATE] += 2.0;
+            }
+
+            // ── Foreland basins ──
+            if (stress > FORELAND_STRESS && stress < MODERATE_STRESS && isDepositional) {
+                scores[ROCK_TYPES.SEDIMENTS] += 2.0;
+                scores[ROCK_TYPES.SANDSTONE] += 1.0;
+            }
+
+            // ── Continental margins / coastal ──
+            if (Math.abs(margin) > 0.02 || (Math.abs(coastal) > 0.01 && stress < MODERATE_STRESS)) {
+                if (elev < SHALLOW_SEA_ELEV) scores[ROCK_TYPES.CARBONATE] += 1.5;
+                scores[ROCK_TYPES.SANDSTONE] += 1.0;
+                scores[ROCK_TYPES.SEDIMENTS] += 0.8;
+            }
+
+            // ── Rift basins ──
+            if (bType === 2 && basin > 0.4 && stress < RIFT_STRESS) {
+                scores[ROCK_TYPES.SANDSTONE] += 1.2;
+                scores[ROCK_TYPES.SEDIMENTS] += 1.5;
+            }
+
+            // ── Depositional basins ──
+            if (isDepositional || basin > BASIN_THRESH) {
+                if (elev < SHALLOW_SEA_ELEV)       scores[ROCK_TYPES.CARBONATE]  += 1.5;
+                else if (elev < SHALE_ELEV)        scores[ROCK_TYPES.SEDIMENTS]  += 1.5;
+                else                               scores[ROCK_TYPES.SANDSTONE]  += 1.2;
+            }
+
+            // ── Erosional interior ──
+            // Only expose granite in strongly eroded, high-elevation areas.
+            // Low-elevation erosion just thins sedimentary cover, doesn't reach basement.
+            if (isErosional && stress < MODERATE_STRESS && elev > 0.20) {
+                scores[ROCK_TYPES.GRANITIC]    += 0.5;
+                scores[ROCK_TYPES.METAMORPHIC] += 0.2;
+            }
+
+            // ── ELEVATION-BASED BASEMENT EXPOSURE ──
+            // Cubic ease-in: foothills barely affected, high mountains strongly.
+            //   elev 0.10 → t=0, elev ~0.40 → t=1
+            //   cubic: t³ keeps low elevations mostly sedimentary,
+            //   ramps steeply only for real peaks.
+            if (elev > 0.12) {
+                const raw = Math.min(1.0, (elev - 0.12) * 2.5);  // reaches 1.0 at ~0.52
+                const t = raw * raw * raw;  // cubic ease-in
+                scores[ROCK_TYPES.METAMORPHIC] += t * 1.2;
+                scores[ROCK_TYPES.GRANITIC]    += t * 0.6;
+                // Andesitic: strong at/near subduction zones in mountains
+                if (hasOcean && bType === 1) {
+                    scores[ROCK_TYPES.ANDESITIC] += t * 2.5;
+                } else if (stress > 0.08 && hasOcean) {
+                    // Near subduction (some stress + ocean involvement)
+                    scores[ROCK_TYPES.ANDESITIC] += t * 1.8;
+                } else if (stress > 0.05) {
+                    // Any stressed mountain region — remnant arc material
+                    scores[ROCK_TYPES.ANDESITIC] += t * 0.5;
+                }
+                // Suppress sedimentary with same curve
+                scores[ROCK_TYPES.SEDIMENTS] *= (1.0 - t * 0.9);
+                scores[ROCK_TYPES.SANDSTONE] *= (1.0 - t * 0.90);
+                scores[ROCK_TYPES.CARBONATE] *= (1.0 - t * 0.3);
+            }
+
+            // ── DEFAULT SEDIMENTARY FLOOR ──
+            // ~75% of continental surface is sedimentary — but only lowlands.
+            if (elev < 0.10) {
+                if (elev < SHALLOW_SEA_ELEV)       scores[ROCK_TYPES.CARBONATE]  += 0.5;
+                else if (basin > 0.4)              scores[ROCK_TYPES.SEDIMENTS]  += 0.5;
+                scores[ROCK_TYPES.SANDSTONE] += 0.3;
+            }
+        }
+
+        // ── Find top-3 rock types by score ──
+        let first = 0, firstScore = scores[0];
+        let second = 0, secondScore = -1;
+        let third = 0, thirdScore = -1;
+        for (let t = 1; t < NUM_TYPES; t++) {
+            const s = scores[t];
+            if (s > firstScore) {
+                third = second; thirdScore = secondScore;
+                second = first; secondScore = firstScore;
+                first = t; firstScore = s;
+            } else if (s > secondScore) {
+                third = second; thirdScore = secondScore;
+                second = t; secondScore = s;
+            } else if (s > thirdScore) {
+                third = t; thirdScore = s;
+            }
+        }
+
+        // ── Pick among top-3 using noise ──
+        // noise remapped to 0..1; selection thresholds:
+        //   > 0.4  → 1st choice  (60% of range → most common)
+        //   > 0.1  → 2nd choice  (30% of range)
+        //   <= 0.1 → 3rd choice  (10% of range)
+        // Only use 2nd/3rd if they actually have score.
+        const px = r_xyz[r * 3], py = r_xyz[r * 3 + 1], pz = r_xyz[r * 3 + 2];
+        // Domain warp: offset the blend lookup by a low-freq noise field
+        // so rock province boundaries bend and flow organically.
+        const warpAmp = 0.12;
+        const wx = px + warpNoise.noise3D(px * 10, py * 10, pz * 10) * warpAmp;
+        const wy = py + warpNoise.noise3D(px * 10 + 31, py * 10 + 31, pz * 10 + 31) * warpAmp;
+        const wz = pz + warpNoise.noise3D(px * 10 + 67, py * 10 + 67, pz * 10 + 67) * warpAmp;
+        const n = blendNoise.noise3D(wx * 28, wy * 28, wz * 28) * 0.5 + 0.5; // 0..1
+
+        if (n > 0.4 || secondScore <= 0) {
+            r_rockType[r] = first;
+        } else if (n > 0.1 || thirdScore <= 0) {
+            r_rockType[r] = second;
+        } else {
+            r_rockType[r] = third;
+        }
+    }
+
+    return { r_rockType };
+}

--- a/js/main.js
+++ b/js/main.js
@@ -11,7 +11,8 @@ import { buildMesh, updateMeshColors, updateSuperPlateBorders, buildMapMesh, reb
 import { setupEditMode } from './edit-mode.js';
 import { detailFromSlider, sliderFromDetail } from './detail-scale.js';
 import { KOPPEN_CLASSES } from './koppen.js';
-import { elevationToColor } from './color-map.js';
+import { elevationToColor, rockTypeColor } from './color-map.js';
+import { ROCK_TYPE_INFO } from './geology.js';
 
 // Slider value displays + stale tracking
 const sliderIds = ['sN','sP','sCn','sJ','sNs','sCsv','sLc'];
@@ -201,7 +202,10 @@ const CLIMATE_LAYERS = new Set([
     'precipSummer', 'precipWinter',
     'rainShadowSummer', 'rainShadowWinter',
     'tempSummer', 'tempWinter',
-    'koppen', 'biome', 'continentality'
+    'koppen', 'biome', 'continentality',
+    'dep_copperCu', 'dep_copperAu',
+    'dep_bronzeCu', 'dep_bronzeAu', 'dep_bronzeSn', 'dep_bronzePbZn', 'dep_bronzeGems',
+    'dep_ironCu', 'dep_ironAu', 'dep_ironSn', 'dep_ironPbZn', 'dep_ironGems', 'dep_ironFe',
 ]);
 
 // Map tabs → tab-layer mapping
@@ -383,6 +387,60 @@ function updateLegend(layer) {
                 updateMapKoppenHoverHighlight();
             });
         });
+    } else if (layer === 'rockType') {
+        // Rock type legend — swatch grid with hover tooltips (like Köppen)
+        let html = '<div class="legend-koppen-header">Rock Type Classification</div>';
+        html += '<div class="legend-koppen">';
+        for (let i = 0; i < ROCK_TYPE_INFO.length; i++) {
+            const rt = ROCK_TYPE_INFO[i];
+            const [r, g, b] = rt.color;
+            const hex = `rgb(${Math.round(r*255)},${Math.round(g*255)},${Math.round(b*255)})`;
+            html += `<div class="legend-koppen-item" data-rock="${i}"><span class="legend-koppen-swatch" style="background:${hex}"></span>${rt.code}</div>`;
+        }
+        html += '<div class="legend-koppen-tooltip" id="rockTypeTip"></div>';
+        html += '</div>';
+        vizLegend.innerHTML = html;
+        const tipEl = document.getElementById('rockTypeTip');
+        const container = vizLegend.querySelector('.legend-koppen');
+        vizLegend.querySelectorAll('.legend-koppen-item').forEach(item => {
+            item.addEventListener('mouseenter', () => {
+                const idx = parseInt(item.dataset.rock, 10);
+                const rt = ROCK_TYPE_INFO[idx];
+                if (!rt) return;
+                tipEl.textContent = `${rt.name} — ${rt.description}`;
+                tipEl.classList.add('visible');
+                const itemRect = item.getBoundingClientRect();
+                const containerRect = container.getBoundingClientRect();
+                const tipWidth = 280;
+                let left = itemRect.left - containerRect.left + itemRect.width / 2 - tipWidth / 2;
+                left = Math.max(0, Math.min(left, containerRect.width - tipWidth));
+                tipEl.style.left = left + 'px';
+                tipEl.style.bottom = (containerRect.bottom - itemRect.top + 6) + 'px';
+            });
+            item.addEventListener('mouseleave', () => {
+                tipEl.classList.remove('visible');
+            });
+        });
+    } else if (layer.startsWith('dep_')) {
+        // Per-metal richness legend — gradient bar with era + metal label
+        const key = layer.slice(4);
+        const chInfo = { copperCu: { label: 'Copper Age \u2014 Copper', high: '#EB9E47' },
+                         copperAu: { label: 'Copper Age \u2014 Gold',   high: '#FFE04D' },
+                         bronzeCu: { label: 'Bronze Age \u2014 Copper', high: '#EB9E47' },
+                         bronzeAu: { label: 'Bronze Age \u2014 Gold',   high: '#FFE04D' },
+                         bronzeSn: { label: 'Bronze Age \u2014 Tin',    high: '#C7C2B3' },
+                         bronzePbZn:{label: 'Bronze Age \u2014 Lead-Zinc', high: '#A6A6CC' },
+                         bronzeGems:{label: 'Bronze Age \u2014 Gems',   high: '#D1A6F2' },
+                         ironCu:   { label: 'Iron Age \u2014 Copper',   high: '#EB9E47' },
+                         ironAu:   { label: 'Iron Age \u2014 Gold',     high: '#FFE04D' },
+                         ironSn:   { label: 'Iron Age \u2014 Tin',      high: '#C7C2B3' },
+                         ironPbZn: { label: 'Iron Age \u2014 Lead-Zinc',high: '#A6A6CC' },
+                         ironGems: { label: 'Iron Age \u2014 Gems',     high: '#D1A6F2' },
+                         ironFe:   { label: 'Iron Age \u2014 Iron',     high: '#E66B4D' } };
+        const info = chInfo[key] || { label: layer, high: '#E6B340' };
+        vizLegend.innerHTML =
+            `<div class="legend-gradient" style="background:linear-gradient(to right,#0A0A0A 0%,${info.high} 100%)"></div>` +
+            `<div class="legend-labels"><span>None</span><span>${info.label}</span><span>Rich</span></div>`;
     } else if (layer === 'biome') {
         // Satellite biome legend — gradient bar of key biome colors
         const biomeStops = [

--- a/js/planet-mesh.js
+++ b/js/planet-mesh.js
@@ -3,9 +3,10 @@
 import * as THREE from 'three';
 import { renderer, scene, waterMesh, atmosMesh, starsMesh } from './scene.js';
 import { state } from './state.js';
-import { elevationToColor, elevToHeightKm, biomeColor } from './color-map.js';
+import { elevationToColor, elevToHeightKm, biomeColor, rockTypeColor } from './color-map.js';
 import { makeRng } from './rng.js';
 import { KOPPEN_CLASSES } from './koppen.js';
+import { depositRichnessColor, METAL_CHANNEL_INFO } from './deposits.js';
 
 // Clipping planes for map wrap — keep everything within x ∈ [-2, 2]
 renderer.localClippingEnabled = true;
@@ -302,9 +303,16 @@ export function buildMapMesh() {
     const isKoppen = debugLayer === 'koppen';
     const isBiome = debugLayer === 'biome';
     const koppenArr = (isKoppen || isBiome) ? (debugLayers && debugLayers.koppen) : null;
+    const isRockType = debugLayer === 'rockType';
+    const rockTypeArr = isRockType ? (debugLayers && debugLayers.rockType) : null;
+    // Deposit layers: dep_copperCu, dep_bronzeSn, etc.
+    const depKey = debugLayer.startsWith('dep_') ? debugLayer.slice(4) : null;
+    const isDeposits = depKey != null && depKey in METAL_CHANNEL_INFO;
+    const depositsRichArr = isDeposits && debugLayers ? debugLayers[debugLayer] : null;
+    const depositsRampColor = isDeposits ? METAL_CHANNEL_INFO[depKey].color : null;
     const isCont = debugLayer === 'continentality';
     const contArr = isCont ? (debugLayers && debugLayers.continentality) : null;
-    if (!isHeightmap && !isLandHeightmap && !isOceanCurrent && !isPrecip && !isRainShadow && !isTemp && !isKoppen && !isBiome && !isCont && debugLayer && debugLayers && debugLayers[debugLayer]) {
+    if (!isHeightmap && !isLandHeightmap && !isOceanCurrent && !isPrecip && !isRainShadow && !isTemp && !isKoppen && !isBiome && !isRockType && !isDeposits && !isCont && debugLayer && debugLayers && debugLayers[debugLayer]) {
         dbgArr = debugLayers[debugLayer];
         for (let r = 0; r < mesh.numRegions; r++) {
             if (dbgArr[r] < dbgMin) dbgMin = dbgArr[r];
@@ -359,6 +367,10 @@ export function buildMapMesh() {
                 [cr, cg, cb] = continentalityColor(contArr[br]);
             } else if (isKoppen && koppenArr) {
                 [cr, cg, cb] = koppenColor(koppenArr[br]);
+            } else if (isRockType && rockTypeArr) {
+                [cr, cg, cb] = rockTypeColor(rockTypeArr[br]);
+            } else if (isDeposits && depositsRichArr) {
+                [cr, cg, cb] = depositRichnessColor(depositsRichArr[br], r_elevation[br], depositsRampColor);
             } else if (isTemp && tempArr) {
                 [cr, cg, cb] = temperatureColor(tempArr[br]);
             } else if (isPrecip && precipArr) {
@@ -733,9 +745,16 @@ export function buildMesh() {
     const isKoppen = debugLayer === 'koppen';
     const isBiome = debugLayer === 'biome';
     const koppenArr = (isKoppen || isBiome) ? (debugLayers && debugLayers.koppen) : null;
+    const isRockType = debugLayer === 'rockType';
+    const rockTypeArr = isRockType ? (debugLayers && debugLayers.rockType) : null;
+    // Deposit layers: dep_copperCu, dep_bronzeSn, etc.
+    const depKey = debugLayer.startsWith('dep_') ? debugLayer.slice(4) : null;
+    const isDeposits = depKey != null && depKey in METAL_CHANNEL_INFO;
+    const depositsRichArr = isDeposits && debugLayers ? debugLayers[debugLayer] : null;
+    const depositsRampColor = isDeposits ? METAL_CHANNEL_INFO[depKey].color : null;
     const isCont = debugLayer === 'continentality';
     const contArr = isCont ? (debugLayers && debugLayers.continentality) : null;
-    if (!isHeightmap && !isLandHeightmap && !isOceanCurrent && !isPrecip && !isRainShadow && !isTemp && !isKoppen && !isBiome && !isCont && debugLayer && debugLayers && debugLayers[debugLayer]) {
+    if (!isHeightmap && !isLandHeightmap && !isOceanCurrent && !isPrecip && !isRainShadow && !isTemp && !isKoppen && !isBiome && !isRockType && !isDeposits && !isCont && debugLayer && debugLayers && debugLayers[debugLayer]) {
         dbgArr = debugLayers[debugLayer];
         for (let r = 0; r < mesh.numRegions; r++) {
             if (dbgArr[r] < dbgMin) dbgMin = dbgArr[r];
@@ -820,6 +839,10 @@ export function buildMesh() {
                 [cr, cg, cb] = continentalityColor(contArr[br]);
             } else if (isKoppen && koppenArr) {
                 [cr, cg, cb] = koppenColor(koppenArr[br]);
+            } else if (isRockType && rockTypeArr) {
+                [cr, cg, cb] = rockTypeColor(rockTypeArr[br]);
+            } else if (isDeposits && depositsRichArr) {
+                [cr, cg, cb] = depositRichnessColor(depositsRichArr[br], r_elevation[br], depositsRampColor);
             } else if (isTemp && tempArr) {
                 [cr, cg, cb] = temperatureColor(tempArr[br]);
             } else if (isPrecip && precipArr) {
@@ -969,9 +992,16 @@ export function updateMeshColors() {
     const isKoppen = debugLayer === 'koppen';
     const isBiome = debugLayer === 'biome';
     const koppenArr = (isKoppen || isBiome) ? (debugLayers && debugLayers.koppen) : null;
+    const isRockType = debugLayer === 'rockType';
+    const rockTypeArr = isRockType ? (debugLayers && debugLayers.rockType) : null;
+    // Deposit layers: dep_copperCu, dep_bronzeSn, etc.
+    const depKey = debugLayer.startsWith('dep_') ? debugLayer.slice(4) : null;
+    const isDeposits = depKey != null && depKey in METAL_CHANNEL_INFO;
+    const depositsRichArr = isDeposits && debugLayers ? debugLayers[debugLayer] : null;
+    const depositsRampColor = isDeposits ? METAL_CHANNEL_INFO[depKey].color : null;
     const isCont = debugLayer === 'continentality';
     const contArr = isCont ? (debugLayers && debugLayers.continentality) : null;
-    if (!isHeightmap && !isLandHeightmap && !isOceanCurrent && !isPrecip && !isRainShadow && !isTemp && !isKoppen && !isBiome && !isCont && debugLayer && debugLayers && debugLayers[debugLayer]) {
+    if (!isHeightmap && !isLandHeightmap && !isOceanCurrent && !isPrecip && !isRainShadow && !isTemp && !isKoppen && !isBiome && !isRockType && !isDeposits && !isCont && debugLayer && debugLayers && debugLayers[debugLayer]) {
         dbgArr = debugLayers[debugLayer];
         for (let r = 0; r < mesh.numRegions; r++) {
             if (dbgArr[r] < dbgMin) dbgMin = dbgArr[r];
@@ -987,6 +1017,8 @@ export function updateMeshColors() {
         if (isBiome && biomeSmoothed) return [biomeSmoothed[br * 3], biomeSmoothed[br * 3 + 1], biomeSmoothed[br * 3 + 2]];
         if (isCont && contArr) return continentalityColor(contArr[br]);
         if (isKoppen && koppenArr) return koppenColor(koppenArr[br]);
+        if (isRockType && rockTypeArr) return rockTypeColor(rockTypeArr[br]);
+        if (isDeposits && depositsRichArr) return depositRichnessColor(depositsRichArr[br], r_elevation[br], depositsRampColor);
         if (isTemp && tempArr) return temperatureColor(tempArr[br]);
         if (isPrecip && precipArr) return precipitationColor(precipArr[br]);
         if (isRainShadow && rainShadowArr) return rainShadowColor(rainShadowArr[br]);
@@ -1901,6 +1933,7 @@ export async function exportMap(type, width, onProgress) {
     // Climate-dependent export types (Satellite / Köppen)
     const debugLayers = state.curData.debugLayers;
     const koppenArr = (type === 'biome' || type === 'koppen') ? (debugLayers && debugLayers.koppen) : null;
+    const rockTypeArr = type === 'rockType' ? (debugLayers && debugLayers.rockType) : null;
     const biomeSmoothed = (type === 'biome' && koppenArr) ? getCachedBiomeSmoothed(mesh, koppenArr, r_elevation) : null;
 
     // Build map triangles (same projection as buildMapMesh, chosen coloring, no grid)
@@ -1949,6 +1982,8 @@ export async function exportMap(type, width, onProgress) {
                 cr = biomeSmoothed[br * 3]; cg = biomeSmoothed[br * 3 + 1]; cb = biomeSmoothed[br * 3 + 2];
             } else if (type === 'koppen' && koppenArr) {
                 [cr, cg, cb] = koppenColor(koppenArr[br]);
+            } else if (type === 'rockType' && rockTypeArr) {
+                [cr, cg, cb] = rockTypeColor(rockTypeArr[br]);
             } else {
                 [cr, cg, cb] = elevationToColor(r_elevation[br]);
             }
@@ -2176,6 +2211,7 @@ export async function exportMapBatch(types, width, onProgress) {
     const { mesh, r_xyz, t_xyz, r_elevation } = state.curData;
     const debugLayers = state.curData.debugLayers;
     const koppenArr = debugLayers && debugLayers.koppen;
+    const rockTypeArr = debugLayers && debugLayers.rockType;
     const biomeSmoothed = koppenArr ? getCachedBiomeSmoothed(mesh, koppenArr, r_elevation) : null;
     const { numSides, numTriangles } = mesh;
     const PI = Math.PI;

--- a/js/planet-worker.js
+++ b/js/planet-worker.js
@@ -14,6 +14,8 @@ import { computeOceanCurrents } from './ocean.js';
 import { computePrecipitation } from './precipitation.js';
 import { computeTemperature } from './temperature.js';
 import { classifyKoppen } from './koppen.js';
+import { assignRockTypes } from './geology.js';
+import { assignDeposits } from './deposits.js';
 import { computeTerrainMetrics } from './terrain-metrics.js';
 import { applyPlatePhysics, expandPlatePhysicsDebug } from './plate-physics.js';
 import { SUPER_PLATE_PHYSICS_MULT } from './terrain-config.js';
@@ -45,9 +47,10 @@ function runPostProcessing(mesh, r_xyz, r_elevation, params, neighborDist, seed,
     const timing = [];
 
     // Terrain warp — first step, before ocean detection or smoothing
+    let warpMap = null;
     if (terrainWarp > 0) {
         const t0 = performance.now();
-        warpTerrain(mesh, r_elevation, r_xyz, seed, terrainWarp, r_hotspot);
+        warpMap = warpTerrain(mesh, r_elevation, r_xyz, seed, terrainWarp, r_hotspot);
         timing.push({ stage: `Terrain warp (strength=${terrainWarp.toFixed(2)})`, ms: performance.now() - t0 });
     }
 
@@ -101,7 +104,7 @@ function runPostProcessing(mesh, r_xyz, r_elevation, params, neighborDist, seed,
         dl_erosionDelta[r] = r_elevation[r] - preErosion[r];
     }
 
-    return { dl_erosionDelta, postTiming: timing };
+    return { dl_erosionDelta, warpMap, postTiming: timing };
 }
 
 function getClimateParams(data) {
@@ -257,9 +260,33 @@ function handleGenerate(data) {
 
         progress(60, 'Eroding terrain\u2026');
         t0 = performance.now();
-        const { dl_erosionDelta, postTiming } = runPostProcessing(mesh, r_xyz, r_elevation, { smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, terrainWarp }, neighborDist, seed, debugLayers.hotspot);
+        const { dl_erosionDelta, warpMap, postTiming } = runPostProcessing(mesh, r_xyz, r_elevation, { smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, terrainWarp }, neighborDist, seed, debugLayers.hotspot);
         timing.push({ stage: 'Terrain post-processing (total)', ms: performance.now() - t0 });
         debugLayers.erosionDelta = dl_erosionDelta;
+
+        // Apply terrain warp mapping to debug layers so rock/deposit classification
+        // aligns with the warped terrain rather than pre-warp positions.
+        if (warpMap) {
+            const layersToWarp = ['hotspot', 'lip', 'base', 'tectonic', 'interior', 'coastal',
+                'ocean', 'margins', 'backArc', 'foldRidge', 'orogenicPower', 'dynamicTopo',
+                'basin', 'boundaryType', 'subductFactor', 'bothOcean', 'hasOcean'];
+            for (const key of layersToWarp) {
+                const src = debugLayers[key];
+                if (!src) continue;
+                const warped = new src.constructor(src.length);
+                for (let r = 0; r < mesh.numRegions; r++) {
+                    warped[r] = src[warpMap[r]];
+                }
+                debugLayers[key] = warped;
+            }
+            // Also warp stress (not in debugLayers, it's a separate array)
+            const warpedStress = new Float32Array(mesh.numRegions);
+            for (let r = 0; r < mesh.numRegions; r++) {
+                warpedStress[r] = r_stress[warpMap[r]];
+            }
+            r_stress.set(warpedStress);
+            timing.push({ stage: 'Warp debug layers for geology', ms: performance.now() - t0 });
+        }
 
         // Expand plate physics diagnostics to hi-res mesh
         {
@@ -273,6 +300,22 @@ function handleGenerate(data) {
             debugLayers.velChange = ppd.dl_velChange;
             debugLayers.mantleFlow = ppd.dl_mantleFlow;
         }
+
+        // Rock type classification (runs before climate; re-runs after Köppen for evaporite)
+        progress(65, 'Classifying rock types\u2026');
+        t0 = performance.now();
+        let { r_rockType } = assignRockTypes(
+            mesh, r_xyz, r_elevation, r_plate, plateIsOcean,
+            debugLayers.boundaryType, r_stress, debugLayers.subductFactor,
+            debugLayers.bothOcean, debugLayers.hasOcean,
+            debugLayers.hotspot, debugLayers.lip, debugLayers.basin,
+            noise, seed, null,
+            debugLayers.erosionDelta, debugLayers.coastal, debugLayers.foldRidge,
+            debugLayers.orogenicPower, debugLayers.backArc, debugLayers.margins,
+            debugLayers.dynamicTopo
+        );
+        debugLayers.rockType = r_rockType;
+        timing.push({ stage: 'Rock type classification', ms: performance.now() - t0 });
 
         let windResult = null, oceanResult = null, precipResult = null, tempResult = null;
 
@@ -315,7 +358,38 @@ function handleGenerate(data) {
             t0 = performance.now();
             debugLayers.koppen = classifyKoppen(mesh, r_elevation, tempResult, precipResult);
             timing.push({ stage: 'Köppen classification', ms: performance.now() - t0 });
+
+            // Re-run rock types with Köppen data for climate-dependent types (evaporite)
+            t0 = performance.now();
+            ({ r_rockType } = assignRockTypes(
+                mesh, r_xyz, r_elevation, r_plate, plateIsOcean,
+                debugLayers.boundaryType, r_stress, debugLayers.subductFactor,
+                debugLayers.bothOcean, debugLayers.hasOcean,
+                debugLayers.hotspot, debugLayers.lip, debugLayers.basin,
+                noise, seed, debugLayers.koppen,
+                debugLayers.erosionDelta, debugLayers.coastal, debugLayers.foldRidge,
+                debugLayers.orogenicPower, debugLayers.backArc, debugLayers.margins,
+                debugLayers.dynamicTopo
+            ));
+            debugLayers.rockType = r_rockType;
+            timing.push({ stage: 'Rock type reclassification (with climate)', ms: performance.now() - t0 });
+
+            // Re-run deposits with climate data for climate-dependent types (bog/laterite iron)
+            t0 = performance.now();
+            const depResult2 = assignDeposits(
+                mesh, r_xyz, r_elevation, r_rockType, r_plate, plateIsOcean,
+                debugLayers.boundaryType, r_stress, debugLayers.basin,
+                debugLayers.hotspot, debugLayers.lip, debugLayers.erosionDelta,
+                debugLayers.coastal, debugLayers.foldRidge, debugLayers.orogenicPower,
+                debugLayers.backArc, debugLayers.koppen, noise, seed
+            );
+            debugLayers.deposits = depResult2.r_deposits;
+            for (const [key, arr] of Object.entries(depResult2.richArrays)) {
+                debugLayers['dep_' + key] = arr;
+            }
+            timing.push({ stage: 'Mineral deposit reclassification (with climate)', ms: performance.now() - t0 });
         }
+
 
         progress(skipClimate ? 75 : 90, 'Computing triangle elevations\u2026');
         t0 = performance.now();

--- a/js/terrain-post.js
+++ b/js/terrain-post.js
@@ -257,6 +257,7 @@ export function warpTerrain(mesh, r_elevation, r_xyz, seed, strength, r_hotspot)
     const maxAmp = WARP_MAX_AMP_MULT * strength; // radians (~760 km at Earth scale when strength=1)
 
     const out = new Float32Array(r_elevation);
+    const warpMap = new Int32Array(N);  // warpMap[r] = source region for r after warp
 
     for (let r = 0; r < N; r++) {
         const px = r_xyz[3 * r], py = r_xyz[3 * r + 1], pz = r_xyz[3 * r + 2];
@@ -303,6 +304,7 @@ export function warpTerrain(mesh, r_elevation, r_xyz, seed, strength, r_hotspot)
         }
 
         out[r] = r_elevation[cur];
+        warpMap[r] = cur;
     }
 
     // Weighted max: pick whichever is larger, biased by strength
@@ -323,6 +325,8 @@ export function warpTerrain(mesh, r_elevation, r_xyz, seed, strength, r_hotspot)
             r_elevation[r] = warped + (orig - warped) * (1 - bias);
         }
     }
+
+    return warpMap;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Rock Type Classification** — 7 land types (Metamorphic, Granitic, Andesitic, Basaltic, Sandstone, Carbonate, Sediments) + Ocean, assigned via additive scoring system where every tectonic signal contributes scores and domain-warped noise selects among the top 3
- **Mineral Deposit System** — 15 deposit types placed by geological rules, visualized as per-metal-per-era richness heatmaps (Copper Age, Bronze Age, Iron Age) with independent noise per metal
- **Terrain warp alignment** — debug layers are remapped through the terrain warp so geology matches warped terrain
- New files: `js/geology.js`, `js/deposits.js`
- UI: Rock Type + 8 deposit layers in Inspect dropdown, hover tooltips, gradient legends, PNG export support

### Rock Type Logic
- Scoring system: tectonic signals (stress, fold ridges, orogenic power, boundary type, LIP, hotspot) add to relevant rock types; cubic ease-in elevation curve exposes basement in mountains while keeping lowlands sedimentary (~75% coverage)
- Cratons: shields (erosional → granitic/metamorphic) vs platforms (depositional → sandstone/carbonate)
- Mountains: subduction → andesitic, continental collision → metamorphic, island arcs → andesitic
- LIP aureole: contact metamorphism ring around LIPs; LIP strength modulates basalt vs sediment

### Deposit Logic
- 15 deposit types from surface weathering (native copper, placer gold) through deep intrusions (porphyry, tin) to climate-dependent (bog iron, laterite)
- Per-metal richness maps with independent noise functions and per-channel sparsity thresholds
- Era carry-forward: 1 age back only unless no newer source; new sources 3× weight
- Climate triggers on-demand when selecting deposit layers

## Test plan
- [ ] Generate planet → select Rock Type in Inspect dropdown → verify colored geological map
- [ ] Hover regions → tooltip shows rock type name with color swatch
- [ ] Select deposit layers (e.g. Bronze Age — Copper) → verify heatmap with black baseline
- [ ] Verify deposits concentrate near mountains/orogens, not flat sedimentary plains
- [ ] Test with climate skipped → select deposit layer → verify climate computes then deposits appear
- [ ] Export Rock Type as PNG → verify clean equirectangular output
- [ ] Test on mobile → verify touch targets and bottom-sheet usability
- [ ] Test at low and high Detail slider values for scale invariance

🤖 Generated with [Claude Code](https://claude.com/claude-code)