### PR TITLE
SP3 — Structural: climate reach tuning + byte-identical perf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ tuning/results/*.json
 tuning/results/climate/
 tuning/climate/data/
 tuning/climate/maps/
+
+tuning/regress-baseline.json
+tuning/regress-screenshots/

--- a/js/climate-config.js
+++ b/js/climate-config.js
@@ -67,7 +67,13 @@ export const CLIMATE_DEFAULTS = Object.freeze({
     // ── Precipitation: moisture & advection ──
     PRECIP_OCEAN_MOISTURE_BASE: 0.4508,      // base moisture of ocean cells
     PRECIP_ADVECT_FLAT_SURVIVAL: 0.8901,    // moisture surviving full advection over flat land
-    PRECIP_ADVECT_REACH_KM: 3961.314,         // moisture advection physical reach
+    // Effective advection reach. Historically 3961 km, but the min(20)-hop clamp
+    // made the true reach ≈ 2001 km at the N=40,000 tuning resolution (20 hops ×
+    // ~100 km). The nominal 3961 was underdetermined (any value ≥ ~2000 km gave
+    // 20 hops at 40k). Set to the real effective value so the reach is consistent
+    // across Detail (fixes the default-204k drop to ~880 km); no-op at 40k.
+    PRECIP_ADVECT_REACH_KM: 2001,
+    PRECIP_ADVECT_MAX_HOPS: 60,               // ceiling that bounds advection cost at very high Detail
     PRECIP_ELEV_DEPLETION_PER_KM: 0.9906,   // moisture depletion per km of terrain rise
 
     // ── Precipitation: ITCZ & convergence ──

--- a/js/climate-config.js
+++ b/js/climate-config.js
@@ -88,6 +88,8 @@ export const CLIMATE_DEFAULTS = Object.freeze({
     PRECIP_RS_APPLY_STRENGTH_SCALE: 2.4002, // propagated shadow → suppression multiplier
     PRECIP_RS_APPLY_MAX_SUPPRESS: 0.9782,   // max suppression in propagated shadow
     PRECIP_RS_APPLY_WINDWARD_ADD: 1.7675,    // additive windward boost from propagated field
+    PRECIP_RS_MAX_HOPS: 60,                 // ceiling on downwind shadow hops (bounds O(N^1.5) cost above ~40k regions; > the 34-hop tuning-resolution value so 40k is unaffected)
+    PRECIP_RS_WINDWARD_MAX_HOPS: 30,        // ceiling on upwind windward hops (> the 15-hop tuning-resolution value)
 
     // ── Precipitation: subtropical high / Mediterranean / monsoon ──
     PRECIP_SUBTROP_CENTER_SUMMER_DEG: 37.738, // suppression band center in local summer

--- a/js/climate-util.js
+++ b/js/climate-util.js
@@ -2,9 +2,16 @@
 
 // ── Laplacian smoothing ──────────────────────────────────────────────────────
 
+// Reused scratch buffer (grown on demand) so the many per-generation smoothing
+// passes don't each allocate a fresh Float32Array. Safe: smoothField is a leaf
+// function and the worker/fallback run single-threaded, so no call nests inside
+// another. The buffer may be larger than numRegions; only its prefix is used.
+let _smoothScratch = new Float32Array(0);
+
 export function smoothField(mesh, field, passes) {
     const { adjOffset, adjList, numRegions } = mesh;
-    const tmp = new Float32Array(numRegions);
+    if (_smoothScratch.length < numRegions) _smoothScratch = new Float32Array(numRegions);
+    const tmp = _smoothScratch;
     let src = field, dst = tmp;
 
     for (let pass = 0; pass < passes; pass++) {
@@ -20,8 +27,8 @@ export function smoothField(mesh, field, passes) {
         }
         const swap = src; src = dst; dst = swap;
     }
-    // If result ended up in tmp, copy back to field
-    if (src !== field) field.set(src);
+    // If the result ended up in the scratch, copy its prefix back to field.
+    if (src !== field) field.set(src.subarray(0, numRegions));
 }
 
 // ── ITCZ latitude lookup (linear interpolation with wrapping) ────────────────

--- a/js/detail-scale.js
+++ b/js/detail-scale.js
@@ -1,5 +1,5 @@
 // Non-linear detail slider mapping (power curve, p=5).
-// Slider position 0–1000 maps to detail 2,000–2,560,000.
+// Slider position 0–1000 maps to detail 5,000–2,560,000.
 // Gives generous control in the normal range; the old max (640K) sits at ~76%.
 
 const MIN = 5000, MAX = 2560000, RANGE = MAX - MIN, STEPS = 1000, P = 5;

--- a/js/elevation.js
+++ b/js/elevation.js
@@ -1,17 +1,18 @@
-// Elevation pipeline — 12 explicit stages.
+// Elevation pipeline — 13 explicit stages (see assignElevation).
 //
-// Stage 1: Tectonic state              (computeTectonicState)
-// Stage 2: Spatial fields              (computeSpatialFields)
-// Stage 3: Terrain classification      (classifyTerrain)
-// Stage 4: Skeleton                    (buildSkeleton)        [first renderable intermediate]
-// Stage 5: Tectonic-band noise         (applyTectonicBandNoise)
-// Stage 6: Elevation-gated detail      (applyDetailTexture)
-// Stage 7: Coastal detail              (applyCoastalDetail)
-// Stage 8: Discrete edifices           (applyEdifices)
-// Stage 9: Uniform background noise    (applyUniformLandNoise)
-// Stage 10: Dynamic topography         (applyDynamicTopography)
-// Stage 11: Final shaping              (applyFinalShaping)
-// Stage 12: Topology fixup             (fixupTopology)
+// Stage 1:  Tectonic state          (computeTectonicState)
+// Stage 2:  Spatial fields          (computeSpatialFields)
+// Stage 3:  Terrain classification  (classifyTerrain)
+// Stage 4:  Skeleton                (buildSkeleton)          [first renderable intermediate]
+// Stage 5:  Phasor ridges           (applyPhasorRidges)
+// Stage 6:  Discrete edifices       (applyIslandArcs / applyVolcanicArcs / applyHotspotsAndLIPs)
+// Stage 7:  Tectonic-band noise     (applyTectonicBandNoise)
+// Stage 8:  Elevation-gated detail  (applyDetailTexture)
+// Stage 9:  Coastal detail          (applyCoastalDetail)
+// Stage 10: Uniform background noise (applyUniformLandNoise)
+// Stage 11: Dynamic topography       (applyDynamicTopography)
+// Stage 12: Final shaping            (applyFinalShaping)
+// Stage 13: Topology fixup           (fixupTopology)
 
 import { makeRandInt, makeRng } from './rng.js';
 import { SimplexNoise } from './simplex-noise.js';

--- a/js/generate.js
+++ b/js/generate.js
@@ -317,6 +317,13 @@ if (worker) {
                 const tMainTotal = performance.now() - tMainStart;
                 const tTotal = performance.now() - _t0;
 
+                // Test-only capture handle (inert unless the regression harness
+                // sets window.__WO_CAPTURE). Lets tuning/regress.mjs read the
+                // deterministic output arrays for golden-master hashing.
+                if (typeof window !== 'undefined' && window.__WO_CAPTURE) {
+                    window.__WO_state = state;
+                }
+
                 // Diagnostics
                 {
                     let landCount = 0, nanCount = 0;

--- a/js/ocean.js
+++ b/js/ocean.js
@@ -168,9 +168,13 @@ function classifyWarmth(r_isOcean, r_lat, numRegions,
 
 // ── Laplacian smoothing (ocean only) ────────────────────────────────────────
 
+// Reused scratch (grown on demand); see the note on smoothField in climate-util.js.
+let _oceanSmoothScratch = new Float32Array(0);
+
 function smoothOcean(mesh, field, r_isOcean, passes) {
     const { adjOffset, adjList, numRegions } = mesh;
-    const tmp = new Float32Array(numRegions);
+    if (_oceanSmoothScratch.length < numRegions) _oceanSmoothScratch = new Float32Array(numRegions);
+    const tmp = _oceanSmoothScratch;
 
     for (let pass = 0; pass < passes; pass++) {
         for (let r = 0; r < numRegions; r++) {
@@ -187,7 +191,7 @@ function smoothOcean(mesh, field, r_isOcean, passes) {
             }
             tmp[r] = sum / count;
         }
-        field.set(tmp);
+        field.set(tmp.subarray(0, numRegions));
     }
 }
 

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -203,7 +203,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
         r_eastX, r_eastY, r_eastZ,
         r_northX, r_northY, r_northZ } = windResult;
 
-    // Scale-dependent hop count: ~2000 km reach.
+    // Scale-dependent hop count: PRECIP_ADVECT_REACH_KM (default 3961 km), currently clamped to 20 hops (see SP2/SP3).
     // Average edge length ≈ π / sqrt(numRegions) radians ≈ (π * 6371) / sqrt(N) km
     // hops ≈ 2000 / edgeLengthKm
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);
@@ -579,7 +579,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
             upOff[numRegions] = upCount;
             dnOff[numRegions] = dnCount;
 
-            // --- Pass 1: Propagate shadow DOWNWIND (~2500 km, 15% survives) ---
+            // --- Pass 1: Propagate shadow DOWNWIND (PRECIP_RS_SHADOW_PROP_KM, default 3363 km; 15% survives) ---
             const shadowHops = Math.max(8, Math.round(CLIMATE.PRECIP_RS_SHADOW_PROP_KM / avgEdgeKm));
             const shadowDecay = 1 - Math.pow(0.15, 1 / shadowHops);
             const shadowField = new Float32Array(rainShadow);

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -580,7 +580,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
             dnOff[numRegions] = dnCount;
 
             // --- Pass 1: Propagate shadow DOWNWIND (PRECIP_RS_SHADOW_PROP_KM, default 3363 km; 15% survives) ---
-            const shadowHops = Math.max(8, Math.round(CLIMATE.PRECIP_RS_SHADOW_PROP_KM / avgEdgeKm));
+            const shadowHops = Math.max(8, Math.min(CLIMATE.PRECIP_RS_MAX_HOPS, Math.round(CLIMATE.PRECIP_RS_SHADOW_PROP_KM / avgEdgeKm)));
             const shadowDecay = 1 - Math.pow(0.15, 1 / shadowHops);
             const shadowField = new Float32Array(rainShadow);
             // Reusable ping-pong buffers for both shadow and windward passes
@@ -608,7 +608,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
             }
 
             // --- Pass 2: Propagate windward rain UPWIND (~1500 km, 25% survives) ---
-            const windwardHops = Math.max(6, Math.round(1500 / avgEdgeKm));
+            const windwardHops = Math.max(6, Math.min(CLIMATE.PRECIP_RS_WINDWARD_MAX_HOPS, Math.round(1500 / avgEdgeKm)));
             const windwardDecay = 1 - Math.pow(0.25, 1 / windwardHops);
             const windwardField = new Float32Array(rainShadow);
             // Reuse ping-pong buffers from shadow pass

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -208,7 +208,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
     // hops ≈ 2000 / edgeLengthKm
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);
     const avgEdgeRad = Math.PI / Math.sqrt(numRegions);
-    const maxHops = Math.max(8, Math.min(20, Math.round(CLIMATE.PRECIP_ADVECT_REACH_KM / avgEdgeKm)));
+    const maxHops = Math.max(8, Math.min(CLIMATE.PRECIP_ADVECT_MAX_HOPS, Math.round(CLIMATE.PRECIP_ADVECT_REACH_KM / avgEdgeKm)));
 
     // Coast distance through land — reuse BFS already computed by wind.js
     const r_coastDistLand = windResult.r_coastDistLand;

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -203,7 +203,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
         r_eastX, r_eastY, r_eastZ,
         r_northX, r_northY, r_northZ } = windResult;
 
-    // Scale-dependent hop count: PRECIP_ADVECT_REACH_KM (default 3961 km), currently clamped to 20 hops (see SP2/SP3).
+    // Scale-dependent hop count: PRECIP_ADVECT_REACH_KM (default 2001 km), clamped to CLIMATE.PRECIP_ADVECT_MAX_HOPS (default 60) hops (see SP3a-2).
     // Average edge length ≈ π / sqrt(numRegions) radians ≈ (π * 6371) / sqrt(N) km
     // hops ≈ 2000 / edgeLengthKm
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);

--- a/js/scene.js
+++ b/js/scene.js
@@ -55,8 +55,9 @@ canvas.addEventListener('touchmove', (e) => {
 
 canvas.addEventListener('touchend', () => { _pinchDist = 0; }, { passive: true });
 
+const _zoomVec = new THREE.Vector3();
 export function tickZoom() {
-    const v = new THREE.Vector3().subVectors(camera.position, ctrl.target);
+    const v = _zoomVec.subVectors(camera.position, ctrl.target);
     const cur = v.length();
     const next = THREE.MathUtils.lerp(cur, _zoomTarget, ZOOM_SMOOTH);
     if (Math.abs(next - cur) < 0.0001) return;

--- a/js/wind.js
+++ b/js/wind.js
@@ -625,6 +625,11 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
     t0 = performance.now();
     const { adjOffset, adjList } = mesh;
 
+    // Reusable BFS/flood-fill queues (Int32Array) — replaces per-pass plain-array
+    // growth; mirrors the pattern in ocean.js. FIFO order is preserved.
+    const bfsQ = new Int32Array(numRegions);
+    const bfsQ2 = new Int32Array(numRegions);
+
     // Find the main ocean: largest connected component of non-land cells.
     // Inland seas / small lakes don't count as "ocean" for continentality.
     const r_oceanLabel = new Int32Array(numRegions);
@@ -635,18 +640,19 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
         if (r_isLand[r] || r_oceanLabel[r] >= 0) continue;
         const label = nextLabel++;
         let size = 0;
-        const floodQueue = [r];
+        bfsQ[0] = r;
+        let fLen = 1;
         r_oceanLabel[r] = label;
         let fHead = 0;
-        while (fHead < floodQueue.length) {
-            const cur = floodQueue[fHead++];
+        while (fHead < fLen) {
+            const cur = bfsQ[fHead++];
             size++;
             const end = adjOffset[cur + 1];
             for (let ni = adjOffset[cur]; ni < end; ni++) {
                 const nb = adjList[ni];
                 if (!r_isLand[nb] && r_oceanLabel[nb] === -1) {
                     r_oceanLabel[nb] = label;
-                    floodQueue.push(nb);
+                    bfsQ[fLen++] = nb;
                 }
             }
         }
@@ -659,7 +665,7 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
     // BFS coast distance through land, seeded only from main-ocean coastline
     const r_coastDist = new Int32Array(numRegions);
     r_coastDist.fill(-1);
-    const bfsQueue = [];
+    let cqLen = 0;
     for (let r = 0; r < numRegions; r++) {
         if (!r_isLand[r]) continue;
         const end = adjOffset[r + 1];
@@ -667,21 +673,21 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
             const nb = adjList[ni];
             if (!r_isLand[nb] && r_oceanLabel[nb] === mainOceanLabel) {
                 r_coastDist[r] = 0;
-                bfsQueue.push(r);
+                bfsQ[cqLen++] = r;
                 break;
             }
         }
     }
     let head = 0;
-    while (head < bfsQueue.length) {
-        const r = bfsQueue[head++];
+    while (head < cqLen) {
+        const r = bfsQ[head++];
         const d = r_coastDist[r] + 1;
         const end = adjOffset[r + 1];
         for (let ni = adjOffset[r]; ni < end; ni++) {
             const nb = adjList[ni];
             if (r_isLand[nb] && r_coastDist[nb] === -1) {
                 r_coastDist[nb] = d;
-                bfsQueue.push(nb);
+                bfsQ[cqLen++] = nb;
             }
         }
     }
@@ -713,7 +719,8 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
     {
         const distWest = new Int32Array(numRegions).fill(-1);
         const distEast = new Int32Array(numRegions).fill(-1);
-        const qW = [], qE = [];
+        const qW = bfsQ, qE = bfsQ2;
+        let qWLen = 0, qELen = 0;
         for (let r = 0; r < numRegions; r++) {
             if (!r_isLand[r] || r_coastDist[r] !== 0) continue; // coastal land only
             // Mean direction to adjacent main-ocean cells, projected on east tangent.
@@ -731,23 +738,23 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
             }
             if (on === 0) continue;
             const oceanDotEast = ox * eX + oz * eZ;
-            if (oceanDotEast < 0) { distWest[r] = 0; qW.push(r); } // ocean to west → west coast
-            else { distEast[r] = 0; qE.push(r); }                  // ocean to east → east coast
+            if (oceanDotEast < 0) { distWest[r] = 0; qW[qWLen++] = r; } // ocean to west → west coast
+            else { distEast[r] = 0; qE[qELen++] = r; }                 // ocean to east → east coast
         }
-        const bfsLand = (dist, q) => {
+        const bfsLand = (dist, q, qLen) => {
             let head = 0;
-            while (head < q.length) {
+            while (head < qLen) {
                 const r = q[head++];
                 const d = dist[r] + 1;
                 const end = adjOffset[r + 1];
                 for (let ni = adjOffset[r]; ni < end; ni++) {
                     const nb = adjList[ni];
-                    if (r_isLand[nb] && dist[nb] === -1) { dist[nb] = d; q.push(nb); }
+                    if (r_isLand[nb] && dist[nb] === -1) { dist[nb] = d; q[qLen++] = nb; }
                 }
             }
         };
-        bfsLand(distWest, qW);
-        bfsLand(distEast, qE);
+        bfsLand(distWest, qW, qWLen);
+        bfsLand(distEast, qE, qELen);
         for (let r = 0; r < numRegions; r++) {
             if (!r_isLand[r]) continue;
             const dw = distWest[r], de = distEast[r];
@@ -766,28 +773,28 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
     // BFS through continental-plate cells
     const r_plateDist = new Int32Array(numRegions);
     r_plateDist.fill(-1);
-    const plateBfsQueue = [];
+    let pqLen = 0;
     for (let r = 0; r < numRegions; r++) {
         if (plateIsOcean.has(r_plate[r])) continue; // skip oceanic plate cells
         const end = adjOffset[r + 1];
         for (let ni = adjOffset[r]; ni < end; ni++) {
             if (plateIsOcean.has(r_plate[adjList[ni]])) {
                 r_plateDist[r] = 0;
-                plateBfsQueue.push(r);
+                bfsQ[pqLen++] = r;
                 break;
             }
         }
     }
     head = 0;
-    while (head < plateBfsQueue.length) {
-        const r = plateBfsQueue[head++];
+    while (head < pqLen) {
+        const r = bfsQ[head++];
         const d = r_plateDist[r] + 1;
         const end = adjOffset[r + 1];
         for (let ni = adjOffset[r]; ni < end; ni++) {
             const nb = adjList[ni];
             if (!plateIsOcean.has(r_plate[nb]) && r_plateDist[nb] === -1) {
                 r_plateDist[nb] = d;
-                plateBfsQueue.push(nb);
+                bfsQ[pqLen++] = nb;
             }
         }
     }

--- a/tuning/climate/README.md
+++ b/tuning/climate/README.md
@@ -20,7 +20,7 @@ excluded (and reported separately as `landAgreement`).
 - `macroF1` — unweighted mean F1 across classes present in the truth, so rare
   but important classes (Mediterranean Csa/Csb, monsoon Cwa/Dwa…) aren't drowned
   out by large deserts and subarctic zones
-- **objective = 0.5·exactAcc + 0.5·macroF1** — what the optimizer maximizes
+- **objective = 0.60·gradedAcc + 0.12·macroF1 + 0.15·groupBalance + 0.13·watchlistF1** — what the optimizer maximizes
 
 Ground-truth codes are mapped onto the app's class set (`As` → `Aw`, the standard
 merge). Ground truth lives in `data/ascii/Koeppen-Geiger-ASCII.txt`.

--- a/tuning/climate/lib/score.mjs
+++ b/tuning/climate/lib/score.mjs
@@ -57,7 +57,7 @@ export function runClimate(ctx, paramOverrides = {}) {
 /**
  * Score a simulated Köppen field against ground truth.
  *
- * objective = 0.48·gradedAcc + 0.20·macroF1 + 0.18·groupBalance + 0.14·watchlistF1
+ * objective = 0.60·gradedAcc + 0.12·macroF1 + 0.15·groupBalance + 0.13·watchlistF1
  *   gradedAcc     — per-cell climatic similarity (partial credit; a big error
  *                   like rainforest→desert scores ~0, an adjacent one ~0.8)
  *   macroF1       — unweighted mean F1, keeps every class alive regardless of area

--- a/tuning/climate/param-space.mjs
+++ b/tuning/climate/param-space.mjs
@@ -72,7 +72,7 @@ export const PARAM_SPACE = {
     PRECIP_RS_APPLY_STRENGTH_SCALE:   { min: 1.0,  max: 4.0 },
     PRECIP_RS_APPLY_MAX_SUPPRESS:     { min: 0.6,  max: 0.98, high: true },
     PRECIP_RS_APPLY_WINDWARD_ADD:     { min: 0.5,  max: 2.0 },
-    PRECIP_RS_MAX_HOPS:               { min: 40,   max: 120 },
+    PRECIP_RS_MAX_HOPS:               { min: 45,   max: 120 },
     PRECIP_RS_WINDWARD_MAX_HOPS:      { min: 18,   max: 60 },
     PRECIP_SUBTROP_CENTER_SUMMER_DEG: { min: 25,   max: 38,   high: true },
     PRECIP_SUBTROP_CENTER_WINTER_DEG: { min: 18,   max: 30 },

--- a/tuning/climate/param-space.mjs
+++ b/tuning/climate/param-space.mjs
@@ -54,7 +54,10 @@ export const PARAM_SPACE = {
     // ── Precipitation (complex model) ──
     PRECIP_OCEAN_MOISTURE_BASE:       { min: 0.2,  max: 0.7 },
     PRECIP_ADVECT_FLAT_SURVIVAL:      { min: 0.5,  max: 0.95, high: true },
-    PRECIP_ADVECT_REACH_KM:           { min: 1000, max: 4000, high: true },
+    // Range narrowed around the effective reach: production reach now depends on
+    // this value (the clamp no longer flattens it), so it must stay near ~2000 km.
+    PRECIP_ADVECT_REACH_KM:           { min: 1500, max: 2500, high: true },
+    PRECIP_ADVECT_MAX_HOPS:           { min: 45,   max: 120 },
     PRECIP_ELEV_DEPLETION_PER_KM:     { min: 0.2,  max: 1.0,  high: true },
     PRECIP_ITCZ_WIDTH_DEG:            { min: 8,    max: 22,   high: true },
     PRECIP_ITCZ_CORE_BOOST:           { min: 1.0,  max: 2.5 },

--- a/tuning/climate/param-space.mjs
+++ b/tuning/climate/param-space.mjs
@@ -69,6 +69,8 @@ export const PARAM_SPACE = {
     PRECIP_RS_APPLY_STRENGTH_SCALE:   { min: 1.0,  max: 4.0 },
     PRECIP_RS_APPLY_MAX_SUPPRESS:     { min: 0.6,  max: 0.98, high: true },
     PRECIP_RS_APPLY_WINDWARD_ADD:     { min: 0.5,  max: 2.0 },
+    PRECIP_RS_MAX_HOPS:               { min: 40,   max: 120 },
+    PRECIP_RS_WINDWARD_MAX_HOPS:      { min: 18,   max: 60 },
     PRECIP_SUBTROP_CENTER_SUMMER_DEG: { min: 25,   max: 38,   high: true },
     PRECIP_SUBTROP_CENTER_WINTER_DEG: { min: 18,   max: 30 },
     PRECIP_SUBTROP_WIDTH_SUMMER_DEG:  { min: 8,    max: 24 },

--- a/tuning/regress.mjs
+++ b/tuning/regress.mjs
@@ -1,0 +1,218 @@
+/**
+ * Golden-master regression harness for World Orogen.
+ *
+ * Generates a fixed basket of planets headlessly and hashes the worker's
+ * deterministic output arrays (elevation + climate). SP1's contract is that
+ * these hashes never change; SP2/SP3 reuse this file in --diff mode to see
+ * intended changes.
+ *
+ *   node tuning/regress.mjs --update   # write baseline
+ *   node tuning/regress.mjs            # check against baseline (default)
+ *   node tuning/regress.mjs --diff     # report changed arrays, don't fail
+ *
+ * Screenshots are saved to tuning/regress-screenshots/ for optional human
+ * comparison but are NOT hash-asserted (GPU rasterization isn't bit-stable).
+ */
+
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const BASELINE_PATH = path.join(__dirname, 'regress-baseline.json');
+const SHOT_DIR = path.join(__dirname, 'regress-screenshots');
+fs.mkdirSync(SHOT_DIR, { recursive: true });
+
+const MODE = process.argv.includes('--update') ? 'update'
+           : process.argv.includes('--diff') ? 'diff'
+           : 'check';
+
+// Fixed basket: 3 seeds x 3 detail levels + one extra. All detail levels are
+// below AUTO_CLIMATE_THRESHOLD (300k) so climate is computed inline and its
+// arrays are present in state.curData for hashing.
+const CASES = [
+  { name: 'seed42-d5k',   seed: 42,  detail: 0,   sliders: {} },   // detail slider 0 -> 5,000 regions
+  { name: 'seed42-d50k',  seed: 42,  detail: 300, sliders: {} },
+  { name: 'seed42-d200k', seed: 42,  detail: 470, sliders: {} },
+  { name: 'seed100-d50k', seed: 100, detail: 300, sliders: { sP: 8,  sLc: 0.6 } },
+  { name: 'seed200-d50k', seed: 200, detail: 300, sliders: { sP: 80, sLc: 0.25 } },
+  { name: 'seed300-d50k', seed: 300, detail: 300, sliders: { sGl: 0.8, sHEr: 0.8, sTEr: 0.8 } },
+];
+
+// Arrays to hash (only those present are hashed; climate ones appear <300k).
+const HASH_KEYS = [
+  'r_elevation', 't_elevation',
+  'r_precip_summer', 'r_precip_winter',
+  'r_temperature_summer', 'r_temperature_winter',
+];
+
+const MIME = {
+  '.html':'text/html', '.js':'application/javascript', '.mjs':'application/javascript',
+  '.css':'text/css', '.json':'application/json', '.png':'image/png', '.svg':'image/svg+xml',
+  '.ico':'image/x-icon', '.woff':'font/woff', '.woff2':'font/woff2',
+  '.webmanifest':'application/manifest+json', '.txt':'text/plain', '.xml':'application/xml', '.wasm':'application/wasm',
+};
+
+function startServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let urlPath = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+      if (urlPath === '/' || urlPath === '') urlPath = '/index.html';
+      const filePath = path.join(PROJECT_ROOT, urlPath);
+      if (!filePath.startsWith(PROJECT_ROOT)) { res.writeHead(403); res.end(); return; }
+      fs.readFile(filePath, (err, data) => {
+        if (err) { res.writeHead(404); res.end('Not found'); return; }
+        res.writeHead(200, { 'Content-Type': MIME[path.extname(filePath).toLowerCase()] || 'application/octet-stream' });
+        res.end(data);
+      });
+    });
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+async function hashCase(page, tc) {
+  await page.evaluate(() => { window.__WO_CAPTURE = true; });
+
+  // Overlays off, detail + sliders set.
+  await page.evaluate(() => {
+    for (const id of ['tutorialOverlay', 'whatsNewOverlay']) {
+      const el = document.getElementById(id); if (el) el.style.display = 'none';
+    }
+  });
+
+  // The app auto-generates once on load with a random seed and default
+  // sliders (js/main.js), and #generate stays disabled with #buildOverlay
+  // (pointer-events: auto) covering it until that generation finishes. If we
+  // click before it settles the click is a no-op and the harness ends up
+  // hashing the random auto-gen instead of our seeded case. Wait for it to
+  // fully finish so the generate-done waiter installed below catches OUR
+  // generation, not the auto-gen's.
+  await page.waitForFunction(() => {
+    const o = document.getElementById('buildOverlay');
+    const b = document.getElementById('generate');
+    return o && o.classList.contains('hidden') && b && !b.disabled;
+  }, { timeout: 180_000 });
+
+  await page.evaluate(({ id, value }) => {
+    const el = document.getElementById(id); el.value = value;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }, { id: 'sN', value: String(tc.detail) });
+  for (const [id, val] of Object.entries(tc.sliders)) {
+    await page.evaluate(({ id, value }) => {
+      const el = document.getElementById(id); el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, { id, value: String(val) });
+  }
+
+  // Inject fixed seed by patching the next 'generate' postMessage.
+  await page.evaluate((seed) => {
+    const orig = Worker.prototype.postMessage;
+    Worker.prototype.postMessage = function (msg, ...rest) {
+      if (msg && msg.cmd === 'generate' && msg.seed === undefined) msg.seed = Number(seed);
+      return orig.call(this, msg, ...rest);
+    };
+  }, tc.seed);
+
+  const done = page.evaluate((timeout) => new Promise((resolve, reject) => {
+    const btn = document.getElementById('generate');
+    const timer = setTimeout(() => reject(new Error('gen timeout')), timeout);
+    btn.addEventListener('generate-done', () => { clearTimeout(timer); resolve(); }, { once: true });
+  }), 180_000);
+  await new Promise((r) => setTimeout(r, 100));
+
+  // For detail/erosion-only cases (no PLATE_SLIDERS change) the click handler
+  // would otherwise see isRebuild=true and reuse state.curData.seed, so the
+  // postMessage patch's `msg.seed === undefined` check never fires and our
+  // seed is silently ignored. Stripping 'stale' forces seed=undefined so the
+  // patch above actually injects tc.seed.
+  await page.evaluate(() => {
+    const b = document.getElementById('generate');
+    if (b) b.classList.remove('stale');
+  });
+  await page.click('#generate');
+  await done;
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Hash arrays in-page (cyrb53 over the raw bytes) — only short hex crosses the bridge.
+  const hashes = await page.evaluate((keys) => {
+    const cyrb53 = (bytes) => {
+      let h1 = 0xdeadbeef, h2 = 0x41c6ce57;
+      for (let i = 0; i < bytes.length; i++) {
+        const ch = bytes[i];
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+      }
+      h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+      h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+      return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(16);
+    };
+    const d = window.__WO_state && window.__WO_state.curData;
+    const out = {};
+    if (!d) return out;
+    for (const k of keys) {
+      const arr = d[k];
+      if (arr && arr.buffer) out[k] = `${arr.length}:${cyrb53(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength))}`;
+    }
+    return out;
+  }, HASH_KEYS);
+
+  // Advisory screenshot (not asserted).
+  const canvas = await page.$('#canvas');
+  if (canvas) await canvas.screenshot({ path: path.join(SHOT_DIR, `${tc.name}.png`) }).catch(() => {});
+
+  return hashes;
+}
+
+async function main() {
+  const { server, port } = await startServer();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--enable-webgl',
+           '--use-gl=angle', '--use-angle=swiftshader-webgl', '--enable-unsafe-swiftshader'],
+  });
+
+  const results = {};
+  try {
+    for (const tc of CASES) {
+      const page = await browser.newPage();
+      await page.setViewport({ width: 1200, height: 900 });
+      page.on('dialog', (d) => d.dismiss());
+      page.on('pageerror', (e) => console.log(`  [PAGE EXCEPTION] ${e.message}`));
+      await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+      await new Promise((r) => setTimeout(r, 2000));
+      console.log(`Generating ${tc.name}...`);
+      results[tc.name] = await hashCase(page, tc);
+      await page.close().catch(() => {});
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  if (MODE === 'update') {
+    fs.writeFileSync(BASELINE_PATH, JSON.stringify(results, null, 2));
+    console.log(`\nBaseline written to ${path.relative(PROJECT_ROOT, BASELINE_PATH)}`);
+    return;
+  }
+
+  const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+  let mismatches = 0;
+  for (const tc of CASES) {
+    const a = baseline[tc.name] || {}, b = results[tc.name] || {};
+    for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) {
+      if (a[k] !== b[k]) {
+        mismatches++;
+        console.log(`  CHANGED ${tc.name}.${k}: ${a[k]} -> ${b[k]}`);
+      }
+    }
+  }
+  if (mismatches === 0) console.log('\nAll cases byte-identical to baseline.');
+  else console.log(`\n${mismatches} array(s) differ from baseline.`);
+  if (MODE === 'check' && mismatches > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## SP3 — Structural: climate reach tuning + byte-identical perf

Cuts transient GC allocation in the climate smoothers with **zero output change** (SP3b), then bounds the rain-shadow `O(N^1.5)` cost and fixes the default-Detail dry-interior regression **without changing the Earth-tuned climate at its tuning resolution** (SP3a).

World Orogen is concept art for planets, not a simulator — so the guiding constraint here is: make it faster and fix a visible artifact, while provably not disturbing the climate output that the Köppen calibration was tuned against.

---

### ⚠️ Dependency on SP1 (please read first)

This branch is built **on top of SP1 (performance-free-wins)**, not directly on `main`, because SP3's byte-identical verification requires SP1's golden-master regression harness (`tuning/regress.mjs`, added in `aaa53c0`).

As a result this PR contains **9 commits**, of which the **first 3 are SP1's foundation** and should land via SP1's own PR:

| # | Commit | Owner | Purpose |
|---|--------|-------|---------|
| 1 | `aaa53c0` | **SP1** | golden-master regression harness (the gate SP3b relies on) |
| 2 | `27de384` | **SP1** | docs corrections |
| 3 | `d8d4015` | **SP1** | reuse scratch Vector3 in `tickZoom` |
| 4 | `0de2173` | **SP3** | reuse module scratch buffers in `smoothField`/`smoothOcean` |
| 5 | `2aaa441` | **SP3** | preallocated `Int32Array` BFS queues in `wind.js` |
| 6 | `003e31c` | **SP3** | cap rain-shadow propagation hops |
| 7 | `46a8954` | **SP3** | consistent advection reach across Detail |
| 8 | `0348614` | **SP3** | correct stale advection-reach comment |
| 9 | `61d589a` | **SP3** | widen `PRECIP_RS_MAX_HOPS` optimizer floor to 45 |

**Recommended merge order:** land SP1 first, then rebase this branch onto the post-SP1 `main` so commits 1–3 disappear and only SP3's 6 commits remain. SP3's *functional* code does not overlap SP1's code changes (SP3 touches `climate-util.js`, `ocean.js`, `wind.js`, `precipitation.js`, `climate-config.js`, `param-space.mjs`), so the rebase is expected to be clean apart from possibly a one-line comment context in `precipitation.js`.

**No dependency on SP2 (scale-invariance).** SP3 only *optionally* references SP2's harness for a cross-resolution spot-check; nothing here requires it.

---

### SP3b — byte-identical performance (commits 4–5)

Both changes are pure allocation refactors: **identical computation, fewer allocations.** Verified bit-for-bit against SP1's golden-master harness.

**1. Module-scratch buffers in `smoothField` & `smoothOcean`** (`js/climate-util.js`, `js/ocean.js`)
The two smoothers allocated a fresh `Float32Array(numRegions)` on *every* call, and they are called many times per generation (wind, temperature, precipitation, ocean chains). Each now reuses a module-level scratch buffer grown on demand. Safe because both are leaf, synchronous, non-reentrant functions and the worker/fallback run single-threaded, so a shared buffer can never alias across calls. The copy-back uses `.subarray(0, numRegions)` because the reused buffer may be larger than the current mesh.

**2. Preallocated `Int32Array` BFS queues in `wind.js`** (`js/wind.js`)
The continentality/westness section grew four plain-array (`[]` + `.push()`) BFS/flood-fill queues per generation. These become preallocated `Int32Array(numRegions)` queues with explicit length counters, mirroring the existing pattern in `ocean.js`. FIFO visit order is preserved exactly, so every derived field is bit-identical. A single pair of buffers is safely reused across the four sequential BFS phases (each fully drains before the next begins).

**Verification:** `node tuning/regress.mjs` reports `All cases byte-identical to baseline.` after each commit (6 fixed seed/detail cases × 6 hashed output arrays: elevation, summer/winter precipitation, summer/winter temperature).

---

### SP3a — climate reach tuning (commits 6–9)

These **intentionally change climate output at non-40K resolutions** but are **exact no-ops at the N=40,000 tuning resolution** (`avgEdgeKm ≈ 100.07 km`), so the real-Earth Köppen calibration is preserved by construction.

**3. Cap rain-shadow propagation hops** (`003e31c`)
Rain-shadow propagation is `O(N^1.5)` and grows unbounded with Detail. Added two caps — `PRECIP_RS_MAX_HOPS = 60` (downwind shadow) and `PRECIP_RS_WINDWARD_MAX_HOPS = 30` (upwind windward) — applied as `Math.min(cap, round(km/avgEdgeKm))` inside the existing floor. Both caps exceed the tuning-resolution hop counts (shadow **34**, windward **15**), so at 40K the caps never bind; above ~40K they bound the loop cost.

**4. Consistent advection reach across Detail** (`46a8954`)
Moisture advection nominally reached 3961 km, but a hardcoded `min(20)`-hop clamp made the *true* reach ≈ 2001 km at the 40K tuning resolution (20 hops × ~100 km) — while at the default Detail (~204K regions) the same clamp cut reach to ~880 km, producing overly dry continental interiors. This sets `PRECIP_ADVECT_REACH_KM` to its real effective value (**2001**, the nominal 3961 was underdetermined — any value ≥ ~2000 km yielded 20 hops at 40K) and replaces the hardcoded 20 with a tunable `PRECIP_ADVECT_MAX_HOPS = 60`. Reach is now consistent across Detail (fixing the dry interiors) and a **no-op at 40K**: `min(60, round(2001/100.07)=20) = 20`, identical to the old `min(20, round(3961/100.07)=40) = 20`.

**5. Comment correction + margin fix** (`0348614`, `61d589a`)
`0348614` updates a WHY comment made stale by the retune. `61d589a` widens the `PRECIP_RS_MAX_HOPS` optimizer floor from 40 → 45: the original floor sat exactly at the maximum in-range 40K shadow-hop count (`round(4000/100.07) = 40`), a zero-margin coincidence flagged in review — the cap still could not bite in-range, but the wider floor restores a genuine safety margin consistent with the other two caps. The `CLIMATE.*` default (60) is unchanged, so the 40K no-op is preserved.

**Config discipline:** every new `CLIMATE.*` tunable (`PRECIP_RS_MAX_HOPS`, `PRECIP_RS_WINDWARD_MAX_HOPS`, `PRECIP_ADVECT_MAX_HOPS`) has a matching `tuning/climate/param-space.mjs` entry (a 1:1 cross-check throws at load otherwise), with `min` values kept above the 40K hop counts so the optimizer can never make a cap bind at the tuning resolution.

---

### Verification

- **SP3b (byte-identical):** `node tuning/regress.mjs` → `All cases byte-identical to baseline.` after commits 4 and 5. A whole-branch review traced every `smoothField`/`smoothOcean`/`bfsQ` call site to confirm no aliasing or re-entrancy risk.
- **SP3a (40K no-op):** verified **arithmetically on the real mesh** — `buildSphere(40000)` yields `numRegions = 40001`, `avgEdgeKm = 100.074`, giving shadow **34→34**, windward **15→15**, advection **20→20** (all identical old vs new). Since the hop counts feeding precipitation are unchanged at 40K, the climate fields — hence the Köppen objective — are byte-identical there by construction.
- **⚠️ Still owed by a maintainer with the data:** the authoritative Earth-match gate `node tuning/climate/evaluate.mjs` could not be run in the automation environment because the Köppen-Geiger ground-truth ASCII grid (`tuning/climate/data/ascii/Koeppen-Geiger-ASCII.txt`) is not committed to the repo. Please run `evaluate.mjs` before/after to empirically confirm the objective is unchanged at N=40,000 (the arithmetic above says it will be).

### Test plan

- [ ] Land SP1 first; rebase this branch onto post-SP1 `main` (drops commits 1–3).
- [ ] `node tuning/regress.mjs` → byte-identical (SP3b gate).
- [ ] `node tuning/climate/evaluate.mjs` before/after with the ground-truth grid present → identical objective at N=40,000 (SP3a gate).
- [ ] Generate at high Detail (e.g. slider 800) and confirm precipitation time no longer grows super-linearly (rain-shadow bounded).
- [ ] Generate at default Detail and confirm continental interiors are wetter (advection-reach fix).

### Scope notes

No UI controls, sliders, keyboard shortcuts, or planet-code encoding changed — all changes are internal tunables and allocation refactors, so no README / tutorial / SEO / `planet-code.js` updates are triggered.
