### PR TITLE
perf: SP1 — performance free wins (zero behavior change, golden-master guarded)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ tuning/results/*.json
 tuning/results/climate/
 tuning/climate/data/
 tuning/climate/maps/
+
+tuning/regress-baseline.json
+tuning/regress-screenshots/

--- a/js/detail-scale.js
+++ b/js/detail-scale.js
@@ -1,5 +1,5 @@
 // Non-linear detail slider mapping (power curve, p=5).
-// Slider position 0–1000 maps to detail 2,000–2,560,000.
+// Slider position 0–1000 maps to detail 5,000–2,560,000.
 // Gives generous control in the normal range; the old max (640K) sits at ~76%.
 
 const MIN = 5000, MAX = 2560000, RANGE = MAX - MIN, STEPS = 1000, P = 5;

--- a/js/elevation.js
+++ b/js/elevation.js
@@ -1966,12 +1966,34 @@ function applyHotspotsAndLIPs(mesh, r_xyz, r_elevation, tect, sf, plateVec, r_pl
     };
 
     const hsPosRng = makeRng(seed + 1001);
+    // Nearest region by max dot product. Greedy hill-climb on the mesh
+    // adjacency graph (dot product is unimodal over the sphere for a fixed
+    // query, so ascent converges to the global nearest); a brute-force
+    // fallback guarantees exactness if the walk stalls at the step cap.
+    // `cur` is retained across calls (warm start) since consecutive queries
+    // along a hotspot chain are close.
+    const { adjOffset: _adjOff, adjList: _adjList } = mesh;
+    const _maxWalk = Math.ceil(Math.sqrt(numRegions));
+    let _nearCur = 0;
     const findNearestR = (px, py, pz) => {
-        let bestDot = -2, bestR = 0;
-        for (let r = 0; r < numRegions; r++) {
-            const dot = px * r_xyz[3*r] + py * r_xyz[3*r+1] + pz * r_xyz[3*r+2];
-            if (dot > bestDot) { bestDot = dot; bestR = r; }
+        let bestR = _nearCur;
+        let bestDot = px * r_xyz[3*bestR] + py * r_xyz[3*bestR+1] + pz * r_xyz[3*bestR+2];
+        let improved = true, steps = 0;
+        while (improved && steps < _maxWalk) {
+            improved = false; steps++;
+            for (let i = _adjOff[bestR], iEnd = _adjOff[bestR + 1]; i < iEnd; i++) {
+                const nb = _adjList[i];
+                const d = px * r_xyz[3*nb] + py * r_xyz[3*nb+1] + pz * r_xyz[3*nb+2];
+                if (d > bestDot) { bestDot = d; bestR = nb; improved = true; }
+            }
         }
+        if (steps >= _maxWalk) {
+            for (let r = 0; r < numRegions; r++) {
+                const d = px * r_xyz[3*r] + py * r_xyz[3*r+1] + pz * r_xyz[3*r+2];
+                if (d > bestDot) { bestDot = d; bestR = r; }
+            }
+        }
+        _nearCur = bestR;
         return bestR;
     };
 

--- a/js/elevation.js
+++ b/js/elevation.js
@@ -1970,7 +1970,7 @@ function applyHotspotsAndLIPs(mesh, r_xyz, r_elevation, tect, sf, plateVec, r_pl
     // adjacency graph (dot product is unimodal over the sphere for a fixed
     // query, so ascent converges to the global nearest); a brute-force
     // fallback guarantees exactness if the walk stalls at the step cap.
-    // `cur` is retained across calls (warm start) since consecutive queries
+    // `_nearCur` is retained across calls (warm start) since consecutive queries
     // along a hotspot chain are close.
     const { adjOffset: _adjOff, adjList: _adjList } = mesh;
     const _maxWalk = Math.ceil(Math.sqrt(numRegions));

--- a/js/elevation.js
+++ b/js/elevation.js
@@ -895,8 +895,6 @@ function buildSkeleton(mesh, r_xyz, plateIsOcean, r_plate, plateVec, plateSeeds,
     const riftNoise = new SimplexNoise(seed + 419);
 
     const eps = 1e-3;
-    const warpScale = WARP_SCALE;
-    const warpOctaves = numRegions > 200000 ? 2 : 3;
 
     for (let r = 0; r < numRegions; r++) {
         const isOceanPlate = r_isOcean[r];
@@ -917,11 +915,6 @@ function buildSkeleton(mesh, r_xyz, plateIsOcean, r_plate, plateVec, plateSeeds,
             r_elevation[r] = (1/a - 1/b) / (1/a + 1/b + 1/c) * BASE_SCALE;
         }
         dl_base[r] = r_elevation[r];
-
-        // Domain-warped coordinates (re-used by feature noise below; stage 5 recomputes)
-        const wx = x + warpScale * noise.fbm(x + 5.3, y + 1.7, z + 3.1, warpOctaves);
-        const wy = y + warpScale * noise.fbm(x + 8.1, y + 2.9, z + 7.3, warpOctaves);
-        const wz = z + warpScale * noise.fbm(x + 1.4, y + 6.2, z + 4.8, warpOctaves);
 
         // Orogenic power (used by stress uplift formula)
         const rawOro = noise.noise3D(x * OROGENIC_FREQ + 33.7, y * OROGENIC_FREQ + 11.2, z * OROGENIC_FREQ + 22.9);

--- a/js/elevation.js
+++ b/js/elevation.js
@@ -1,17 +1,18 @@
-// Elevation pipeline — 12 explicit stages.
+// Elevation pipeline — 13 explicit stages (see assignElevation).
 //
-// Stage 1: Tectonic state              (computeTectonicState)
-// Stage 2: Spatial fields              (computeSpatialFields)
-// Stage 3: Terrain classification      (classifyTerrain)
-// Stage 4: Skeleton                    (buildSkeleton)        [first renderable intermediate]
-// Stage 5: Tectonic-band noise         (applyTectonicBandNoise)
-// Stage 6: Elevation-gated detail      (applyDetailTexture)
-// Stage 7: Coastal detail              (applyCoastalDetail)
-// Stage 8: Discrete edifices           (applyEdifices)
-// Stage 9: Uniform background noise    (applyUniformLandNoise)
-// Stage 10: Dynamic topography         (applyDynamicTopography)
-// Stage 11: Final shaping              (applyFinalShaping)
-// Stage 12: Topology fixup             (fixupTopology)
+// Stage 1:  Tectonic state          (computeTectonicState)
+// Stage 2:  Spatial fields          (computeSpatialFields)
+// Stage 3:  Terrain classification  (classifyTerrain)
+// Stage 4:  Skeleton                (buildSkeleton)          [first renderable intermediate]
+// Stage 5:  Phasor ridges           (applyPhasorRidges)
+// Stage 6:  Discrete edifices       (applyIslandArcs / applyVolcanicArcs / applyHotspotsAndLIPs)
+// Stage 7:  Tectonic-band noise     (applyTectonicBandNoise)
+// Stage 8:  Elevation-gated detail  (applyDetailTexture)
+// Stage 9:  Coastal detail          (applyCoastalDetail)
+// Stage 10: Uniform background noise (applyUniformLandNoise)
+// Stage 11: Dynamic topography       (applyDynamicTopography)
+// Stage 12: Final shaping            (applyFinalShaping)
+// Stage 13: Topology fixup           (fixupTopology)
 
 import { makeRandInt, makeRng } from './rng.js';
 import { SimplexNoise } from './simplex-noise.js';

--- a/js/generate.js
+++ b/js/generate.js
@@ -3,7 +3,7 @@
 
 import Delaunator from 'delaunator';
 import { setDelaunator, SphereMesh } from './sphere-mesh.js';
-import { computePlateColors, buildMesh } from './planet-mesh.js';
+import { computePlateColors, buildMesh, updateMeshColors } from './planet-mesh.js';
 import { state } from './state.js';
 import { detailFromSlider } from './detail-scale.js';
 import { computeOceanCurrents } from './ocean.js';
@@ -669,7 +669,7 @@ if (worker) {
                     }
                 }
                 state.climateComputed = true;
-                buildMesh();
+                updateMeshColors();
 
                 const f = v => typeof v === 'number' ? v.toFixed(1) : v;
                 const ct = msg._climateTiming || {};

--- a/js/generate.js
+++ b/js/generate.js
@@ -78,8 +78,8 @@ function fail(err) {
 }
 
 // Reconstruct SphereMesh from transferred data
-function reconstructMesh(triangles, halfedges, numRegions) {
-    return new SphereMesh(triangles, halfedges, numRegions);
+function reconstructMesh(triangles, halfedges, numRegions, meshAdj) {
+    return new SphereMesh(triangles, halfedges, numRegions, meshAdj || null);
 }
 
 // Build minimal wind-result-like object for computeOceanCurrents fallback.
@@ -187,7 +187,7 @@ if (worker) {
                 const tMainStart = performance.now();
 
                 const tReconStart = performance.now();
-                const mesh = reconstructMesh(msg.triangles, msg.halfedges, msg.numRegions);
+                const mesh = reconstructMesh(msg.triangles, msg.halfedges, msg.numRegions, msg.meshAdj);
                 const tRecon = performance.now() - tReconStart;
 
                 const tColorsStart = performance.now();

--- a/js/generate.js
+++ b/js/generate.js
@@ -317,6 +317,13 @@ if (worker) {
                 const tMainTotal = performance.now() - tMainStart;
                 const tTotal = performance.now() - _t0;
 
+                // Test-only capture handle (inert unless the regression harness
+                // sets window.__WO_CAPTURE). Lets tuning/regress.mjs read the
+                // deterministic output arrays for golden-master hashing.
+                if (typeof window !== 'undefined' && window.__WO_CAPTURE) {
+                    window.__WO_state = state;
+                }
+
                 // Diagnostics
                 {
                     let landCount = 0, nanCount = 0;

--- a/js/planet-mesh.js
+++ b/js/planet-mesh.js
@@ -74,6 +74,17 @@ function landHeightmapColor(elevation) {
     return [t, t, t];
 }
 
+// Scalar grayscale variants — identical to heightmapColor(e)[0] / landHeightmapColor(e)[0]
+// but without allocating a 3-element array just to read one channel.
+function heightmapGray(elevation) {
+    const h = elevToHeightKm(elevation);
+    return Math.max(0, Math.min(1, (h + 5) / 11));
+}
+function landHeightmapGray(elevation) {
+    if (elevation <= 0) return 0;
+    return Math.max(0, Math.min(1, elevToHeightKm(elevation) / 6));
+}
+
 // Land mask: white = land, black = ocean
 function landMaskColor(elevation) {
     return elevation > 0 ? [1, 1, 1] : [0, 0, 0];
@@ -372,10 +383,10 @@ export function buildMapMesh() {
         // Per-vertex colors for smooth heightmaps, flat for everything else
         let c0r, c0g, c0b, c1r, c1g, c1b, c2r, c2g, c2b;
         if (isSmooth) {
-            const colorFn = isLandHeightmap ? landHeightmapColor : heightmapColor;
-            const v0 = colorFn(t_elevation[it])[0];
-            const v1 = colorFn(t_elevation[ot])[0];
-            const v2 = colorFn(r_elevation[br])[0];
+            const grayFn = isLandHeightmap ? landHeightmapGray : heightmapGray;
+            const v0 = grayFn(t_elevation[it]);
+            const v1 = grayFn(t_elevation[ot]);
+            const v2 = grayFn(r_elevation[br]);
             c0r = c0g = c0b = v0;
             c1r = c1g = c1b = v1;
             c2r = c2g = c2b = v2;
@@ -834,10 +845,10 @@ export function buildMesh() {
 
         if (isSmooth) {
             // Smooth heightmap: per-vertex colors from averaged triangle elevations
-            const colorFn = isLandHeightmap ? landHeightmapColor : heightmapColor;
-            const c0 = colorFn(t_elevation[it])[0];  // inner_t (vertex 0, never swapped)
-            const cOt = colorFn(t_elevation[ot])[0];  // outer_t
-            const cBr = colorFn(r_elevation[br])[0];  // begin_r
+            const grayFn = isLandHeightmap ? landHeightmapGray : heightmapGray;
+            const c0 = grayFn(t_elevation[it]);  // inner_t (vertex 0, never swapped)
+            const cOt = grayFn(t_elevation[ot]);  // outer_t
+            const cBr = grayFn(r_elevation[br]);  // begin_r
             // After winding fix, v1/v2 may have swapped (outer_t ↔ begin_r)
             const c1 = swapped ? cBr : cOt;
             const c2 = swapped ? cOt : cBr;
@@ -1061,10 +1072,10 @@ export function updateMeshColors() {
             const it = mesh.s_inner_t(s);
             const ot = mesh.s_outer_t(s);
             const br = mesh.s_begin_r(s);
-            const colorFn = isLandHeightmap ? landHeightmapColor : heightmapColor;
-            const c0 = colorFn(t_elevation[it])[0];
-            const cOt = colorFn(t_elevation[ot])[0];
-            const cBr = colorFn(r_elevation[br])[0];
+            const grayFn = isLandHeightmap ? landHeightmapGray : heightmapGray;
+            const c0 = grayFn(t_elevation[it]);
+            const cOt = grayFn(t_elevation[ot]);
+            const cBr = grayFn(r_elevation[br]);
             const swapped = sideSwapped && sideSwapped[s];
             const c1 = swapped ? cBr : cOt;
             const c2 = swapped ? cOt : cBr;
@@ -1099,10 +1110,10 @@ export function updateMeshColors() {
                 const it = mesh.s_inner_t(s);
                 const ot = mesh.s_outer_t(s);
                 const br = mesh.s_begin_r(s);
-                const colorFn = isLandHeightmap ? landHeightmapColor : heightmapColor;
-                const v0 = colorFn(t_elevation[it])[0];
-                const v1 = colorFn(t_elevation[ot])[0];
-                const v2 = colorFn(r_elevation[br])[0];
+                const grayFn = isLandHeightmap ? landHeightmapGray : heightmapGray;
+                const v0 = grayFn(t_elevation[it]);
+                const v1 = grayFn(t_elevation[ot]);
+                const v2 = grayFn(r_elevation[br]);
                 mapColors[off] = mapColors[off+1] = mapColors[off+2] = v0;
                 mapColors[off+3] = mapColors[off+4] = mapColors[off+5] = v1;
                 mapColors[off+6] = mapColors[off+7] = mapColors[off+8] = v2;
@@ -1971,10 +1982,10 @@ export async function exportMap(type, width, onProgress) {
         let c0r, c0g, c0b, c1r, c1g, c1b, c2r, c2g, c2b;
         if (is16Bit) {
             // Smooth heightmap: triangle-center vertices use averaged elevation
-            const colorFn = type === 'landheightmap' ? landHeightmapColor : heightmapColor;
-            const v0 = colorFn(t_elev[it])[0];
-            const v1 = colorFn(t_elev[ot])[0];
-            const v2 = colorFn(r_elevation[br])[0];
+            const grayFn = type === 'landheightmap' ? landHeightmapGray : heightmapGray;
+            const v0 = grayFn(t_elev[it]);
+            const v1 = grayFn(t_elev[ot]);
+            const v2 = grayFn(r_elevation[br]);
             c0r = c0g = c0b = v0;
             c1r = c1g = c1b = v1;
             c2r = c2g = c2b = v2;
@@ -2328,10 +2339,10 @@ export async function exportMapBatch(types, width, onProgress) {
 
             if (is16Bit) {
                 // Smooth heightmap: triangle-center vertices use averaged elevation
-                const colorFn = type === 'landheightmap' ? landHeightmapColor : heightmapColor;
-                const v0 = colorFn(t_elev[triInnerT[i]])[0];
-                const v1 = colorFn(t_elev[triOuterT[i]])[0];
-                const v2 = colorFn(r_elevation[br])[0];
+                const grayFn = type === 'landheightmap' ? landHeightmapGray : heightmapGray;
+                const v0 = grayFn(t_elev[triInnerT[i]]);
+                const v1 = grayFn(t_elev[triOuterT[i]]);
+                const v2 = grayFn(r_elevation[br]);
                 colData[off] = colData[off+1] = colData[off+2] = v0;
                 colData[off+3] = colData[off+4] = colData[off+5] = v1;
                 colData[off+6] = colData[off+7] = colData[off+8] = v2;

--- a/js/planet-worker.js
+++ b/js/planet-worker.js
@@ -441,6 +441,12 @@ function handleGenerate(data) {
             triangles: mesh.triangles,
             halfedges: mesh.halfedges,
             numRegions: mesh.numRegions,
+            meshAdj: {
+                r_s: mesh._r_s,
+                adjOffset: mesh._adjOffset,
+                adjList: mesh._adjList,
+                adjTriList: mesh._adjTriList,
+            },
             r_xyz, t_xyz, r_plate,
             plateSeeds: Array.from(plateSeeds),
             plateVec,

--- a/js/planet-worker.js
+++ b/js/planet-worker.js
@@ -193,7 +193,7 @@ function buildClimateFields(windResult, oceanResult, precipResult, tempResult) {
 }
 
 function handleGenerate(data) {
-    const { N, P, jitter, nMag, numContinents, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, terrainWarp, continentSizeVariety = 0, temperatureOffset = 0, precipitationOffset = 0, landCoverage = 0.3, seed: overrideSeed, toggledIndices, skipClimate } = data;
+    const { N, P, jitter, nMag, numContinents, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, terrainWarp, continentSizeVariety = 0, temperatureOffset = 0, precipitationOffset = 0, landCoverage = 0.3, seed: overrideSeed, toggledIndices, skipClimate, computeMetrics = false } = data;
     const spread = 5;
     const timing = []; // top-level pipeline timing
 
@@ -411,20 +411,25 @@ function handleGenerate(data) {
 
         // Compute terrain quality metrics using retained-state clones
         // (the originals will be transferred and neutered below).
+        // Terrain metrics are a dev-only scorecard (never rendered). Skip the
+        // ~19-metric pass in normal generation; the tuning harnesses opt in
+        // via computeMetrics on the generate command.
         let terrainMetrics = null;
-        try {
-            terrainMetrics = computeTerrainMetrics({
-                mesh: W.mesh,
-                r_xyz: W.r_xyz,
-                r_elevation: W.r_elevation_final,
-                r_plate: W.r_plate,
-                plateIsOcean: Array.from(W.plateIsOcean),
-                r_stress: W.r_stress,
-                debugLayers,
-                prePostElev: W.prePostElev,
-            });
-        } catch (e) {
-            terrainMetrics = { _error: e.message };
+        if (computeMetrics) {
+            try {
+                terrainMetrics = computeTerrainMetrics({
+                    mesh: W.mesh,
+                    r_xyz: W.r_xyz,
+                    r_elevation: W.r_elevation_final,
+                    r_plate: W.r_plate,
+                    plateIsOcean: Array.from(W.plateIsOcean),
+                    r_stress: W.r_stress,
+                    debugLayers,
+                    prePostElev: W.prePostElev,
+                });
+            } catch (e) {
+                terrainMetrics = { _error: e.message };
+            }
         }
 
         const tWorkerTotal = performance.now() - tTotal0;

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -205,7 +205,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
 
     // Scale-dependent hop count: PRECIP_ADVECT_REACH_KM (default 3961 km), currently clamped to 20 hops (see SP2/SP3).
     // Average edge length ≈ π / sqrt(numRegions) radians ≈ (π * 6371) / sqrt(N) km
-    // hops ≈ 2000 / edgeLengthKm
+    // hops ≈ PRECIP_ADVECT_REACH_KM / edgeLengthKm
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);
     const avgEdgeRad = Math.PI / Math.sqrt(numRegions);
     const maxHops = Math.max(8, Math.min(20, Math.round(CLIMATE.PRECIP_ADVECT_REACH_KM / avgEdgeKm)));

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -203,7 +203,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
         r_eastX, r_eastY, r_eastZ,
         r_northX, r_northY, r_northZ } = windResult;
 
-    // Scale-dependent hop count: ~2000 km reach.
+    // Scale-dependent hop count: PRECIP_ADVECT_REACH_KM (default 3961 km), currently clamped to 20 hops (see SP2/SP3).
     // Average edge length ≈ π / sqrt(numRegions) radians ≈ (π * 6371) / sqrt(N) km
     // hops ≈ 2000 / edgeLengthKm
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);
@@ -579,7 +579,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
             upOff[numRegions] = upCount;
             dnOff[numRegions] = dnCount;
 
-            // --- Pass 1: Propagate shadow DOWNWIND (~2500 km, 15% survives) ---
+            // --- Pass 1: Propagate shadow DOWNWIND (PRECIP_RS_SHADOW_PROP_KM, default 3363 km; 15% survives) ---
             const shadowHops = Math.max(8, Math.round(CLIMATE.PRECIP_RS_SHADOW_PROP_KM / avgEdgeKm));
             const shadowDecay = 1 - Math.pow(0.15, 1 / shadowHops);
             const shadowField = new Float32Array(rainShadow);

--- a/js/scene.js
+++ b/js/scene.js
@@ -55,8 +55,9 @@ canvas.addEventListener('touchmove', (e) => {
 
 canvas.addEventListener('touchend', () => { _pinchDist = 0; }, { passive: true });
 
+const _zoomVec = new THREE.Vector3();
 export function tickZoom() {
-    const v = new THREE.Vector3().subVectors(camera.position, ctrl.target);
+    const v = _zoomVec.subVectors(camera.position, ctrl.target);
     const cur = v.length();
     const next = THREE.MathUtils.lerp(cur, _zoomTarget, ZOOM_SMOOTH);
     if (Math.abs(next - cur) < 0.0001) return;

--- a/js/sphere-mesh.js
+++ b/js/sphere-mesh.js
@@ -92,12 +92,22 @@ export function addPoleToMesh(poleId, triangles, halfedges) {
 // Lightweight dual-mesh helper wrapping Delaunator output.
 // Regions = Voronoi cells, Triangles = Delaunay triangles, Sides = half-edges.
 export class SphereMesh {
-    constructor(triangles, halfedges, numRegions) {
+    constructor(triangles, halfedges, numRegions, prebuilt = null) {
         this.triangles = triangles;
         this.halfedges = halfedges;
         this.numRegions = numRegions;
         this.numSides = triangles.length;
         this.numTriangles = (triangles.length / 3) | 0;
+
+        if (prebuilt) {
+            this._r_s = prebuilt.r_s;
+            this._adjOffset = prebuilt.adjOffset;
+            this._adjList = prebuilt.adjList;
+            this._adjTriList = prebuilt.adjTriList;
+            this.adjOffset = this._adjOffset;
+            this.adjList = this._adjList;
+            return;
+        }
 
         this._r_s = new Int32Array(numRegions).fill(-1);
         for (let s = 0; s < this.numSides; s++) {

--- a/tuning/auto-tune.mjs
+++ b/tuning/auto-tune.mjs
@@ -69,6 +69,17 @@ async function runSeed(browser, baseUrl, seed) {
       }
     });
 
+    // The app auto-generates once on load with a random seed and default
+    // sliders (js/main.js), and #generate stays disabled until that
+    // generation finishes. If we proceed before it settles, the click
+    // below is a no-op and the harness ends up capturing the random
+    // auto-gen instead of our seeded case. Wait for it to fully finish.
+    await page.waitForFunction(() => {
+      const o = document.getElementById('buildOverlay');
+      const b = document.getElementById('generate');
+      return o && o.classList.contains('hidden') && b && !b.disabled;
+    }, { timeout: 180000 });
+
     // Set low detail for speed
     await page.evaluate(() => {
       const el = document.getElementById('sN');
@@ -80,7 +91,10 @@ async function runSeed(browser, baseUrl, seed) {
     await page.evaluate((s) => {
       const origPost = Worker.prototype.postMessage;
       Worker.prototype.postMessage = function(msg, ...rest) {
-        if (msg && msg.cmd === 'generate' && msg.seed === undefined) msg.seed = Number(s);
+        if (msg && msg.cmd === 'generate' && msg.seed === undefined) {
+          msg.seed = Number(s);
+          msg.computeMetrics = true;
+        }
         return origPost.call(this, msg, ...rest);
       };
     }, seed);
@@ -95,6 +109,15 @@ async function runSeed(browser, baseUrl, seed) {
     }, 120_000);
 
     await new Promise((r) => setTimeout(r, 100));
+    // For detail/erosion-only cases (no plate-affecting slider change) the
+    // click handler would otherwise see isRebuild=true and reuse the prior
+    // seed, so the postMessage patch's `msg.seed === undefined` check never
+    // fires and our seed is silently ignored. Stripping 'stale' forces
+    // seed=undefined so the patch above actually injects our seed.
+    await page.evaluate(() => {
+      const b = document.getElementById('generate');
+      if (b) b.classList.remove('stale');
+    });
     await page.click('#generate');
     await genDone;
 

--- a/tuning/climate/README.md
+++ b/tuning/climate/README.md
@@ -20,7 +20,7 @@ excluded (and reported separately as `landAgreement`).
 - `macroF1` — unweighted mean F1 across classes present in the truth, so rare
   but important classes (Mediterranean Csa/Csb, monsoon Cwa/Dwa…) aren't drowned
   out by large deserts and subarctic zones
-- **objective = 0.5·exactAcc + 0.5·macroF1** — what the optimizer maximizes
+- **objective = 0.60·gradedAcc + 0.12·macroF1 + 0.15·groupBalance + 0.13·watchlistF1** — what the optimizer maximizes
 
 Ground-truth codes are mapped onto the app's class set (`As` → `Aw`, the standard
 merge). Ground truth lives in `data/ascii/Koeppen-Geiger-ASCII.txt`.

--- a/tuning/climate/lib/score.mjs
+++ b/tuning/climate/lib/score.mjs
@@ -57,7 +57,7 @@ export function runClimate(ctx, paramOverrides = {}) {
 /**
  * Score a simulated Köppen field against ground truth.
  *
- * objective = 0.48·gradedAcc + 0.20·macroF1 + 0.18·groupBalance + 0.14·watchlistF1
+ * objective = 0.60·gradedAcc + 0.12·macroF1 + 0.15·groupBalance + 0.13·watchlistF1
  *   gradedAcc     — per-cell climatic similarity (partial credit; a big error
  *                   like rainforest→desert scores ~0, an adjacent one ~0.8)
  *   macroF1       — unweighted mean F1, keeps every class alive regardless of area

--- a/tuning/regress.mjs
+++ b/tuning/regress.mjs
@@ -1,0 +1,218 @@
+/**
+ * Golden-master regression harness for World Orogen.
+ *
+ * Generates a fixed basket of planets headlessly and hashes the worker's
+ * deterministic output arrays (elevation + climate). SP1's contract is that
+ * these hashes never change; SP2/SP3 reuse this file in --diff mode to see
+ * intended changes.
+ *
+ *   node tuning/regress.mjs --update   # write baseline
+ *   node tuning/regress.mjs            # check against baseline (default)
+ *   node tuning/regress.mjs --diff     # report changed arrays, don't fail
+ *
+ * Screenshots are saved to tuning/regress-screenshots/ for optional human
+ * comparison but are NOT hash-asserted (GPU rasterization isn't bit-stable).
+ */
+
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const BASELINE_PATH = path.join(__dirname, 'regress-baseline.json');
+const SHOT_DIR = path.join(__dirname, 'regress-screenshots');
+fs.mkdirSync(SHOT_DIR, { recursive: true });
+
+const MODE = process.argv.includes('--update') ? 'update'
+           : process.argv.includes('--diff') ? 'diff'
+           : 'check';
+
+// Fixed basket: 3 seeds x 3 detail levels + one extra. All detail levels are
+// below AUTO_CLIMATE_THRESHOLD (300k) so climate is computed inline and its
+// arrays are present in state.curData for hashing.
+const CASES = [
+  { name: 'seed42-d5k',   seed: 42,  detail: 0,   sliders: {} },   // detail slider 0 -> 5,000 regions
+  { name: 'seed42-d50k',  seed: 42,  detail: 300, sliders: {} },
+  { name: 'seed42-d200k', seed: 42,  detail: 470, sliders: {} },
+  { name: 'seed100-d50k', seed: 100, detail: 300, sliders: { sP: 8,  sLc: 0.6 } },
+  { name: 'seed200-d50k', seed: 200, detail: 300, sliders: { sP: 80, sLc: 0.25 } },
+  { name: 'seed300-d50k', seed: 300, detail: 300, sliders: { sGl: 0.8, sHEr: 0.8, sTEr: 0.8 } },
+];
+
+// Arrays to hash (only those present are hashed; climate ones appear <300k).
+const HASH_KEYS = [
+  'r_elevation', 't_elevation',
+  'r_precip_summer', 'r_precip_winter',
+  'r_temperature_summer', 'r_temperature_winter',
+];
+
+const MIME = {
+  '.html':'text/html', '.js':'application/javascript', '.mjs':'application/javascript',
+  '.css':'text/css', '.json':'application/json', '.png':'image/png', '.svg':'image/svg+xml',
+  '.ico':'image/x-icon', '.woff':'font/woff', '.woff2':'font/woff2',
+  '.webmanifest':'application/manifest+json', '.txt':'text/plain', '.xml':'application/xml', '.wasm':'application/wasm',
+};
+
+function startServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let urlPath = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+      if (urlPath === '/' || urlPath === '') urlPath = '/index.html';
+      const filePath = path.join(PROJECT_ROOT, urlPath);
+      if (!filePath.startsWith(PROJECT_ROOT)) { res.writeHead(403); res.end(); return; }
+      fs.readFile(filePath, (err, data) => {
+        if (err) { res.writeHead(404); res.end('Not found'); return; }
+        res.writeHead(200, { 'Content-Type': MIME[path.extname(filePath).toLowerCase()] || 'application/octet-stream' });
+        res.end(data);
+      });
+    });
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+async function hashCase(page, tc) {
+  await page.evaluate(() => { window.__WO_CAPTURE = true; });
+
+  // Overlays off, detail + sliders set.
+  await page.evaluate(() => {
+    for (const id of ['tutorialOverlay', 'whatsNewOverlay']) {
+      const el = document.getElementById(id); if (el) el.style.display = 'none';
+    }
+  });
+
+  // The app auto-generates once on load with a random seed and default
+  // sliders (js/main.js), and #generate stays disabled with #buildOverlay
+  // (pointer-events: auto) covering it until that generation finishes. If we
+  // click before it settles the click is a no-op and the harness ends up
+  // hashing the random auto-gen instead of our seeded case. Wait for it to
+  // fully finish so the generate-done waiter installed below catches OUR
+  // generation, not the auto-gen's.
+  await page.waitForFunction(() => {
+    const o = document.getElementById('buildOverlay');
+    const b = document.getElementById('generate');
+    return o && o.classList.contains('hidden') && b && !b.disabled;
+  }, { timeout: 180_000 });
+
+  await page.evaluate(({ id, value }) => {
+    const el = document.getElementById(id); el.value = value;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }, { id: 'sN', value: String(tc.detail) });
+  for (const [id, val] of Object.entries(tc.sliders)) {
+    await page.evaluate(({ id, value }) => {
+      const el = document.getElementById(id); el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, { id, value: String(val) });
+  }
+
+  // Inject fixed seed by patching the next 'generate' postMessage.
+  await page.evaluate((seed) => {
+    const orig = Worker.prototype.postMessage;
+    Worker.prototype.postMessage = function (msg, ...rest) {
+      if (msg && msg.cmd === 'generate' && msg.seed === undefined) msg.seed = Number(seed);
+      return orig.call(this, msg, ...rest);
+    };
+  }, tc.seed);
+
+  const done = page.evaluate((timeout) => new Promise((resolve, reject) => {
+    const btn = document.getElementById('generate');
+    const timer = setTimeout(() => reject(new Error('gen timeout')), timeout);
+    btn.addEventListener('generate-done', () => { clearTimeout(timer); resolve(); }, { once: true });
+  }), 180_000);
+  await new Promise((r) => setTimeout(r, 100));
+
+  // For detail/erosion-only cases (no PLATE_SLIDERS change) the click handler
+  // would otherwise see isRebuild=true and reuse state.curData.seed, so the
+  // postMessage patch's `msg.seed === undefined` check never fires and our
+  // seed is silently ignored. Stripping 'stale' forces seed=undefined so the
+  // patch above actually injects tc.seed.
+  await page.evaluate(() => {
+    const b = document.getElementById('generate');
+    if (b) b.classList.remove('stale');
+  });
+  await page.click('#generate');
+  await done;
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Hash arrays in-page (cyrb53 over the raw bytes) — only short hex crosses the bridge.
+  const hashes = await page.evaluate((keys) => {
+    const cyrb53 = (bytes) => {
+      let h1 = 0xdeadbeef, h2 = 0x41c6ce57;
+      for (let i = 0; i < bytes.length; i++) {
+        const ch = bytes[i];
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+      }
+      h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+      h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+      return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(16);
+    };
+    const d = window.__WO_state && window.__WO_state.curData;
+    const out = {};
+    if (!d) return out;
+    for (const k of keys) {
+      const arr = d[k];
+      if (arr && arr.buffer) out[k] = `${arr.length}:${cyrb53(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength))}`;
+    }
+    return out;
+  }, HASH_KEYS);
+
+  // Advisory screenshot (not asserted).
+  const canvas = await page.$('#canvas');
+  if (canvas) await canvas.screenshot({ path: path.join(SHOT_DIR, `${tc.name}.png`) }).catch(() => {});
+
+  return hashes;
+}
+
+async function main() {
+  const { server, port } = await startServer();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--enable-webgl',
+           '--use-gl=angle', '--use-angle=swiftshader-webgl', '--enable-unsafe-swiftshader'],
+  });
+
+  const results = {};
+  try {
+    for (const tc of CASES) {
+      const page = await browser.newPage();
+      await page.setViewport({ width: 1200, height: 900 });
+      page.on('dialog', (d) => d.dismiss());
+      page.on('pageerror', (e) => console.log(`  [PAGE EXCEPTION] ${e.message}`));
+      await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+      await new Promise((r) => setTimeout(r, 2000));
+      console.log(`Generating ${tc.name}...`);
+      results[tc.name] = await hashCase(page, tc);
+      await page.close().catch(() => {});
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  if (MODE === 'update') {
+    fs.writeFileSync(BASELINE_PATH, JSON.stringify(results, null, 2));
+    console.log(`\nBaseline written to ${path.relative(PROJECT_ROOT, BASELINE_PATH)}`);
+    return;
+  }
+
+  const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+  let mismatches = 0;
+  for (const tc of CASES) {
+    const a = baseline[tc.name] || {}, b = results[tc.name] || {};
+    for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) {
+      if (a[k] !== b[k]) {
+        mismatches++;
+        console.log(`  CHANGED ${tc.name}.${k}: ${a[k]} -> ${b[k]}`);
+      }
+    }
+  }
+  if (mismatches === 0) console.log('\nAll cases byte-identical to baseline.');
+  else console.log(`\n${mismatches} array(s) differ from baseline.`);
+  if (MODE === 'check' && mismatches > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/tuning/render-harness.mjs
+++ b/tuning/render-harness.mjs
@@ -233,6 +233,17 @@ async function main() {
           }
         });
 
+        // The app auto-generates once on load with a random seed and default
+        // sliders (js/main.js), and #generate stays disabled until that
+        // generation finishes. If we proceed before it settles, the click
+        // below is a no-op and the harness ends up capturing the random
+        // auto-gen instead of our seeded case. Wait for it to fully finish.
+        await page.waitForFunction(() => {
+          const o = document.getElementById('buildOverlay');
+          const b = document.getElementById('generate');
+          return o && o.classList.contains('hidden') && b && !b.disabled;
+        }, { timeout: 180000 });
+
         // Set detail slider low for fast iteration
         await setSlider(page, 'sN', DETAIL_SLIDER_VALUE);
 
@@ -250,6 +261,7 @@ async function main() {
           Worker.prototype.postMessage = function(msg, ...rest) {
             if (msg && msg.cmd === 'generate' && msg.seed === undefined) {
               msg.seed = Number(seed);
+              msg.computeMetrics = true;
             }
             return origPost.call(this, msg, ...rest);
           };
@@ -260,6 +272,15 @@ async function main() {
         const genDone = installGenerationWaiter(page, 120_000);
         // Small delay so the evaluate above has time to register the listener
         await new Promise((r) => setTimeout(r, 100));
+        // For detail/erosion-only cases (no plate-affecting slider change) the
+        // click handler would otherwise see isRebuild=true and reuse the prior
+        // seed, so the postMessage patch's `msg.seed === undefined` check never
+        // fires and our seed is silently ignored. Stripping 'stale' forces
+        // seed=undefined so the patch above actually injects tc.seed.
+        await page.evaluate(() => {
+          const b = document.getElementById('generate');
+          if (b) b.classList.remove('stale');
+        });
         await page.click('#generate');
 
         // Wait for generation to finish


### PR DESCRIPTION
## SP1 — Performance Free Wins

Eight low-risk performance fixes that make generation faster with **zero change to the generated planet**, plus a reusable golden-master regression harness (Task 1) that guards the whole set. Every commit is verified **bit-identical** (elevation + climate output arrays) against a captured baseline; the composed branch passes a capstone byte-identical check.

**Guiding constraint:** no build step, no new runtime dependencies (harness uses Node built-ins + Puppeteer only), scale-invariance untouched (that's SP2/SP3), WHY-comments only.

### What & why, per commit

| Commit | Change | Why |
|--------|--------|-----|
| `test: golden-master regression harness` | New `tuning/regress.mjs` generates 6 fixed planets headlessly and hashes the worker's deterministic output arrays, asserting byte-identical to a baseline. Adds a gated, **inert** capture handle in `js/generate.js` (active only when `window.__WO_CAPTURE` is set). | Provides the verification gate every other fix relies on; left in-repo for SP2/SP3 to reuse in diff mode. |
| `docs: correct stale comments/formula` | Fixes the objective-formula in `tuning/climate/README.md` + `score.mjs` docstring to match executing weights (`0.60/0.12/0.15/0.13`), corrects km reach comments to cite the real config constants, rewrites the elevation stage-count header to the actual 13-stage order, fixes the detail-range comment (`5,000` not `2,000`). | Comments/markdown only — stale docs are worse than none. |
| `perf: reuse a scratch Vector3 in tickZoom` | Hoists a module-scope scratch vector instead of allocating one per animation frame. | Removes per-frame GC churn in the render loop. |
| `perf: gate terrain-metrics scorecard` | The worker's ~19-metric scorecard (never rendered in-app) is now computed only when `computeMetrics: true` is passed on the generate message. Both tuning harnesses opt in. | Skips a dev-only pass on every normal generation. |
| `perf: recolor instead of full rebuild on climateDone` | On-demand climate completion now calls `updateMeshColors()` (colors only) instead of `buildMesh()` (full geometry rebuild). | Climate changes only per-cell colors, not geometry — a full rebuild is wasted work. |
| `perf: remove dead domain-warp coordinates` | Deletes `wx/wy/wz` + warp scalars computed per land cell in `buildSkeleton` but read nowhere in it (the live copies in `applyTectonicBandNoise`/`applyDetailTexture` are untouched). | Removes 3 fbm calls per land cell with zero output change. |
| `perf: warm-started adjacency walk for findNearestR` | Replaces the O(numRegions) brute-force nearest-region scan (hotspot/LIP placement) with a greedy hill-climb over the mesh adjacency graph, warm-started across calls, with a brute-force **fallback** on step-cap. | Near-O(1) per query; the fallback guarantees the exact same index brute force returned. |
| `perf: reuse worker-built mesh adjacency on main thread` | The worker ships its already-built CSR adjacency (`meshAdj`) in the `done` message (structured-cloned, **not** transferred, so `W.mesh` stays intact for reapply/edit); the main-thread `SphereMesh` constructor accepts it and skips the two O(numSides) rebuild loops. | Moves mesh-adjacency reconstruction off the main thread; the adjacency is identical to a from-scratch build. |
| `perf: scalar grayscale color helpers` | Adds `heightmapGray`/`landHeightmapGray` (identical to `heightmapColor(e)[0]`/`landHeightmapColor(e)[0]`) and converts six `colorFn(x)[0]` sites, removing per-call 3-element array allocations. | Avoids allocating an `[r,g,b]` array just to read one channel in the heightmap color fills. |
| `docs: fix stale precip/comment drift` | Post-review one-line comment corrections (precip hop-count comment → `PRECIP_ADVECT_REACH_KM`; `findNearestR` warm-start comment → `_nearCur`). | Whole-branch review follow-ups; comment-only. |

### Notable, intentional deviations from the original plan

- **Harness determinism fix.** The app auto-generates once on load with a *random* seed; the plan's harness clicked `#generate` while that was still running (button disabled, overlay intercepting), so it hashed the random auto-generation → non-deterministic baseline. This race was also latent in the pre-existing `render-harness.mjs`/`auto-tune.mjs` (it just never mattered for advisory screenshots). Fix: wait for the initial auto-gen to settle (`#buildOverlay` `hidden` + `#generate` enabled) and strip the `stale` class before clicking, forcing a fresh seeded generation. Applied to all three tuning scripts.
- **Task 4 scope.** Gating metrics would have silently starved `render-harness.mjs` **and** `auto-tune.mjs` (both read `window.__terrainMetrics`); the same fix + `computeMetrics: true` were ported into both so the metrics tooling keeps working — and now runs on the *intended* seeded planet, not a random one.
- **Task 9 trimmed to the effective part.** The plan's Step 3 (`_rgbScratch` + a destructure rewrite) was omitted: `_rgbScratch` would be dead code (its use was explicitly deferred) and array destructuring doesn't allocate, so the rewrite saved nothing. Only the real allocation win (the six `colorFn[0]` → `grayFn` conversions) was kept.

### Verification

- **Golden-master:** `node tuning/regress.mjs` → *"All cases byte-identical to baseline."* on every individual commit and on the composed HEAD (capstone).
- **Paths the 6-case basket doesn't exercise** were verified separately: Task 5 (`climateDone`) via a headless smoke test forcing the on-demand climate path (0 errors, recolor confirmed); Task 7 (`findNearestR`) via temporary instrumentation asserting walk == brute force — **100 calls/case × 6 cases, 0 mismatches**; Task 8 via a temporary assertion that prebuilt adjacency equals a from-scratch build across all render-harness cases (0 mismatches).
- Whole-branch review (independent): **no Critical, no blocking Important**; the two "Important" notes are forward-looking robustness suggestions for when SP2/SP3 reuse the harness (see below).

### Cross-worktree dependency

**None.** SP1 is fully self-contained and depends on nothing from the SP2/SP3 worktrees. The relationship is the reverse: SP1 *provides* the reusable golden-master harness (`tuning/regress.mjs`) that SP2/SP3 are intended to reuse in `--diff` mode. Two non-blocking harness-robustness suggestions were surfaced for those future sub-projects (not fixed here, as they're out of SP1's zero-change scope): (1) `regress.mjs` diff-mode should distinguish "array removed/added" from "array changed"; (2) the `cyrb53` hash is a non-cryptographic 53-bit hash — adequate for accidental-collision detection but worth a note before it's leaned on more heavily.

### Notes for reviewers

- To run the harness locally, Puppeteer must be resolvable by `node` the same way `tuning/render-harness.mjs` already requires it (dev-only; not a committed dependency — there is no `package.json`).
- The generated `tuning/regress-baseline.json` and `tuning/regress-screenshots/` are git-ignored.

### Test plan

- [ ] `node tuning/regress.mjs` → "All cases byte-identical to baseline."
- [ ] `node tuning/render-harness.mjs` → still writes `*_metrics.json` (metrics opt-in works).
- [ ] Manual: generate a planet; switch to Köppen/Climate, Heightmap, Land Heightmap, Temperature views on both globe and map — all render identically.
