### PR TITLE
feat: SP4 — climate physics user controls (axial tilt, rotation, greenhouse + 4 character sliders)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ tuning/results/*.json
 tuning/results/climate/
 tuning/climate/data/
 tuning/climate/maps/
+tuning/screenshots/
+tuning/regress-baseline.json
+tuning/regress-screenshots/
+tuning/scale-invariance-baseline.json
+tuning/scale-invariance-screenshots/
+node_modules/

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ All three are considered together; ties are broken in the order above.
 - **Seasonal wind simulation** — pressure-driven wind patterns with a longitude-varying ITCZ that tracks the thermal equator (~5° over ocean, up to 15-20° over continents), Gaussian pressure bands (subtropical highs, subpolar lows, polar highs), land/sea thermal contrast for monsoon-like pressure reversals, elevation barometric effects, and Coriolis-deflected geostrophic wind with natural cross-equatorial flow reversal. Computed for both summer and winter seasons.
 - **Ocean surface currents** — rule-based geographic gyre simulation driven by wind belts (trade winds, westerlies, polar easterlies) with a longitude-varying ITCZ equatorial countercurrent. Continental shelves are classified as western or eastern boundaries via coast-normal BFS, producing subtropical gyres (CW in NH, CCW in SH) with western boundary intensification (Gulf Stream, Kuroshio effect) and weaker eastern boundary return flow. Detects circumpolar channels for unobstructed eastward currents (Antarctic Circumpolar Current). Currents are colored by heat transport: red = warm poleward flow, blue = cold equatorward flow, black = zonal (neutral). Computed for both summer and winter seasons.
 - **Precipitation** — blended dual-model approach: a complex moisture advection simulation is blended with a fast heuristic zonal model (blend weight and all climate constants are tuned against real-Earth Köppen data; see `js/climate-config.js`). The advection model simulates wind-driven moisture transport from coasts with six mechanisms: ITCZ convective uplift, frontal convergence, orographic rain/shadow, lee cyclogenesis, polar-front precipitation, and subtropical high suppression. The heuristic model provides smooth latitude-based patterns (ITCZ wet belt, subtropical dry belt, mid-latitude recovery, polar dryness) modulated by continentality and orographic effects. Blending the two reduces splotchiness while preserving terrain-informed detail and strengthening subtropical desert formation (~20–35°). Visualized on a brown (dry) → green (moderate) → blue (wet) color ramp. Computed for both summer and winter seasons.
+- **Planetary and climate-character controls** — three planetary sliders (Axial Tilt, Rotation Rate, Greenhouse) reshape the simulation itself: seasons scale with tilt, circulation bands shift equatorward or poleward with rotation rate, and pole-equator contrast flattens or sharpens with greenhouse strength. Four climate-character sliders (Winter Severity, Orographic Rain, Maritime Influence, Mountain Chill) restyle continental winters, mountain rain shadows, coastal mildness, and altitude lapse rate. All seven recompute climate-only on slider release and are encoded in the planet code.
 - **Map type switcher** — first-class Terrain / Satellite / Climate / Heightmap tabs with color legends for each view
 - **On-demand climate** — optional deferred climate computation; skip climate during generation for faster terrain iteration, compute it on demand when needed
 - **Detailed visualization** — twenty-six selectable inspection layers organized by category (Geology, Atmosphere, Ocean, Climate, Elevation) for viewing each component in isolation. Wind/pressure layers show directional wind arrows, ocean current layers show current arrows colored by heat transport, on both globe and map views. Precipitation layers use a brown→green→blue ramp showing dry to wet regions.
@@ -69,7 +70,7 @@ A top navigation bar connects the two pages:
 
 ### Sharing Planets
 
-Every generated planet produces a **planet code** (shown below the Build button) that encodes the random seed, all slider values, and any plate edits. An unedited planet is 21 characters; plate edits (applied via Rebuild) extend the code to include the toggled plates. Older codes (13–18 characters) from previous versions are still supported — missing sliders default to their current default values. To share a planet:
+Every generated planet produces a **planet code** (shown below the Build button) that encodes the random seed, all slider values, and any plate edits. An unedited planet is 27 characters; plate edits (applied via Rebuild) extend the code to include the toggled plates. Older codes (13–22 characters) from previous versions — including the 21- and 22-character codes produced just before this update — are still supported; missing sliders (such as the seven planetary/climate-character sliders below) default to their current default values. To share a planet:
 
 - **Copy** the code with the copy button and send it to someone
 - **Load** a code by pasting it into the planet code field and clicking Load (or pressing Enter). The Load button turns blue when a new code is ready to apply.
@@ -106,12 +107,26 @@ Post-processing passes that refine the terrain (collapsed by default — the def
 
 ### Climate
 
-Global climate offsets that adjust temperature and precipitation without a full rebuild. Changing these triggers a fast climate-only recompute.
+Planetary and climate-character controls that adjust the simulation without a full rebuild. Changing any slider triggers a climate-only recompute on release: the **Planet** group reshapes the simulation — Axial Tilt and Rotation Rate reshape circulation itself and invalidate the cached wind and ocean current fields, while Greenhouse — like the **Character** knobs (including the existing Temperature and Precipitation offsets) — reuses those cached fields for a cheaper temperature/precipitation-only recompute.
+
+**Planet**
+
+| Control | Range | Default | Description |
+|---------|-------|---------|-------------|
+| Axial Tilt | 0 – 45° | 23.5° | Tilt of the spin axis — drives the strength of seasons. 0° is seasonless, Earth is 23.5°, higher gives extreme seasonal swings and deep monsoons |
+| Rotation Rate | 0.5 – 2× | 1× | Spin speed vs Earth — fast rotators bend winds harder and pull circulation bands toward the equator; slow rotators widen the tropical cells |
+| Greenhouse | -1 – 1 | 0 | Atmosphere thickness — thick warms the whole planet and softens the equator-to-pole contrast; thin cools it and sharpens the poles |
+
+**Character**
 
 | Control | Range | Default | Description |
 |---------|-------|---------|-------------|
 | Temperature | -15 – 15 | 0 | Global temperature offset in °C — positive makes the planet warmer, negative colder. Climate zones shift accordingly |
 | Precipitation | -1 – 1 | 0 | Global precipitation scale — positive makes the planet wetter, negative drier. Affects desert and rainforest distribution |
+| Winter Severity | 0 – 2× | 1× | How brutally continental interiors cool in their winter — high values push Siberian-style winters deeper into the continents |
+| Orographic Rain | 0 – 2× | 1× | How strongly mountains wring rain out of the wind — windward slopes get wetter and leeward rain shadows get deeper |
+| Maritime Influence | 0 – 2× | 1× | How far ocean warmth reaches inland — high values carry mild coastal climates deep into the continents |
+| Mountain Chill | 0 – 2× | 1× | How fast temperature falls with altitude — high values frost highlands and snow-cap peaks sooner |
 
 ### Auto Climate
 

--- a/index.html
+++ b/index.html
@@ -46,6 +46,8 @@
             "Tectonic plate simulation with collision detection",
             "Glacial, hydraulic, and thermal erosion",
             "Climate simulation with wind, precipitation, and ocean currents",
+            "Axial tilt and rotation controls with tilt-scaled seasons",
+            "Greenhouse and climate-character sliders",
             "Hotspot volcanism with island chains",
             "Interactive plate editing",
             "Equirectangular heightmap import with automatic climate simulation",
@@ -125,7 +127,7 @@
         <ul>
             <li>Tectonic plate simulation with convergent, divergent, and transform boundaries</li>
             <li>Multiple erosion types: glacial (fjords, U-shaped valleys), hydraulic (river valleys), and thermal (talus slopes)</li>
-            <li>Climate simulation with seasonal wind patterns, ocean currents, precipitation, and K&ouml;ppen climate classification</li>
+            <li>Climate simulation with seasonal wind patterns, ocean currents, precipitation, and K&ouml;ppen climate classification &mdash; tune axial tilt, rotation rate, and greenhouse strength (which reshape seasons and circulation), plus climate-character sliders for winter severity, orographic rain, maritime influence, and mountain lapse rate</li>
             <li>Hotspot volcanism with drift-trail island chains (like Hawaii)</li>
             <li>Interactive plate editing — select multiple plates for batch land/ocean toggling with visual preview before rebuild</li>
             <li>Heightmap import — bring your own equirectangular B&amp;W heightmap (Earth, Mars, hand-drawn) and run full climate simulation on it</li>
@@ -245,7 +247,7 @@
             </div>
         </details>
         <details class="section">
-            <summary>Climate <span class="tip" data-tip="Global temperature and precipitation offsets — changes apply on slider release, recomputing only precipitation, temperature, and climate zones">?</span></summary>
+            <summary>Climate <span class="tip" data-tip="Planetary and climate-character controls (tilt, rotation, greenhouse, temperature, precipitation, and four character knobs) — changes apply on slider release, recomputing only wind/ocean (for tilt/rotation), precipitation, temperature, and climate zones">?</span></summary>
             <div class="section-body">
                 <div class="climate-hint">Changes apply on release — only climate zones are recomputed.</div>
                 <div class="cg-sub">Planet</div>
@@ -437,6 +439,7 @@
                 <h3>Visualize Your World</h3>
                 <p>Switch between <strong>Terrain</strong>, <strong>Satellite</strong>, <strong>Climate</strong>, and <strong>Heightmap</strong> views using the tabs under Visual Options. Use the <strong>Inspect</strong> dropdown for detailed layers like pressure, wind, and precipitation.</p>
                 <p>At high detail, climate is skipped automatically for faster generation &mdash; it computes on demand when you switch to a climate view.</p>
+                <p>Expand the <strong>Climate</strong> panel to give your world alien seasons with <strong>Axial Tilt</strong>, spin it faster with <strong>Rotation Rate</strong>, or thicken its atmosphere with <strong>Greenhouse</strong> &mdash; plus four character sliders for winters, mountain rain, coastal mildness, and lapse rate. Changes apply when you release the slider, recomputing only climate.</p>
             </div>
             <div class="tutorial-step" data-step="4">
                 <h3>Save &amp; Share</h3>
@@ -533,11 +536,18 @@
                     <li><strong>Better terrain at every detail level</strong> &mdash; Mountains, erosion, and coastlines now scale consistently whether you're at 5K or 2.5M regions.</li>
                 </ul>
             </div>
+            <div class="whatsnew-step" data-step="4">
+                <h3>Planet &amp; Climate Controls</h3>
+                <ul class="whatsnew-list">
+                    <li><strong>Planet &amp; Climate controls</strong> &mdash; shape your world's seasons (Axial Tilt), spin (Rotation Rate), and atmosphere (Greenhouse), plus four climate-character sliders (Winter Severity, Orographic Rain, Maritime Influence, Mountain Chill). All recompute climate-only on release.</li>
+                </ul>
+            </div>
             <div class="tutorial-dots">
                 <span class="dot active" data-dot="0"></span>
                 <span class="dot" data-dot="1"></span>
                 <span class="dot" data-dot="2"></span>
                 <span class="dot" data-dot="3"></span>
+                <span class="dot" data-dot="4"></span>
             </div>
             <div class="tutorial-nav">
                 <button id="whatsNewBack" class="btn-ghost" disabled>Back</button>

--- a/index.html
+++ b/index.html
@@ -248,6 +248,23 @@
             <summary>Climate <span class="tip" data-tip="Global temperature and precipitation offsets — changes apply on slider release, recomputing only precipitation, temperature, and climate zones">?</span></summary>
             <div class="section-body">
                 <div class="climate-hint">Changes apply on release — only climate zones are recomputed.</div>
+                <div class="cg-sub">Planet</div>
+                <div class="cg">
+                    <label>Axial Tilt <span class="tip" data-tip="Tilt of the spin axis — drives the strength of seasons. 0° is seasonless, Earth is 23.5°, higher gives extreme seasonal swings and deep monsoons.">?</span> <span class="v" id="vTilt">23.5°</span></label>
+                    <input type="range" id="sTilt" min="0" max="45" value="23.5" step="0.5">
+                    <div class="slider-hint"><span>No seasons</span><span>Extreme seasons</span></div>
+                </div>
+                <div class="cg">
+                    <label>Rotation Rate <span class="tip" data-tip="Spin speed vs Earth — fast rotators bend winds harder and pull circulation bands toward the equator; slow rotators widen the tropical cells.">?</span> <span class="v" id="vRot">1.0×</span></label>
+                    <input type="range" id="sRot" min="0.5" max="2" value="1" step="0.1">
+                    <div class="slider-hint"><span>Slow</span><span>Fast</span></div>
+                </div>
+                <div class="cg">
+                    <label>Greenhouse <span class="tip" data-tip="Atmosphere thickness — thick warms the whole planet and softens the equator-to-pole contrast; thin cools it and sharpens the poles.">?</span> <span class="v" id="vGh">±0.0</span></label>
+                    <input type="range" id="sGh" min="-1" max="1" value="0" step="0.1">
+                    <div class="slider-hint"><span>Thin</span><span>Thick</span></div>
+                </div>
+                <div class="cg-sub">Character</div>
                 <div class="cg">
                     <label>Temperature <span class="tip" data-tip="Shift global temperature — positive makes the planet warmer, negative makes it colder. Climate zones shift accordingly.">?</span> <span class="v" id="vTmp">±0°C</span></label>
                     <input type="range" id="sTmp" min="-15" max="15" value="0" step="1">
@@ -257,6 +274,26 @@
                     <label>Precipitation <span class="tip" data-tip="Scale global precipitation — positive makes the planet wetter, negative drier. Affects desert and rainforest distribution.">?</span> <span class="v" id="vPrc">±0%</span></label>
                     <input type="range" id="sPrc" min="-1" max="1" value="0" step="0.1">
                     <div class="slider-hint"><span>Drier</span><span>Wetter</span></div>
+                </div>
+                <div class="cg">
+                    <label>Winter Severity <span class="tip" data-tip="How brutally continental interiors cool in their winter — high values push Siberian-style winters deeper into the continents.">?</span> <span class="v" id="vWs">1.0×</span></label>
+                    <input type="range" id="sWs" min="0" max="2" value="1" step="0.1">
+                    <div class="slider-hint"><span>Mild</span><span>Brutal</span></div>
+                </div>
+                <div class="cg">
+                    <label>Orographic Rain <span class="tip" data-tip="How strongly mountains wring rain out of the wind — windward slopes get wetter and leeward rain shadows get deeper.">?</span> <span class="v" id="vOro">1.0×</span></label>
+                    <input type="range" id="sOro" min="0" max="2" value="1" step="0.1">
+                    <div class="slider-hint"><span>Weak</span><span>Strong</span></div>
+                </div>
+                <div class="cg">
+                    <label>Maritime Influence <span class="tip" data-tip="How far ocean warmth reaches inland — high values carry mild coastal climates deep into the continents.">?</span> <span class="v" id="vMar">1.0×</span></label>
+                    <input type="range" id="sMar" min="0" max="2" value="1" step="0.1">
+                    <div class="slider-hint"><span>Isolated</span><span>Far-reaching</span></div>
+                </div>
+                <div class="cg">
+                    <label>Mountain Chill <span class="tip" data-tip="How fast temperature falls with altitude — high values frost highlands and snow-cap peaks sooner.">?</span> <span class="v" id="vLap">1.0×</span></label>
+                    <input type="range" id="sLap" min="0" max="2" value="1" step="0.1">
+                    <div class="slider-hint"><span>Gentle</span><span>Harsh</span></div>
                 </div>
             </div>
         </details>

--- a/js/climate-config.js
+++ b/js/climate-config.js
@@ -64,6 +64,12 @@ export const CLIMATE_DEFAULTS = Object.freeze({
     TEMP_CLOUD_MOD_STRENGTH: 0.05,        // max pull toward 0 under full cloud cover
     TEMP_CLEARSKY_AMP_STRENGTH: 0.2745,     // max amplification of extremes under clear skies
 
+    // ── Temperature: greenhouse (user Greenhouse slider g ∈ [−1,1]; all three
+    // terms are exactly inert at g = 0, so the optimizer never needs them) ──
+    TEMP_GH_UNIFORM_C: 10,                   // uniform warming per unit g
+    TEMP_GH_GRADIENT_FRAC: 0.35,             // equator→pole range shrink at g=1 (polar amplification)
+    TEMP_GH_WINTER_LIFT: 0.15,               // winter-share reduction at g=1 (winters warm faster)
+
     // ── Precipitation: moisture & advection ──
     PRECIP_OCEAN_MOISTURE_BASE: 0.4508,      // base moisture of ocean cells
     PRECIP_ADVECT_FLAT_SURVIVAL: 0.8901,    // moisture surviving full advection over flat land

--- a/js/climate-util.js
+++ b/js/climate-util.js
@@ -108,3 +108,14 @@ export function percentile(arr, p) {
     floydRivest(work, 0, n - 1, k);
     return work[k] || 1;
 }
+
+// ── Season-factor scaling for user-tunable axial tilt ────────────────────────
+
+// Earth's tilt is the reference the whole climate system was tuned at; the
+// exact-equality early return guarantees a bit-identical no-op at 23.5°.
+export const REF_TILT_DEG = 23.5;
+
+export function seasonFactorFromTilt(axialTiltDeg) {
+    if (axialTiltDeg === REF_TILT_DEG) { return 1; }
+    return Math.sin(axialTiltDeg * Math.PI / 180) / Math.sin(REF_TILT_DEG * Math.PI / 180);
+}

--- a/js/generate.js
+++ b/js/generate.js
@@ -317,6 +317,13 @@ if (worker) {
                 const tMainTotal = performance.now() - tMainStart;
                 const tTotal = performance.now() - _t0;
 
+                // Test-only capture handle (inert unless the regression harness
+                // sets window.__WO_CAPTURE). Lets tuning/regress.mjs read the
+                // deterministic output arrays for golden-master hashing.
+                if (typeof window !== 'undefined' && window.__WO_CAPTURE) {
+                    window.__WO_state = state;
+                }
+
                 // Diagnostics
                 {
                     let landCount = 0, nanCount = 0;

--- a/js/generate.js
+++ b/js/generate.js
@@ -14,6 +14,23 @@ import { classifyKoppen } from './koppen.js';
 // Main thread still needs Delaunator for SphereMesh reconstruction
 setDelaunator(Delaunator);
 
+// Climate-only slider values; optional-chained so pages without the climate
+// panel (and Task-1-era code before the sliders exist) fall back to defaults.
+function readClimateSliders() {
+    return {
+        temperatureOffset: +(document.getElementById('sTmp')?.value ?? 0),
+        precipitationOffset: +(document.getElementById('sPrc')?.value ?? 0),
+        landCoverage: +(document.getElementById('sLc')?.value ?? 0.3),
+        axialTilt: +(document.getElementById('sTilt')?.value ?? 23.5),
+        rotationRate: +(document.getElementById('sRot')?.value ?? 1),
+        greenhouse: +(document.getElementById('sGh')?.value ?? 0),
+        winterSeverity: +(document.getElementById('sWs')?.value ?? 1),
+        orographicRain: +(document.getElementById('sOro')?.value ?? 1),
+        maritimeInfluence: +(document.getElementById('sMar')?.value ?? 1),
+        mountainChill: +(document.getElementById('sLap')?.value ?? 1),
+    };
+}
+
 // Read all slider values from the DOM into a params object
 function readSliders() {
     return {
@@ -29,9 +46,7 @@ function readSliders() {
         ridgeSharpening: +document.getElementById('sRs').value,
         glacialErosion: +document.getElementById('sGl').value,
         continentSizeVariety: +document.getElementById('sCsv').value,
-        temperatureOffset: +document.getElementById('sTmp').value,
-        precipitationOffset: +document.getElementById('sPrc').value,
-        landCoverage: +document.getElementById('sLc').value,
+        ...readClimateSliders(),
     };
 }
 
@@ -935,13 +950,11 @@ export function reapplyViaWorker(onDone, skipClimate = false) {
     _t0 = performance.now();
 
     const s = readSlidersOptional();
-    const temperatureOffset = +(document.getElementById('sTmp')?.value ?? 0);
-    const precipitationOffset = +(document.getElementById('sPrc')?.value ?? 0);
-    const landCoverage = +(document.getElementById('sLc')?.value ?? 0.3);
+    const climate = readClimateSliders();
 
     worker.postMessage({
         cmd: 'reapply',
-        ...s, temperatureOffset, precipitationOffset, landCoverage,
+        ...s, ...climate,
         skipClimate
     });
 }
@@ -954,14 +967,14 @@ export function editRecomputeViaWorker(onDone, skipClimate = false) {
     _onDone = onDone || null;
     _t0 = performance.now();
 
-    const { nMag, terrainWarp, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, temperatureOffset, precipitationOffset, landCoverage } = readSliders();
+    const { nMag, terrainWarp, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening } = readSliders();
 
     worker.postMessage({
         cmd: 'editRecompute',
         plateIsOcean: Array.from(d.plateIsOcean),
         plateDensity: d.plateDensity,
         nMag, terrainWarp, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening,
-        temperatureOffset, precipitationOffset, landCoverage,
+        ...readClimateSliders(),
         skipClimate
     });
 }
@@ -971,13 +984,10 @@ export function computeClimateViaWorker(onProgress, onDone) {
     _onProgress = onProgress || (() => {});
     _onDone = onDone || null;
     _t0 = performance.now();
-    const temperatureOffset = +(document.getElementById('sTmp')?.value ?? 0);
-    const precipitationOffset = +(document.getElementById('sPrc')?.value ?? 0);
-    const landCoverage = +(document.getElementById('sLc')?.value ?? 0.3);
 
     worker.postMessage({
         cmd: 'computeClimate',
-        temperatureOffset, precipitationOffset, landCoverage
+        ...readClimateSliders()
     });
 }
 

--- a/js/heuristic-precip.js
+++ b/js/heuristic-precip.js
@@ -124,9 +124,10 @@ export function computeHeuristicWindField(numRegions, r_lat, r_lon, itczLookup) 
  * @param {Float32Array} r_elevGradE - pre-computed east elevation gradient
  * @param {Float32Array} r_elevGradN - pre-computed north elevation gradient
  * @param {Int32Array} r_coastDistLand - BFS hop distance from coast through land
+ * @param {number} [seasonFactor=1] - seasonal-contrast scale from axial tilt (1 at Earth tilt)
  * @returns {{ r_precip_summer, r_precip_winter }}
  */
-export function computeHeuristicPrecipitation(mesh, r_xyz, r_elevation, windResult, r_elevGradE, r_elevGradN, r_coastDistLand) {
+export function computeHeuristicPrecipitation(mesh, r_xyz, r_elevation, windResult, r_elevGradE, r_elevGradN, r_coastDistLand, seasonFactor = 1) {
     const numRegions = mesh.numRegions;
     const { r_lat, r_lon, r_isLand, r_continentality } = windResult;
 
@@ -177,6 +178,13 @@ export function computeHeuristicPrecipitation(mesh, r_xyz, r_elevation, windResu
 
     const result = {};
 
+    let effSummerMod = CLIMATE.HEUR_SEASON_SUMMER_MOD;
+    let effWinterMod = CLIMATE.HEUR_SEASON_WINTER_MOD;
+    if (seasonFactor !== 1) {
+        effSummerMod = 1 + (effSummerMod - 1) * seasonFactor;
+        effWinterMod = 1 + (effWinterMod - 1) * seasonFactor;
+    }
+
     const seasons = [
         { name: 'summer', shift: 5 },
         { name: 'winter', shift: -5 }
@@ -209,7 +217,7 @@ export function computeHeuristicPrecipitation(mesh, r_xyz, r_elevation, windResu
             // ── B. Seasonal modifier + Mediterranean subtropical suppression ──
             const absLatDeg = Math.abs(lat) / DEG;
             const inSummerHemi = isSummer ? (lat >= 0) : (lat < 0);
-            let seasonMod = inSummerHemi ? CLIMATE.HEUR_SEASON_SUMMER_MOD : CLIMATE.HEUR_SEASON_WINTER_MOD;
+            let seasonMod = inSummerHemi ? effSummerMod : effWinterMod;
 
             // Mediterranean suppression: subtropical highs expand poleward in
             // local summer, strongly suppressing rainfall at 25-42° latitude.

--- a/js/main.js
+++ b/js/main.js
@@ -1234,7 +1234,7 @@ window.addEventListener('resize', () => {
 
 // What's New modal — shown once per version for returning users
 (function initWhatsNew() {
-    const VERSION    = '2';
+    const VERSION    = '3';
     const LS_KEY     = 'wo-whatsnew-seen';
     const LS_TUTORIAL = 'atlas-engine-tutorial-seen';
     const overlay    = document.getElementById('whatsNewOverlay');

--- a/js/main.js
+++ b/js/main.js
@@ -538,6 +538,13 @@ function updatePlanetCode(flash) {
         +document.getElementById('sTmp').value,
         +document.getElementById('sPrc').value,
         +document.getElementById('sLc').value,
+        +document.getElementById('sTilt').value,
+        +document.getElementById('sRot').value,
+        +document.getElementById('sGh').value,
+        +document.getElementById('sWs').value,
+        +document.getElementById('sOro').value,
+        +document.getElementById('sMar').value,
+        +document.getElementById('sLap').value,
         getToggledIndices()
     );
     currentCode = code;
@@ -611,6 +618,9 @@ function paramsToSliderMap(params) {
         sHEr: params.hydraulicErosion, sTEr: params.thermalErosion,
         sRs: params.ridgeSharpening, sTmp: params.temperatureOffset,
         sPrc: params.precipitationOffset,
+        sTilt: params.axialTilt, sRot: params.rotationRate, sGh: params.greenhouse,
+        sWs: params.winterSeverity, sOro: params.orographicRain,
+        sMar: params.maritimeInfluence, sLap: params.mountainChill,
     };
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -133,7 +133,10 @@ function initSliderTooltip(slider) {
     slider.addEventListener('pointercancel', hide);
 }
 
-for (const [s,v] of [['sN','vN'],['sP','vP'],['sCn','vCn'],['sJ','vJ'],['sNs','vNs'],['sCsv','vCsv'],['sLc','vLc'],['sTw','vTw'],['sS','vS'],['sGl','vGl'],['sHEr','vHEr'],['sTEr','vTEr'],['sRs','vRs'],['sTmp','vTmp'],['sPrc','vPrc']]) {
+// Climate sliders recompute climate-only on release (change), not per drag tick
+const CLIMATE_SLIDER_IDS = new Set(['sTmp', 'sPrc', 'sTilt', 'sRot', 'sGh', 'sWs', 'sOro', 'sMar', 'sLap']);
+
+for (const [s,v] of [['sN','vN'],['sP','vP'],['sCn','vCn'],['sJ','vJ'],['sNs','vNs'],['sCsv','vCsv'],['sLc','vLc'],['sTw','vTw'],['sS','vS'],['sGl','vGl'],['sHEr','vHEr'],['sTEr','vTEr'],['sRs','vRs'],['sTmp','vTmp'],['sPrc','vPrc'],['sTilt','vTilt'],['sRot','vRot'],['sGh','vGh'],['sWs','vWs'],['sOro','vOro'],['sMar','vMar'],['sLap','vLap']]) {
     const slider = document.getElementById(s);
     initSliderTooltip(slider);
     slider.addEventListener('input', e => {
@@ -150,19 +153,26 @@ for (const [s,v] of [['sN','vN'],['sP','vP'],['sCn','vCn'],['sJ','vJ'],['sNs','v
             document.getElementById(v).textContent = (pct > 0 ? '+' : pct === 0 ? '\u00b1' : '') + pct + '%';
         } else if (s === 'sLc') {
             document.getElementById(v).textContent = Math.round(+e.target.value * 100) + '%';
+        } else if (s === 'sTilt') {
+            document.getElementById(v).textContent = (+e.target.value).toFixed(1).replace(/\.0$/, '') + '°';
+        } else if (s === 'sGh') {
+            const val = +e.target.value;
+            document.getElementById(v).textContent = (val > 0 ? '+' : val === 0 ? '±' : '') + val.toFixed(1);
+        } else if (s === 'sRot' || s === 'sWs' || s === 'sOro' || s === 'sMar' || s === 'sLap') {
+            document.getElementById(v).textContent = (+e.target.value).toFixed(1) + '×';
         } else {
             document.getElementById(v).textContent = e.target.value;
         }
         if (s === 'sTw' || s === 'sS' || s === 'sGl' || s === 'sHEr' || s === 'sTEr' || s === 'sRs') {
             markReapplyPending();
-        } else if (s === 'sTmp' || s === 'sPrc') {
+        } else if (CLIMATE_SLIDER_IDS.has(s)) {
             // Display-only update during drag; actual recompute on change (release)
         } else {
             checkStale();
         }
     });
     // Climate sliders: recompute only on release (change), not every drag tick
-    if (s === 'sTmp' || s === 'sPrc') {
+    if (CLIMATE_SLIDER_IDS.has(s)) {
         slider.addEventListener('change', () => {
             if (!state.curData) return;
             updatePlanetCode(false);

--- a/js/ocean.js
+++ b/js/ocean.js
@@ -121,8 +121,9 @@ function hasCircumpolarChannel(r_lat, r_lon, r_isOcean, numRegions, targetLat, b
 //   Polar cell (easterlies westward):  western=warm, eastern=cold  (flipped back)
 
 function classifyWarmth(r_isOcean, r_lat, numRegions,
-    r_westCoastDist, r_eastCoastDist, fadeRange, seasonalShiftDeg) {
+    r_westCoastDist, r_eastCoastDist, fadeRange, seasonalShiftDeg, bandScale = 1) {
     const r_warmth = new Float32Array(numRegions);
+    const b28 = 28 * bandScale, b35 = 35 * bandScale, b55 = 55 * bandScale, b65 = 65 * bandScale;
 
     for (let r = 0; r < numRegions; r++) {
         if (!r_isOcean[r]) continue;
@@ -133,14 +134,14 @@ function classifyWarmth(r_isOcean, r_lat, numRegions,
         // Wind cell sign: trades/polar push water west (western=warm → +1),
         // westerlies push water east (western=cold → -1)
         let cellSign;
-        if (bandLatDeg < 28) {
+        if (bandLatDeg < b28) {
             cellSign = 1;
-        } else if (bandLatDeg < 35) {
-            cellSign = 1 - 2 * smoothstep(28, 35, bandLatDeg);
-        } else if (bandLatDeg < 55) {
+        } else if (bandLatDeg < b35) {
+            cellSign = 1 - 2 * smoothstep(b28, b35, bandLatDeg);
+        } else if (bandLatDeg < b55) {
             cellSign = -1;
-        } else if (bandLatDeg < 65) {
-            cellSign = -1 + 2 * smoothstep(55, 65, bandLatDeg);
+        } else if (bandLatDeg < b65) {
+            cellSign = -1 + 2 * smoothstep(b55, b65, bandLatDeg);
         } else {
             cellSign = 1;
         }
@@ -206,6 +207,10 @@ function smoothOcean(mesh, field, r_isOcean, passes) {
  */
 export function computeOceanCurrents(mesh, r_xyz, r_elevation, windResult, userClimate = {}) {
     const { rotationRate = 1, seasonFactor = 1 } = userClimate;
+    // INTERIM (until SP5 couples currents to the real wind field): shift the
+    // hardcoded gyre band latitudes with rotation the same way the wind bands
+    // move, so atmosphere and ocean don't visibly disagree.
+    const bandScale = Math.pow(rotationRate, -1 / 3);
     console.log('[ocean.js] computeOceanCurrents called, numRegions:', mesh.numRegions);
     const numRegions = mesh.numRegions;
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);
@@ -267,6 +272,7 @@ export function computeOceanCurrents(mesh, r_xyz, r_elevation, windResult, userC
         t0 = performance.now();
         const currentE = new Float32Array(numRegions);
         const currentN = new Float32Array(numRegions);
+        const c30 = 30 * bandScale, c35 = 35 * bandScale, c58 = 58 * bandScale, c65 = 65 * bandScale;
 
         for (let r = 0; r < numRegions; r++) {
             if (!r_isOcean[r]) continue;
@@ -288,18 +294,18 @@ export function computeOceanCurrents(mesh, r_xyz, r_elevation, windResult, userC
             if (distFromItcz < 3) {
                 // ITCZ zone: eastward countercurrent at center, blends to westward at edges
                 baseE = 1 - 2 * smoothstep(0, 3, distFromItcz);
-            } else if (bandLatDeg < 30) {
+            } else if (bandLatDeg < c30) {
                 // Trade winds: westward
                 baseE = -1;
-            } else if (bandLatDeg < 35) {
+            } else if (bandLatDeg < c35) {
                 // Subtropical transition: blend trades → westerlies
-                baseE = -1 + 2 * smoothstep(30, 35, bandLatDeg);
-            } else if (bandLatDeg < 58) {
+                baseE = -1 + 2 * smoothstep(c30, c35, bandLatDeg);
+            } else if (bandLatDeg < c58) {
                 // Ferrel cell / westerlies: eastward
                 baseE = 1;
-            } else if (bandLatDeg < 65) {
+            } else if (bandLatDeg < c65) {
                 // Subpolar transition: blend westerlies → polar easterlies
-                baseE = 1 - 1.5 * smoothstep(58, 65, bandLatDeg);
+                baseE = 1 - 1.5 * smoothstep(c58, c65, bandLatDeg);
             } else {
                 // Polar easterlies: weak westward
                 baseE = -0.5;
@@ -355,7 +361,7 @@ export function computeOceanCurrents(mesh, r_xyz, r_elevation, windResult, userC
         // small island contributions (few coast cells → weak signal after smoothing).
         t0 = performance.now();
         const r_warmth = classifyWarmth(r_isOcean, r_lat, numRegions,
-            r_westCoastDist, r_eastCoastDist, warmthRange, seasonalShiftDeg);
+            r_westCoastDist, r_eastCoastDist, warmthRange, seasonalShiftDeg, bandScale);
         const warmthSmoothPasses = Math.max(3, Math.round(900 / avgEdgeKm));
         smoothOcean(mesh, r_warmth, r_isOcean, warmthSmoothPasses);
 

--- a/js/ocean.js
+++ b/js/ocean.js
@@ -259,8 +259,9 @@ export function computeOceanCurrents(mesh, r_xyz, r_elevation, windResult, userC
     ];
 
     for (const { name, itczLookup } of seasons) {
-        // Seasonal shift: wind cells migrate ~5° toward summer hemisphere
-        const seasonalShiftDeg = name === 'summer' ? 5 : -5;
+        // Wind cells migrate toward the summer hemisphere; the migration is a
+        // seasonal effect so it scales with tilt (0 at 0°).
+        const seasonalShiftDeg = (name === 'summer' ? 5 : -5) * seasonFactor;
 
         // Steps 3–4: Wind band classification + current vectors
         t0 = performance.now();

--- a/js/ocean.js
+++ b/js/ocean.js
@@ -204,7 +204,8 @@ function smoothOcean(mesh, field, r_isOcean, passes) {
  * @param {object} windResult - output from computeWind() (includes lat, lon, sinLat, isLand, tangent frames, ITCZ arrays)
  * @returns {object} current vectors, warmth, and speed arrays for both seasons
  */
-export function computeOceanCurrents(mesh, r_xyz, r_elevation, windResult) {
+export function computeOceanCurrents(mesh, r_xyz, r_elevation, windResult, userClimate = {}) {
+    const { rotationRate = 1, seasonFactor = 1 } = userClimate;
     console.log('[ocean.js] computeOceanCurrents called, numRegions:', mesh.numRegions);
     const numRegions = mesh.numRegions;
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);

--- a/js/planet-code.js
+++ b/js/planet-code.js
@@ -19,12 +19,20 @@ const SLIDERS = [
     { min: -15,   step: 1,    count: 31  }, // 13: Temperature
     { min: -1,    step: 0.1,  count: 21  }, // 14: Precipitation
     { min: 0,     step: 0.01, count: 101 }, // 15: Land Coverage
+    { min: 0,     step: 0.5,  count: 91  }, // 16: Axial Tilt
+    { min: 0.5,   step: 0.1,  count: 16  }, // 17: Rotation Rate
+    { min: -1,    step: 0.1,  count: 21  }, // 18: Greenhouse
+    { min: 0,     step: 0.1,  count: 21  }, // 19: Winter Severity
+    { min: 0,     step: 0.1,  count: 21  }, // 20: Orographic Rain
+    { min: 0,     step: 0.1,  count: 21  }, // 21: Maritime Influence
+    { min: 0,     step: 0.1,  count: 21  }, // 22: Mountain Chill
 ];
 
-// Mixed-radix bases (right-to-left): lcIdx, prcIdx, tmpIdx, csvIdx, twIdx, scIdx, rsIdx, teIdx, heIdx, glIdx, smIdx, nsIdx, cnIdx, pIdx, jIdx, nIdx, seed
-const RADICES = [101, 21, 31, 21, 21, 21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2556];
+// Mixed-radix bases (right-to-left): lapIdx, marIdx, oroIdx, wsIdx, ghIdx, rotIdx, tiltIdx, lcIdx, prcIdx, tmpIdx, csvIdx, twIdx, scIdx, rsIdx, teIdx, heIdx, glIdx, smIdx, nsIdx, cnIdx, pIdx, jIdx, nIdx, seed
+const RADICES = [21, 21, 21, 21, 21, 16, 91, 101, 21, 31, 21, 21, 21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2556];
 const SEED_MAX = 16777216; // 2^24
-const BASE_LEN = 22; // base code length (no toggles)
+const BASE_LEN = 27; // base code length (no toggles)
+const PREV6_LEN = 22; // previous 22-char codes (before SP4 climate controls)
 const PREV5_LEN = 21; // previous 21-char codes (before land coverage)
 const PREV4_LEN = 18; // previous 18-char codes (before continent variety/temp/precip)
 const PREV3_LEN = 17; // previous 17-char codes (before terrain warp)
@@ -50,6 +58,9 @@ const PREV5_RADICES = [21, 31, 21, 21, 21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 
 
 // Previous4-gen radices for decoding 18-char codes (before continent variety/temp/precip)
 const PREV4_RADICES = [21, 21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2556];
+
+// Previous6-gen radices for decoding 22-char codes (before SP4 climate controls)
+const PREV6_RADICES = [101, 21, 31, 21, 21, 21, 21, 21, 21, 21, 21, 51, 10, 117, 21, 2556];
 
 function toIndex(value, slider) {
     return Math.round((value - slider.min) / slider.step);
@@ -83,7 +94,9 @@ const DECODE_FORMATS = {
         ],
         defaults: { terrainWarp: 0.5, glacialErosion: 0, thermalErosion: 0.1,
                     ridgeSharpening: 0.35, soilCreep: 0.05, continentSizeVariety: 0,
-                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3,
+                    axialTilt: 23.5, rotationRate: 1, greenhouse: 0, winterSeverity: 1,
+                    orographicRain: 1, maritimeInfluence: 1, mountainChill: 1 }
     },
     [PREV_LEN]: {
         radices: PREV_RADICES,
@@ -93,7 +106,9 @@ const DECODE_FORMATS = {
         ],
         defaults: { terrainWarp: 0.5, glacialErosion: 0, ridgeSharpening: 0.35,
                     soilCreep: 0.05, continentSizeVariety: 0,
-                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3,
+                    axialTilt: 23.5, rotationRate: 1, greenhouse: 0, winterSeverity: 1,
+                    orographicRain: 1, maritimeInfluence: 1, mountainChill: 1 }
     },
     [PREV2_LEN]: {
         radices: PREV2_RADICES,
@@ -102,7 +117,9 @@ const DECODE_FORMATS = {
             ['smoothing', 5], ['roughness', 4], ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
         ],
         defaults: { terrainWarp: 0.5, glacialErosion: 0, continentSizeVariety: 0,
-                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3,
+                    axialTilt: 23.5, rotationRate: 1, greenhouse: 0, winterSeverity: 1,
+                    orographicRain: 1, maritimeInfluence: 1, mountainChill: 1 }
     },
     [PREV3_LEN]: {
         radices: PREV3_RADICES,
@@ -112,7 +129,9 @@ const DECODE_FORMATS = {
             ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
         ],
         defaults: { terrainWarp: 0.5, continentSizeVariety: 0,
-                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+                    temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3,
+                    axialTilt: 23.5, rotationRate: 1, greenhouse: 0, winterSeverity: 1,
+                    orographicRain: 1, maritimeInfluence: 1, mountainChill: 1 }
     },
     [PREV4_LEN]: {
         radices: PREV4_RADICES,
@@ -121,7 +140,9 @@ const DECODE_FORMATS = {
             ['thermalErosion', 8], ['hydraulicErosion', 7], ['glacialErosion', 6],
             ['smoothing', 5], ['roughness', 4], ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
         ],
-        defaults: { continentSizeVariety: 0, temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3 }
+        defaults: { continentSizeVariety: 0, temperatureOffset: 0, precipitationOffset: 0, landCoverage: 0.3,
+                    axialTilt: 23.5, rotationRate: 1, greenhouse: 0, winterSeverity: 1,
+                    orographicRain: 1, maritimeInfluence: 1, mountainChill: 1 }
     },
     [PREV5_LEN]: {
         radices: PREV5_RADICES,
@@ -131,11 +152,26 @@ const DECODE_FORMATS = {
             ['thermalErosion', 8], ['hydraulicErosion', 7], ['glacialErosion', 6],
             ['smoothing', 5], ['roughness', 4], ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
         ],
-        defaults: { landCoverage: 0.3 }
+        defaults: { landCoverage: 0.3,
+                    axialTilt: 23.5, rotationRate: 1, greenhouse: 0, winterSeverity: 1,
+                    orographicRain: 1, maritimeInfluence: 1, mountainChill: 1 }
+    },
+    [PREV6_LEN]: {
+        radices: PREV6_RADICES,
+        fields: [
+            ['landCoverage', 15], ['precipitationOffset', 14], ['temperatureOffset', 13],
+            ['continentSizeVariety', 12], ['terrainWarp', 11], ['soilCreep', 10], ['ridgeSharpening', 9],
+            ['thermalErosion', 8], ['hydraulicErosion', 7], ['glacialErosion', 6],
+            ['smoothing', 5], ['roughness', 4], ['numContinents', 3], ['P', 2], ['jitter', 1], ['N', 0],
+        ],
+        defaults: { axialTilt: 23.5, rotationRate: 1, greenhouse: 0, winterSeverity: 1,
+                    orographicRain: 1, maritimeInfluence: 1, mountainChill: 1 }
     },
     [BASE_LEN]: {
         radices: RADICES,
         fields: [
+            ['mountainChill', 22], ['maritimeInfluence', 21], ['orographicRain', 20],
+            ['winterSeverity', 19], ['greenhouse', 18], ['rotationRate', 17], ['axialTilt', 16],
             ['landCoverage', 15], ['precipitationOffset', 14], ['temperatureOffset', 13],
             ['continentSizeVariety', 12], ['terrainWarp', 11], ['soilCreep', 10], ['ridgeSharpening', 9],
             ['thermalErosion', 8], ['hydraulicErosion', 7], ['glacialErosion', 6],
@@ -191,10 +227,17 @@ function decodeFormat(packed, config, toggleStr) {
  * @param {number} temperatureOffset - Temperature offset (-15–15, step 1)
  * @param {number} precipitationOffset - Precipitation offset (-1–1, step 0.1)
  * @param {number} landCoverage - Land Coverage (0–1, step 0.05)
+ * @param {number} [axialTilt=23.5] - Axial Tilt (0–45 degrees, step 0.5)
+ * @param {number} [rotationRate=1] - Rotation Rate (0.5–2, step 0.1)
+ * @param {number} [greenhouse=0] - Greenhouse (-1–1, step 0.1)
+ * @param {number} [winterSeverity=1] - Winter Severity (0–2, step 0.1)
+ * @param {number} [orographicRain=1] - Orographic Rain (0–2, step 0.1)
+ * @param {number} [maritimeInfluence=1] - Maritime Influence (0–2, step 0.1)
+ * @param {number} [mountainChill=1] - Mountain Chill (0–2, step 0.1)
  * @param {number[]} [toggledIndices=[]] - Sorted array of toggled plate indices
- * @returns {string} base36 code (22 chars without edits, 22 + '-' + 2*k with k edits)
+ * @returns {string} base36 code (27 chars without edits, 27 + '-' + 2*k with k edits)
  */
-export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, terrainWarp, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, soilCreep, continentSizeVariety, temperatureOffset, precipitationOffset, landCoverage, toggledIndices = []) {
+export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, terrainWarp, smoothing, glacialErosion, hydraulicErosion, thermalErosion, ridgeSharpening, soilCreep, continentSizeVariety, temperatureOffset, precipitationOffset, landCoverage, axialTilt = 23.5, rotationRate = 1, greenhouse = 0, winterSeverity = 1, orographicRain = 1, maritimeInfluence = 1, mountainChill = 1, toggledIndices = []) {
     const nIdx  = toIndex(N, SLIDERS[0]);
     const jIdx  = toIndex(jitter, SLIDERS[1]);
     const pIdx  = toIndex(P, SLIDERS[2]);
@@ -211,25 +254,39 @@ export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, t
     const tmpIdx = toIndex(temperatureOffset, SLIDERS[13]);
     const prcIdx = toIndex(precipitationOffset, SLIDERS[14]);
     const lcIdx  = toIndex(landCoverage, SLIDERS[15]);
+    const tiltIdx = toIndex(axialTilt, SLIDERS[16]);
+    const rotIdx = toIndex(rotationRate, SLIDERS[17]);
+    const ghIdx = toIndex(greenhouse, SLIDERS[18]);
+    const wsIdx = toIndex(winterSeverity, SLIDERS[19]);
+    const oroIdx = toIndex(orographicRain, SLIDERS[20]);
+    const marIdx = toIndex(maritimeInfluence, SLIDERS[21]);
+    const lapIdx = toIndex(mountainChill, SLIDERS[22]);
 
-    // Mixed-radix packing (least-significant first: lcIdx, prcIdx, tmpIdx, csvIdx, twIdx, ...)
+    // Mixed-radix packing (least-significant first: lapIdx, marIdx, oroIdx, wsIdx, ghIdx, rotIdx, tiltIdx, lcIdx, prcIdx, tmpIdx, csvIdx, twIdx, ...)
     let packed = BigInt(seed);
-    packed = packed * BigInt(RADICES[15]) + BigInt(nIdx);    // * 2556
-    packed = packed * BigInt(RADICES[14]) + BigInt(jIdx);    // * 21
-    packed = packed * BigInt(RADICES[13]) + BigInt(pIdx);    // * 117
-    packed = packed * BigInt(RADICES[12]) + BigInt(cnIdx);   // * 10
-    packed = packed * BigInt(RADICES[11]) + BigInt(nsIdx);   // * 51
-    packed = packed * BigInt(RADICES[10]) + BigInt(smIdx);   // * 21
-    packed = packed * BigInt(RADICES[9])  + BigInt(glIdx);   // * 21
-    packed = packed * BigInt(RADICES[8])  + BigInt(heIdx);   // * 21
-    packed = packed * BigInt(RADICES[7])  + BigInt(teIdx);   // * 21
-    packed = packed * BigInt(RADICES[6])  + BigInt(rsIdx);   // * 21
-    packed = packed * BigInt(RADICES[5])  + BigInt(scIdx);   // * 21
-    packed = packed * BigInt(RADICES[4])  + BigInt(twIdx);   // * 21
-    packed = packed * BigInt(RADICES[3])  + BigInt(csvIdx);  // * 21
-    packed = packed * BigInt(RADICES[2])  + BigInt(tmpIdx);  // * 31
-    packed = packed * BigInt(RADICES[1])  + BigInt(prcIdx);  // * 21
-    packed = packed * BigInt(RADICES[0])  + BigInt(lcIdx);   // * 21
+    packed = packed * BigInt(RADICES[22]) + BigInt(nIdx);    // * 2556
+    packed = packed * BigInt(RADICES[21]) + BigInt(jIdx);    // * 21
+    packed = packed * BigInt(RADICES[20]) + BigInt(pIdx);    // * 117
+    packed = packed * BigInt(RADICES[19]) + BigInt(cnIdx);   // * 10
+    packed = packed * BigInt(RADICES[18]) + BigInt(nsIdx);   // * 51
+    packed = packed * BigInt(RADICES[17]) + BigInt(smIdx);   // * 21
+    packed = packed * BigInt(RADICES[16]) + BigInt(glIdx);   // * 21
+    packed = packed * BigInt(RADICES[15]) + BigInt(heIdx);   // * 21
+    packed = packed * BigInt(RADICES[14]) + BigInt(teIdx);   // * 21
+    packed = packed * BigInt(RADICES[13]) + BigInt(rsIdx);   // * 21
+    packed = packed * BigInt(RADICES[12]) + BigInt(scIdx);   // * 21
+    packed = packed * BigInt(RADICES[11]) + BigInt(twIdx);   // * 21
+    packed = packed * BigInt(RADICES[10]) + BigInt(csvIdx);  // * 21
+    packed = packed * BigInt(RADICES[9])  + BigInt(tmpIdx);  // * 31
+    packed = packed * BigInt(RADICES[8])  + BigInt(prcIdx);  // * 21
+    packed = packed * BigInt(RADICES[7])  + BigInt(lcIdx);   // * 101
+    packed = packed * BigInt(RADICES[6])  + BigInt(tiltIdx); // * 91
+    packed = packed * BigInt(RADICES[5])  + BigInt(rotIdx);  // * 16
+    packed = packed * BigInt(RADICES[4])  + BigInt(ghIdx);   // * 21
+    packed = packed * BigInt(RADICES[3])  + BigInt(wsIdx);   // * 21
+    packed = packed * BigInt(RADICES[2])  + BigInt(oroIdx);  // * 21
+    packed = packed * BigInt(RADICES[1])  + BigInt(marIdx);  // * 21
+    packed = packed * BigInt(RADICES[0])  + BigInt(lapIdx);  // * 21
 
     let code = packed.toString(36).padStart(BASE_LEN, '0');
 
@@ -245,9 +302,9 @@ export function encodePlanetCode(seed, N, jitter, P, numContinents, roughness, t
 
 /**
  * Decode a base36 planet code back into planet parameters.
- * Supports 22-char (current), 21-char (prev5), 18-char (prev4), 17-char (prev3), 16-char (prev2), 14-char (previous-gen), and 13-char (legacy) codes.
- * @param {string} code - base36 code (13, 14, 16, 17, 18, 21, or 22 chars, optionally followed by "-" + toggle indices)
- * @returns {{ seed: number, N: number, jitter: number, P: number, numContinents: number, roughness: number, terrainWarp: number, smoothing: number, glacialErosion: number, hydraulicErosion: number, thermalErosion: number, ridgeSharpening: number, soilCreep: number, continentSizeVariety: number, temperatureOffset: number, precipitationOffset: number, landCoverage: number, toggledIndices: number[] } | null}
+ * Supports 27-char (current), 22-char (prev6), 21-char (prev5), 18-char (prev4), 17-char (prev3), 16-char (prev2), 14-char (previous-gen), and 13-char (legacy) codes.
+ * @param {string} code - base36 code (13, 14, 16, 17, 18, 21, 22, or 27 chars, optionally followed by "-" + toggle indices)
+ * @returns {{ seed: number, N: number, jitter: number, P: number, numContinents: number, roughness: number, terrainWarp: number, smoothing: number, glacialErosion: number, hydraulicErosion: number, thermalErosion: number, ridgeSharpening: number, soilCreep: number, continentSizeVariety: number, temperatureOffset: number, precipitationOffset: number, landCoverage: number, axialTilt: number, rotationRate: number, greenhouse: number, winterSeverity: number, orographicRain: number, maritimeInfluence: number, mountainChill: number, toggledIndices: number[] } | null}
  */
 export function decodePlanetCode(code) {
     if (typeof code !== 'string') return null;

--- a/js/planet-worker.js
+++ b/js/planet-worker.js
@@ -14,6 +14,7 @@ import { computeOceanCurrents } from './ocean.js';
 import { computePrecipitation } from './precipitation.js';
 import { computeTemperature } from './temperature.js';
 import { classifyKoppen } from './koppen.js';
+import { seasonFactorFromTilt } from './climate-util.js';
 import { computeTerrainMetrics } from './terrain-metrics.js';
 import { applyPlatePhysics, expandPlatePhysicsDebug } from './plate-physics.js';
 import { SUPER_PLATE_PHYSICS_MULT, DETAIL_NOISE_DAMPEN_STRENGTH } from './terrain-config.js';
@@ -164,8 +165,23 @@ function getClimateParams(data) {
     const temperatureOffset = data?.temperatureOffset ?? W?.temperatureOffset ?? 0;
     const precipitationOffset = data?.precipitationOffset ?? W?.precipitationOffset ?? 0;
     const landCoverage = data?.landCoverage ?? W?.landCoverage ?? 0.3;
-    if (W) { W.temperatureOffset = temperatureOffset; W.precipitationOffset = precipitationOffset; W.landCoverage = landCoverage; }
-    return { temperatureOffset, precipitationOffset, landCoverage };
+    const axialTilt = data?.axialTilt ?? W?.axialTilt ?? 23.5;
+    const rotationRate = data?.rotationRate ?? W?.rotationRate ?? 1;
+    const greenhouse = data?.greenhouse ?? W?.greenhouse ?? 0;
+    const winterSeverity = data?.winterSeverity ?? W?.winterSeverity ?? 1;
+    const orographicRain = data?.orographicRain ?? W?.orographicRain ?? 1;
+    const maritimeInfluence = data?.maritimeInfluence ?? W?.maritimeInfluence ?? 1;
+    const mountainChill = data?.mountainChill ?? W?.mountainChill ?? 1;
+    if (W) {
+        // Tilt and rotation reshape the wind field itself, so the cached
+        // wind/ocean results are stale the moment either changes.
+        if ((W.axialTilt ?? 23.5) !== axialTilt || (W.rotationRate ?? 1) !== rotationRate) {
+            W.cachedWind = null;
+            W.cachedOcean = null;
+        }
+        Object.assign(W, { temperatureOffset, precipitationOffset, landCoverage, axialTilt, rotationRate, greenhouse, winterSeverity, orographicRain, maritimeInfluence, mountainChill });
+    }
+    return { temperatureOffset, precipitationOffset, landCoverage, axialTilt, rotationRate, greenhouse, winterSeverity, orographicRain, maritimeInfluence, mountainChill };
 }
 
 function buildClimateFields(windResult, oceanResult, precipResult, tempResult) {
@@ -193,7 +209,7 @@ function buildClimateFields(windResult, oceanResult, precipResult, tempResult) {
 }
 
 function handleGenerate(data) {
-    const { N, P, jitter, nMag, numContinents, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, terrainWarp, continentSizeVariety = 0, temperatureOffset = 0, precipitationOffset = 0, landCoverage = 0.3, seed: overrideSeed, toggledIndices, skipClimate } = data;
+    const { N, P, jitter, nMag, numContinents, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, terrainWarp, continentSizeVariety = 0, temperatureOffset = 0, precipitationOffset = 0, landCoverage = 0.3, axialTilt = 23.5, rotationRate = 1, greenhouse = 0, winterSeverity = 1, orographicRain = 1, maritimeInfluence = 1, mountainChill = 1, seed: overrideSeed, toggledIndices, skipClimate } = data;
     const spread = 5;
     const timing = []; // top-level pipeline timing
 
@@ -335,9 +351,12 @@ function handleGenerate(data) {
         let windResult = null, oceanResult = null, precipResult = null, tempResult = null;
 
         if (!skipClimate) {
+            const seasonFactor = seasonFactorFromTilt(axialTilt);
+            const userClimate = { greenhouse, winterSeverity, maritimeInfluence, mountainChill, orographicRain, rotationRate, seasonFactor };
+
             progress(70, 'Simulating wind patterns\u2026');
             t0 = performance.now();
-            windResult = computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noise);
+            windResult = computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noise, axialTilt, rotationRate);
             timing.push({ stage: 'Wind simulation', ms: performance.now() - t0 });
             if (windResult._windTiming) timing.push(...windResult._windTiming);
             debugLayers.pressureSummer = windResult.r_pressure_summer;
@@ -348,13 +367,13 @@ function handleGenerate(data) {
 
             progress(78, 'Computing ocean currents\u2026');
             t0 = performance.now();
-            oceanResult = computeOceanCurrents(mesh, r_xyz, r_elevation, windResult);
+            oceanResult = computeOceanCurrents(mesh, r_xyz, r_elevation, windResult, userClimate);
             timing.push({ stage: 'Ocean currents', ms: performance.now() - t0 });
             if (oceanResult._oceanTiming) timing.push(...oceanResult._oceanTiming);
 
             progress(82, 'Computing precipitation\u2026');
             t0 = performance.now();
-            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage);
+            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage, userClimate);
             timing.push({ stage: 'Precipitation', ms: performance.now() - t0 });
             if (precipResult._precipTiming) timing.push(...precipResult._precipTiming);
             debugLayers.precipSummer = precipResult.r_precip_summer;
@@ -364,7 +383,7 @@ function handleGenerate(data) {
 
             progress(86, 'Computing temperature\u2026');
             t0 = performance.now();
-            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset);
+            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset, userClimate);
             timing.push({ stage: 'Temperature', ms: performance.now() - t0 });
             if (tempResult._tempTiming) timing.push(...tempResult._tempTiming);
             debugLayers.tempSummer = tempResult.r_temperature_summer;
@@ -397,6 +416,7 @@ function handleGenerate(data) {
             mountain_r: new Set(mountain_r), coastline_r: new Set(coastline_r), ocean_r: new Set(ocean_r),
             r_stress: new Float32Array(r_stress),
             temperatureOffset, precipitationOffset, landCoverage,
+            axialTilt, rotationRate, greenhouse, winterSeverity, orographicRain, maritimeInfluence, mountainChill,
             cachedWind: windResult, cachedOcean: oceanResult,
             // Retain detail-noise dampen + orogenic fields so reapply (which
             // reuses prePostElev) shapes the noise the same way as the initial
@@ -478,7 +498,7 @@ function handleReapply(data) {
     if (!W) { self.postMessage({ type: 'error', message: 'No retained state for reapply' }); return; }
 
     const skipClimate = !!data.skipClimate;
-    const { temperatureOffset, precipitationOffset, landCoverage } = getClimateParams(data);
+    const { temperatureOffset, precipitationOffset, landCoverage, axialTilt, rotationRate, greenhouse, winterSeverity, orographicRain, maritimeInfluence, mountainChill } = getClimateParams(data);
 
     try {
         const tTotal0 = performance.now();
@@ -501,24 +521,27 @@ function handleReapply(data) {
         let tWind = 0, tOcean = 0, tPrecip = 0, tTemp = 0;
 
         if (!skipClimate) {
+            const seasonFactor = seasonFactorFromTilt(axialTilt);
+            const userClimate = { greenhouse, winterSeverity, maritimeInfluence, mountainChill, orographicRain, rotationRate, seasonFactor };
+
             progress(60, 'Simulating wind patterns\u2026');
             t0 = performance.now();
-            windResult = computeWind(W.mesh, W.r_xyz, r_elevation, W.plateIsOcean, W.r_plate, W.noise);
+            windResult = computeWind(W.mesh, W.r_xyz, r_elevation, W.plateIsOcean, W.r_plate, W.noise, axialTilt, rotationRate);
             tWind = performance.now() - t0;
 
             progress(75, 'Computing ocean currents\u2026');
             t0 = performance.now();
-            oceanResult = computeOceanCurrents(W.mesh, W.r_xyz, r_elevation, windResult);
+            oceanResult = computeOceanCurrents(W.mesh, W.r_xyz, r_elevation, windResult, userClimate);
             tOcean = performance.now() - t0;
 
             progress(80, 'Computing precipitation\u2026');
             t0 = performance.now();
-            precipResult = computePrecipitation(W.mesh, W.r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage);
+            precipResult = computePrecipitation(W.mesh, W.r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage, userClimate);
             tPrecip = performance.now() - t0;
 
             progress(85, 'Computing temperature\u2026');
             t0 = performance.now();
-            tempResult = computeTemperature(W.mesh, W.r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset);
+            tempResult = computeTemperature(W.mesh, W.r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset, userClimate);
             tTemp = performance.now() - t0;
 
             W.cachedWind = windResult;
@@ -579,7 +602,7 @@ function handleEditRecompute(data) {
     if (!W) { self.postMessage({ type: 'error', message: 'No retained state for editRecompute' }); return; }
 
     const skipClimate = !!data.skipClimate;
-    const { temperatureOffset, precipitationOffset, landCoverage } = getClimateParams(data);
+    const { temperatureOffset, precipitationOffset, landCoverage, axialTilt, rotationRate, greenhouse, winterSeverity, orographicRain, maritimeInfluence, mountainChill } = getClimateParams(data);
 
     try {
         const tTotal0 = performance.now();
@@ -625,9 +648,12 @@ function handleEditRecompute(data) {
         let tWind = 0, tOcean = 0, tPrecip = 0, tTemp = 0;
 
         if (!skipClimate) {
+            const seasonFactor = seasonFactorFromTilt(axialTilt);
+            const userClimate = { greenhouse, winterSeverity, maritimeInfluence, mountainChill, orographicRain, rotationRate, seasonFactor };
+
             progress(65, 'Simulating wind patterns\u2026');
             t0 = performance.now();
-            windResult = computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, W.noise);
+            windResult = computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, W.noise, axialTilt, rotationRate);
             tWind = performance.now() - t0;
             debugLayers.pressureSummer = windResult.r_pressure_summer;
             debugLayers.pressureWinter = windResult.r_pressure_winter;
@@ -637,12 +663,12 @@ function handleEditRecompute(data) {
 
             progress(78, 'Computing ocean currents\u2026');
             t0 = performance.now();
-            oceanResult = computeOceanCurrents(mesh, r_xyz, r_elevation, windResult);
+            oceanResult = computeOceanCurrents(mesh, r_xyz, r_elevation, windResult, userClimate);
             tOcean = performance.now() - t0;
 
             progress(82, 'Computing precipitation\u2026');
             t0 = performance.now();
-            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage);
+            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage, userClimate);
             tPrecip = performance.now() - t0;
             debugLayers.precipSummer = precipResult.r_precip_summer;
             debugLayers.precipWinter = precipResult.r_precip_winter;
@@ -651,7 +677,7 @@ function handleEditRecompute(data) {
 
             progress(86, 'Computing temperature\u2026');
             t0 = performance.now();
-            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset);
+            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset, userClimate);
             tTemp = performance.now() - t0;
             debugLayers.tempSummer = tempResult.r_temperature_summer;
             debugLayers.tempWinter = tempResult.r_temperature_winter;
@@ -721,11 +747,14 @@ function handleEditRecompute(data) {
 function handleComputeClimate(data) {
     if (!W) { self.postMessage({ type: 'error', message: 'No retained state for computeClimate' }); return; }
 
-    const { temperatureOffset, precipitationOffset, landCoverage } = getClimateParams(data);
+    const { temperatureOffset, precipitationOffset, landCoverage, axialTilt, rotationRate, greenhouse, winterSeverity, orographicRain, maritimeInfluence, mountainChill } = getClimateParams(data);
 
     try {
         const tTotal0 = performance.now();
         const { mesh, r_xyz, r_elevation_final, plateIsOcean, r_plate, noise } = W;
+
+        const seasonFactor = seasonFactorFromTilt(axialTilt);
+        const userClimate = { greenhouse, winterSeverity, maritimeInfluence, mountainChill, orographicRain, rotationRate, seasonFactor };
 
         let windResult = W.cachedWind;
         let oceanResult = W.cachedOcean;
@@ -735,12 +764,12 @@ function handleComputeClimate(data) {
         if (!windResult) {
             progress(0, 'Simulating wind patterns\u2026');
             t0 = performance.now();
-            windResult = computeWind(mesh, r_xyz, r_elevation_final, plateIsOcean, r_plate, noise);
+            windResult = computeWind(mesh, r_xyz, r_elevation_final, plateIsOcean, r_plate, noise, axialTilt, rotationRate);
             tWind = performance.now() - t0;
 
             progress(30, 'Computing ocean currents\u2026');
             t0 = performance.now();
-            oceanResult = computeOceanCurrents(mesh, r_xyz, r_elevation_final, windResult);
+            oceanResult = computeOceanCurrents(mesh, r_xyz, r_elevation_final, windResult, userClimate);
             tOcean = performance.now() - t0;
 
             W.cachedWind = windResult;
@@ -749,12 +778,12 @@ function handleComputeClimate(data) {
 
         progress(50, 'Computing precipitation\u2026');
         t0 = performance.now();
-        const precipResult = computePrecipitation(mesh, r_xyz, r_elevation_final, windResult, oceanResult, precipitationOffset, landCoverage);
+        const precipResult = computePrecipitation(mesh, r_xyz, r_elevation_final, windResult, oceanResult, precipitationOffset, landCoverage, userClimate);
         const tPrecip = performance.now() - t0;
 
         progress(70, 'Computing temperature\u2026');
         t0 = performance.now();
-        const tempResult = computeTemperature(mesh, r_xyz, r_elevation_final, windResult, oceanResult, precipResult, temperatureOffset);
+        const tempResult = computeTemperature(mesh, r_xyz, r_elevation_final, windResult, oceanResult, precipResult, temperatureOffset, userClimate);
         const tTemp = performance.now() - t0;
 
         progress(88, 'Classifying climates\u2026');
@@ -911,7 +940,7 @@ function deriveSyntheticPlates(mesh, r_elevation) {
 }
 
 function handleImportHeightmap(data) {
-    const { N, jitter, grayscale, imageWidth, imageHeight, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, terrainWarp, temperatureOffset = 0, precipitationOffset = 0, landCoverage = 0.3, seed: overrideSeed, skipClimate } = data;
+    const { N, jitter, grayscale, imageWidth, imageHeight, smoothing, hydraulicErosion, thermalErosion, ridgeSharpening, glacialErosion, terrainWarp, temperatureOffset = 0, precipitationOffset = 0, landCoverage = 0.3, axialTilt = 23.5, rotationRate = 1, greenhouse = 0, winterSeverity = 1, orographicRain = 1, maritimeInfluence = 1, mountainChill = 1, seed: overrideSeed, skipClimate } = data;
     const timing = [];
 
     try {
@@ -980,10 +1009,12 @@ function handleImportHeightmap(data) {
 
         if (!skipClimate) {
             const noise = new SimplexNoise(seed);
+            const seasonFactor = seasonFactorFromTilt(axialTilt);
+            const userClimate = { greenhouse, winterSeverity, maritimeInfluence, mountainChill, orographicRain, rotationRate, seasonFactor };
 
             progress(60, 'Simulating wind patterns\u2026');
             t0 = performance.now();
-            windResult = computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noise);
+            windResult = computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noise, axialTilt, rotationRate);
             timing.push({ stage: 'Wind simulation', ms: performance.now() - t0 });
             debugLayers.pressureSummer = windResult.r_pressure_summer;
             debugLayers.pressureWinter = windResult.r_pressure_winter;
@@ -993,12 +1024,12 @@ function handleImportHeightmap(data) {
 
             progress(72, 'Computing ocean currents\u2026');
             t0 = performance.now();
-            oceanResult = computeOceanCurrents(mesh, r_xyz, r_elevation, windResult);
+            oceanResult = computeOceanCurrents(mesh, r_xyz, r_elevation, windResult, userClimate);
             timing.push({ stage: 'Ocean currents', ms: performance.now() - t0 });
 
             progress(80, 'Computing precipitation\u2026');
             t0 = performance.now();
-            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage);
+            precipResult = computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset, landCoverage, userClimate);
             timing.push({ stage: 'Precipitation', ms: performance.now() - t0 });
             debugLayers.precipSummer = precipResult.r_precip_summer;
             debugLayers.precipWinter = precipResult.r_precip_winter;
@@ -1007,7 +1038,7 @@ function handleImportHeightmap(data) {
 
             progress(88, 'Computing temperature\u2026');
             t0 = performance.now();
-            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset);
+            tempResult = computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset, userClimate);
             timing.push({ stage: 'Temperature', ms: performance.now() - t0 });
             debugLayers.tempSummer = tempResult.r_temperature_summer;
             debugLayers.tempWinter = tempResult.r_temperature_winter;
@@ -1036,6 +1067,7 @@ function handleImportHeightmap(data) {
             seed, nMag, noise: new SimplexNoise(seed),
             mountain_r: new Set(mountain_r), coastline_r: new Set(coastline_r), ocean_r: new Set(ocean_r),
             r_stress: new Float32Array(r_stress),
+            axialTilt, rotationRate, greenhouse, winterSeverity, orographicRain, maritimeInfluence, mountainChill,
             cachedWind: windResult, cachedOcean: oceanResult
         };
         timing.push({ stage: 'Clone state for retention', ms: performance.now() - t0 });

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -194,7 +194,8 @@ function advectMoisture(mesh, r_xyz, r_heightKm, r_isLand,
  * @param {object} oceanResult - output from computeOceanCurrents()
  * @returns {{ r_precip_summer, r_precip_winter }} normalized 0–1 arrays
  */
-export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset = 0, landCoverage = 0.3) {
+export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, oceanResult, precipitationOffset = 0, landCoverage = 0.3, userClimate = {}) {
+    const { orographicRain = 1, seasonFactor = 1 } = userClimate;
     console.log('[precipitation.js] computePrecipitation called, numRegions:', mesh.numRegions);
     const numRegions = mesh.numRegions;
     const timing = [];

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -253,6 +253,10 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
         effSubtropCenterWinter = mid + (effSubtropCenterWinter - mid) * seasonFactor;
     }
 
+    const effOroUpliftAdd = CLIMATE.PRECIP_ORO_UPLIFT_ADD * orographicRain;
+    const effRsStrengthScale = CLIMATE.PRECIP_RS_APPLY_STRENGTH_SCALE * orographicRain;
+    const effRsWindwardAdd = CLIMATE.PRECIP_RS_APPLY_WINDWARD_ADD * orographicRain;
+
     const seasons = [
         { name: 'summer', shift: 5 },
         { name: 'winter', shift: -5 }
@@ -370,7 +374,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
                     // the wind is pushing up, the more rain wrung out.
                     // gradient strength matters more than absolute height.
                     const uplift = Math.min(1, windDotGrad * 15);
-                    p += uplift * CLIMATE.PRECIP_ORO_UPLIFT_ADD;
+                    p += uplift * effOroUpliftAdd;
                 } else {
                     // Leeward: rain shadow. The advection step already depleted
                     // moisture crossing the ridge; this is the *extra* suppression
@@ -664,11 +668,11 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
             const rs = rainShadow[r];
             if (rs < -0.01) {
                 // Shadow zone: precipitation suppression behind mountains
-                const strength = Math.min(1, -rs * CLIMATE.PRECIP_RS_APPLY_STRENGTH_SCALE);
+                const strength = Math.min(1, -rs * effRsStrengthScale);
                 precip[r] *= Math.max(0.02, 1 - strength * CLIMATE.PRECIP_RS_APPLY_MAX_SUPPRESS);
             } else if (rs > 0.01) {
                 // Windward zone: strong orographic precipitation enhancement
-                precip[r] += rs * CLIMATE.PRECIP_RS_APPLY_WINDWARD_ADD;
+                precip[r] += rs * effRsWindwardAdd;
             }
         }
 

--- a/js/precipitation.js
+++ b/js/precipitation.js
@@ -243,6 +243,16 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
 
     const result = {};
 
+    let effSubtropCenterSummer = CLIMATE.PRECIP_SUBTROP_CENTER_SUMMER_DEG;
+    let effSubtropCenterWinter = CLIMATE.PRECIP_SUBTROP_CENTER_WINTER_DEG;
+    if (seasonFactor !== 1) {
+        // The summer/winter center split IS the seasonal migration; scale
+        // the split about its midpoint so 0 tilt collapses both to one band.
+        const mid = (effSubtropCenterSummer + effSubtropCenterWinter) / 2;
+        effSubtropCenterSummer = mid + (effSubtropCenterSummer - mid) * seasonFactor;
+        effSubtropCenterWinter = mid + (effSubtropCenterWinter - mid) * seasonFactor;
+    }
+
     const seasons = [
         { name: 'summer', shift: 5 },
         { name: 'winter', shift: -5 }
@@ -380,7 +390,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
             // poleward in local summer (creating Mediterranean dry summers)
             // and retreats equatorward in local winter (allowing westerly rain).
             const inLocalSummer = (name === 'summer') ? (lat >= 0) : (lat < 0);
-            const subtropCenter = inLocalSummer ? CLIMATE.PRECIP_SUBTROP_CENTER_SUMMER_DEG : CLIMATE.PRECIP_SUBTROP_CENTER_WINTER_DEG;
+            const subtropCenter = inLocalSummer ? effSubtropCenterSummer : effSubtropCenterWinter;
             const subtropWidth  = inLocalSummer ? CLIMATE.PRECIP_SUBTROP_WIDTH_SUMMER_DEG : CLIMATE.PRECIP_SUBTROP_WIDTH_WINTER_DEG;
             let   subtropPeak   = inLocalSummer ? CLIMATE.PRECIP_SUBTROP_PEAK_SUMMER : CLIMATE.PRECIP_SUBTROP_PEAK_WINTER;
 
@@ -708,7 +718,7 @@ export function computePrecipitation(mesh, r_xyz, r_elevation, windResult, ocean
 
     // ── Step 4: Blend with heuristic model and normalize ──
     t0 = performance.now();
-    const heuristic = computeHeuristicPrecipitation(mesh, r_xyz, r_elevation, windResult, r_elevGradE, r_elevGradN, r_coastDistLand);
+    const heuristic = computeHeuristicPrecipitation(mesh, r_xyz, r_elevation, windResult, r_elevGradE, r_elevGradN, r_coastDistLand, seasonFactor);
 
     for (const seasonName of ['summer', 'winter']) {
         const complex = result[`r_precip_${seasonName}`];

--- a/js/temperature.js
+++ b/js/temperature.js
@@ -797,6 +797,9 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);
     const oceanWarmthPasses = Math.max(4, Math.round(CLIMATE.TEMP_OCEAN_WARMTH_DIFFUSE_KM / avgEdgeKm));
     const plateCont = r_plateContinentality || r_continentality;
+    // Winter interior cooling is a seasonal-contrast effect: it must vanish on
+    // a seasonless (0-tilt) world along with the swing itself.
+    const effContWinterCool = CLIMATE.TEMP_CONT_WINTER_COOL_C * seasonFactor;
 
     // Compute zone-based temperature continentality (Stages A-E)
     const tCont0 = performance.now();
@@ -859,7 +862,7 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
             const T_itcz = CLIMATE.TEMP_PEAK_C - CLIMATE.TEMP_POLEWARD_RANGE_C * Math.pow(tItcz, CLIMATE.TEMP_POLEWARD_EXP);
 
             // Flat reference curve (ITCZ at 5° in summer hemisphere)
-            const flatItczLat = (name === 'summer' ? 5 : -5) * DEG;
+            const flatItczLat = (name === 'summer' ? 5 : -5) * DEG * seasonFactor;
             const distFlat = Math.abs(lat - flatItczLat) / DEG;
             const tFlat = Math.max(0, distFlat - tropicalHW) / maxDist;
             const T_flat = CLIMATE.TEMP_PEAK_C - CLIMATE.TEMP_POLEWARD_RANGE_C * Math.pow(tFlat, CLIMATE.TEMP_POLEWARD_EXP);
@@ -925,7 +928,7 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
                 const distAnn = Math.abs(lat) / DEG;
 
                 const tc = isLand ? r_tempCont[r] : 0;
-                const tableAmplitude = lookupSwingAmplitude(distAnn, tc);
+                const tableAmplitude = lookupSwingAmplitude(distAnn, tc) * seasonFactor;
 
                 // Estimate ITCZ seasonal contribution
                 const sumItczLat = itczLookupSummer(lon);
@@ -967,7 +970,7 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
                     const westRelief = r_westness
                         ? 1 - Math.max(0, r_westness[r]) * CLIMATE.TEMP_WINTER_COOL_WEST_RELIEF
                         : 1;
-                    T -= cont * CLIMATE.TEMP_CONT_WINTER_COOL_C * westRelief;
+                    T -= cont * effContWinterCool * westRelief;
                 }
 
                 // Oceanic warming offset: ocean thermal inertia keeps oceanic

--- a/js/temperature.js
+++ b/js/temperature.js
@@ -800,6 +800,11 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
     // Winter interior cooling is a seasonal-contrast effect: it must vanish on
     // a seasonless (0-tilt) world along with the swing itself.
     const effContWinterCool = CLIMATE.TEMP_CONT_WINTER_COOL_C * seasonFactor;
+    // Greenhouse: thicker atmosphere warms uniformly, flattens the equator→pole
+    // gradient (polar amplification), and softens winters slightly.
+    const effPolewardRange = CLIMATE.TEMP_POLEWARD_RANGE_C * (1 - CLIMATE.TEMP_GH_GRADIENT_FRAC * greenhouse);
+    const ghUniformC = CLIMATE.TEMP_GH_UNIFORM_C * greenhouse;
+    const effWinterShare = CLIMATE.TEMP_SWING_WINTER_SHARE * (1 - CLIMATE.TEMP_GH_WINTER_LIFT * Math.max(0, greenhouse));
 
     // Compute zone-based temperature continentality (Stages A-E)
     const tCont0 = performance.now();
@@ -859,13 +864,13 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
             const itczLat = itczLookup(lon);
             const distItcz = Math.abs(lat - itczLat) / DEG;
             const tItcz = Math.max(0, distItcz - tropicalHW) / maxDist;
-            const T_itcz = CLIMATE.TEMP_PEAK_C - CLIMATE.TEMP_POLEWARD_RANGE_C * Math.pow(tItcz, CLIMATE.TEMP_POLEWARD_EXP);
+            const T_itcz = CLIMATE.TEMP_PEAK_C - effPolewardRange * Math.pow(tItcz, CLIMATE.TEMP_POLEWARD_EXP);
 
             // Flat reference curve (ITCZ at 5° in summer hemisphere)
             const flatItczLat = (name === 'summer' ? 5 : -5) * DEG * seasonFactor;
             const distFlat = Math.abs(lat - flatItczLat) / DEG;
             const tFlat = Math.max(0, distFlat - tropicalHW) / maxDist;
-            const T_flat = CLIMATE.TEMP_PEAK_C - CLIMATE.TEMP_POLEWARD_RANGE_C * Math.pow(tFlat, CLIMATE.TEMP_POLEWARD_EXP);
+            const T_flat = CLIMATE.TEMP_PEAK_C - effPolewardRange * Math.pow(tFlat, CLIMATE.TEMP_POLEWARD_EXP);
 
             // Blend: ITCZ curve dominates tropics, flat curve dominates poles
             const absLatDeg = Math.abs(lat) / DEG;
@@ -937,8 +942,8 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
                 const distWinter = Math.abs(lat - winItczLat) / DEG;
                 const tS = Math.max(0, distSummer - tropicalHW) / maxDist;
                 const tW = Math.max(0, distWinter - tropicalHW) / maxDist;
-                const T_summer = CLIMATE.TEMP_PEAK_C - CLIMATE.TEMP_POLEWARD_RANGE_C * Math.pow(tS, CLIMATE.TEMP_POLEWARD_EXP);
-                const T_winter = CLIMATE.TEMP_PEAK_C - CLIMATE.TEMP_POLEWARD_RANGE_C * Math.pow(tW, CLIMATE.TEMP_POLEWARD_EXP);
+                const T_summer = CLIMATE.TEMP_PEAK_C - effPolewardRange * Math.pow(tS, CLIMATE.TEMP_POLEWARD_EXP);
+                const T_winter = CLIMATE.TEMP_PEAK_C - effPolewardRange * Math.pow(tW, CLIMATE.TEMP_POLEWARD_EXP);
                 const itczAmplitude = Math.abs(T_summer - T_winter) / 2;
 
                 const extraAmplitude = Math.max(0, tableAmplitude - itczAmplitude) * CLIMATE.TEMP_EXTRA_SWING_FACTOR;
@@ -948,7 +953,7 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
                 // the annual mean than summers rise above it (radiative cooling
                 // under winter highs). TEMP_SWING_WINTER_SHARE = 0.5 → symmetric;
                 // 0.6 → winter gets 60% of the total extra swing.
-                const wShare = CLIMATE.TEMP_SWING_WINTER_SHARE;
+                const wShare = effWinterShare;
                 T += isLocalSummer
                     ? extraAmplitude * 2 * (1 - wShare)
                     : -extraAmplitude * 2 * wShare;
@@ -984,7 +989,7 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
                 }
             }
 
-            T += temperatureOffset;
+            T += temperatureOffset + ghUniformC;
             temp[r] = T;
         }
 

--- a/js/temperature.js
+++ b/js/temperature.js
@@ -777,7 +777,8 @@ function diffuseOceanWarmth(mesh, r_oceanWarmth, r_isLand, r_plateContinentality
  * @param {object} precipResult - output from computePrecipitation()
  * @returns {{ r_temperature_summer, r_temperature_winter, _tempTiming }}
  */
-export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset = 0) {
+export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanResult, precipResult, temperatureOffset = 0, userClimate = {}) {
+    const { greenhouse = 0, winterSeverity = 1, maritimeInfluence = 1, mountainChill = 1, seasonFactor = 1 } = userClimate;
     const numRegions = mesh.numRegions;
     const timing = [];
 

--- a/js/temperature.js
+++ b/js/temperature.js
@@ -795,11 +795,14 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
 
     // Pre-compute constants shared across seasons
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);
-    const oceanWarmthPasses = Math.max(4, Math.round(CLIMATE.TEMP_OCEAN_WARMTH_DIFFUSE_KM / avgEdgeKm));
+    const oceanWarmthPasses = Math.max(4, Math.round(CLIMATE.TEMP_OCEAN_WARMTH_DIFFUSE_KM * maritimeInfluence / avgEdgeKm));
     const plateCont = r_plateContinentality || r_continentality;
     // Winter interior cooling is a seasonal-contrast effect: it must vanish on
     // a seasonless (0-tilt) world along with the swing itself.
-    const effContWinterCool = CLIMATE.TEMP_CONT_WINTER_COOL_C * seasonFactor;
+    const effContWinterCool = CLIMATE.TEMP_CONT_WINTER_COOL_C * winterSeverity * seasonFactor;
+    const effCoastalShiftC = CLIMATE.TEMP_COASTAL_WARMTH_SHIFT_C * maritimeInfluence;
+    const effMoistLapse = CLIMATE.TEMP_MOIST_LAPSE_C_PER_KM * mountainChill;
+    const effDryLapseExtra = CLIMATE.TEMP_DRY_LAPSE_EXTRA_C_PER_KM * mountainChill;
     // Greenhouse: thicker atmosphere warms uniformly, flattens the equator→pole
     // gradient (polar amplification), and softens winters slightly.
     const effPolewardRange = CLIMATE.TEMP_POLEWARD_RANGE_C * (1 - CLIMATE.TEMP_GH_GRADIENT_FRAC * greenhouse);
@@ -882,7 +885,7 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
             // saturated air at ~5 C/km (moist adiabatic) due to latent heat
             // release. Use precipitation as a moisture proxy to interpolate.
             const moisture = r_precip ? r_precip[r] : 0.5;
-            const lapse = CLIMATE.TEMP_MOIST_LAPSE_C_PER_KM + CLIMATE.TEMP_DRY_LAPSE_EXTRA_C_PER_KM * (1 - moisture); // 4.5 C/km (wet) to 9.3 C/km (dry)
+            const lapse = effMoistLapse + effDryLapseExtra * (1 - moisture); // 4.5 C/km (wet) to 9.3 C/km (dry)
             if (isLand && elev > 0) {
                 T -= lapse * elevToHeightKm(elev);
             }
@@ -899,7 +902,7 @@ export function computeTemperature(mesh, r_xyz, r_elevation, windResult, oceanRe
                 // crosses continental shelves naturally
                 const cw = coastalWarmth[r];
                 if (Math.abs(cw) > 0.001) {
-                    T += cw * (1 - smoothstep(0, 0.95, pCont)) * CLIMATE.TEMP_COASTAL_WARMTH_SHIFT_C;
+                    T += cw * (1 - smoothstep(0, 0.95, pCont)) * effCoastalShiftC;
                 }
             }
 

--- a/js/wind.js
+++ b/js/wind.js
@@ -538,9 +538,10 @@ function pressureToWind(r_gradE, r_gradN, r_sinLat,
  * @param {Int32Array} r_plate - per-region plate ID
  * @param {SimplexNoise} noise - seeded noise instance
  * @param {number} [axialTilt=23.5] - axial tilt in degrees
+ * @param {number} [rotationRate=1] - rotation rate multiplier (unused here; consumed by ocean.js)
  * @returns {object} pressure and wind arrays for both seasons
  */
-export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noise, axialTilt = 23.5) {
+export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noise, axialTilt = 23.5, rotationRate = 1) {
     const numRegions = mesh.numRegions;
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);
     const tiltRad = axialTilt * DEG;

--- a/js/wind.js
+++ b/js/wind.js
@@ -553,13 +553,20 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
     // Seasonal-contrast quantities scale with tilt (×1 at Earth tilt, 0 at 0°):
     // band migration, monsoon thermal low, and the winter continental high are
     // all consequences of the seasonal insolation swing.
+    // Fast rotators: stronger Coriolis turning and equator-compressed bands
+    // (Hadley width shrinks with spin); slow rotators widen the tropical cell.
+    // Math.pow(1, x) === 1, so ρ = 1 is exact without a guard; the deflection
+    // map subtracts, so it does need one.
+    const bandScale = Math.pow(rotationRate, -1 / 3);
     const effWind = {
         subtropShiftDeg: CLIMATE.WIND_SUBTROP_SEASONAL_SHIFT_DEG * seasonFactor,
         thermalLowHpa: CLIMATE.WIND_SUMMER_THERMAL_LOW_HPA * seasonFactor,
         thermalHighHpa: CLIMATE.WIND_WINTER_THERMAL_HIGH_HPA * seasonFactor,
-        subtropHighLatDeg: CLIMATE.WIND_SUBTROP_HIGH_LAT_DEG,
-        subpolarLowLatDeg: CLIMATE.WIND_SUBPOLAR_LOW_LAT_DEG,
-        geoMaxAngleDeg: CLIMATE.WIND_GEOSTROPHIC_MAX_ANGLE_DEG,
+        subtropHighLatDeg: Math.min(42, Math.max(22, CLIMATE.WIND_SUBTROP_HIGH_LAT_DEG * bandScale)),
+        subpolarLowLatDeg: Math.min(72, Math.max(44, CLIMATE.WIND_SUBPOLAR_LOW_LAT_DEG * bandScale)),
+        geoMaxAngleDeg: rotationRate === 1
+            ? CLIMATE.WIND_GEOSTROPHIC_MAX_ANGLE_DEG
+            : 90 - (90 - CLIMATE.WIND_GEOSTROPHIC_MAX_ANGLE_DEG) * Math.pow(rotationRate, -0.8),
     };
     const timing = [];
 

--- a/js/wind.js
+++ b/js/wind.js
@@ -3,7 +3,7 @@
 
 import { CLIMATE } from './climate-config.js';
 import { elevToHeightKm } from './color-map.js';
-import { smoothField, percentile } from './climate-util.js';
+import { smoothField, percentile, seasonFactorFromTilt } from './climate-util.js';
 
 const DEG = Math.PI / 180;
 const RAD = 180 / Math.PI;
@@ -228,9 +228,10 @@ function buildGeoIndex(r_lat, r_lon, r_sinLat, r_cosLat, r_elevation, r_isLand, 
  * @param {Object} geoIndex - from buildGeoIndex ({sample, sampleDual, _outLocal, _outWide})
  * @param {string} season - 'summer' (NH) or 'winter' (NH)
  * @param {number} tiltRad - axial tilt in radians
+ * @param {number} [seasonFactor=1] - seasonal-contrast scale from axial tilt (1 at Earth tilt)
  * @returns {{ spline, lons: Float64Array, lats: Float64Array }}
  */
-function computeITCZ(geoIndex, season, tiltRad) {
+function computeITCZ(geoIndex, season, tiltRad, seasonFactor = 1) {
     const { sample: geoSample, sampleDual, _outLocal, _outWide } = geoIndex;
     const NUM_LON = 72;
     // Two sampling radii: local (5°) for precise land detection, wide (30°) for continental scale
@@ -244,9 +245,12 @@ function computeITCZ(geoIndex, season, tiltRad) {
     // Full tilt in summer hemisphere (e.g. +23.5° for NH summer)
     const subsolarLat = sign * tiltRad;
 
-    // Scan range: -30° to +30° in 2.5° steps
-    const SCAN_MIN = -30;
-    const SCAN_MAX = 30;
+    // Excursion clamp scales with tilt: pinned at 0°, roams wide at 45°.
+    const effClampDeg = CLIMATE.WIND_ITCZ_CLAMP_DEG * seasonFactor;
+    // Scan must cover the clamp; ±30 (the Earth-tuned range) until the clamp
+    // itself needs more.
+    const SCAN_MAX = Math.max(30, effClampDeg + 5);
+    const SCAN_MIN = -SCAN_MAX;
     const SCAN_STEP = 2.5;
     const numScans = Math.round((SCAN_MAX - SCAN_MIN) / SCAN_STEP) + 1;
 
@@ -371,9 +375,9 @@ function computeITCZ(geoIndex, season, tiltRad) {
         lats.set(tmp);
     }
 
-    // Clamp to ±30° (ITCZ never migrates beyond the tropics)
+    // Clamp ITCZ migration (scaled by tilt; ±~20° at Earth tilt)
     for (let i = 0; i < NUM_LON; i++) {
-        lats[i] = Math.max(-CLIMATE.WIND_ITCZ_CLAMP_DEG * DEG, Math.min(CLIMATE.WIND_ITCZ_CLAMP_DEG * DEG, lats[i]));
+        lats[i] = Math.max(-effClampDeg * DEG, Math.min(effClampDeg * DEG, lats[i]));
     }
 
     const spline = buildPeriodicSpline(lons, lats);
@@ -385,7 +389,7 @@ function computeITCZ(geoIndex, season, tiltRad) {
 /**
  * Compute pressure at a single region.
  */
-function regionPressure(lat, lon, itczSpline, season, landFrac, elevation, noiseFn, px, py, pz) {
+function regionPressure(lat, lon, itczSpline, season, landFrac, elevation, noiseFn, px, py, pz, eff) {
     const itczLat = evaluateSpline(itczSpline, lon);
     const latDeg = lat * RAD;
     const seasonSign = season === 'summer' ? 1 : -1;
@@ -397,16 +401,16 @@ function regionPressure(lat, lon, itczSpline, season, landFrac, elevation, noise
     p -= CLIMATE.WIND_ITCZ_LOW_DEPTH_HPA * Math.exp(-0.5 * (dItcz / CLIMATE.WIND_ITCZ_LOW_WIDTH_DEG) ** 2);
 
     // (b) Subtropical highs — shift with season, weaker over hot land
-    const shiftDeg = seasonSign * CLIMATE.WIND_SUBTROP_SEASONAL_SHIFT_DEG;
-    const nhSubHigh = CLIMATE.WIND_SUBTROP_HIGH_LAT_DEG + shiftDeg;
-    const shSubHigh = -(CLIMATE.WIND_SUBTROP_HIGH_LAT_DEG - shiftDeg);
+    const shiftDeg = seasonSign * eff.subtropShiftDeg;
+    const nhSubHigh = eff.subtropHighLatDeg + shiftDeg;
+    const shSubHigh = -(eff.subtropHighLatDeg - shiftDeg);
     const highIntensity = CLIMATE.WIND_SUBTROP_HIGH_STRENGTH_HPA * (1 - CLIMATE.WIND_SUBTROP_LAND_WEAKENING * landFrac);
     p += highIntensity * Math.exp(-0.5 * ((latDeg - nhSubHigh) / CLIMATE.WIND_SUBTROP_HIGH_WIDTH_DEG) ** 2);
     p += highIntensity * Math.exp(-0.5 * ((latDeg - shSubHigh) / CLIMATE.WIND_SUBTROP_HIGH_WIDTH_DEG) ** 2);
 
     // (c) Subpolar lows
-    p -= CLIMATE.WIND_SUBPOLAR_LOW_DEPTH_HPA * Math.exp(-0.5 * ((latDeg - CLIMATE.WIND_SUBPOLAR_LOW_LAT_DEG) / CLIMATE.WIND_SUBPOLAR_LOW_WIDTH_DEG) ** 2);
-    p -= CLIMATE.WIND_SUBPOLAR_LOW_DEPTH_HPA * Math.exp(-0.5 * ((latDeg + CLIMATE.WIND_SUBPOLAR_LOW_LAT_DEG) / CLIMATE.WIND_SUBPOLAR_LOW_WIDTH_DEG) ** 2);
+    p -= CLIMATE.WIND_SUBPOLAR_LOW_DEPTH_HPA * Math.exp(-0.5 * ((latDeg - eff.subpolarLowLatDeg) / CLIMATE.WIND_SUBPOLAR_LOW_WIDTH_DEG) ** 2);
+    p -= CLIMATE.WIND_SUBPOLAR_LOW_DEPTH_HPA * Math.exp(-0.5 * ((latDeg + eff.subpolarLowLatDeg) / CLIMATE.WIND_SUBPOLAR_LOW_WIDTH_DEG) ** 2);
 
     // (d) Polar highs
     p += CLIMATE.WIND_POLAR_HIGH_STRENGTH_HPA * Math.exp(-0.5 * ((latDeg - 85) / 8) ** 2);
@@ -430,10 +434,10 @@ function regionPressure(lat, lon, itczSpline, season, landFrac, elevation, noise
         const isSummerHemisphere = (seasonSign > 0 && lat > 0) || (seasonSign < 0 && lat < 0);
         if (isSummerHemisphere) {
             // Thermal low over hot continent
-            p -= CLIMATE.WIND_SUMMER_THERMAL_LOW_HPA * latFactor * continentalScale;
+            p -= eff.thermalLowHpa * latFactor * continentalScale;
         } else {
             // Thermal high over cold continent (stronger — Siberian/Canadian highs)
-            p += CLIMATE.WIND_WINTER_THERMAL_HIGH_HPA * latFactor * continentalScale;
+            p += eff.thermalHighHpa * latFactor * continentalScale;
         }
     }
 
@@ -490,7 +494,7 @@ export function computeGradients(mesh, r_xyz, r_pressure,
 // ── Pressure gradient → wind ─────────────────────────────────────────────────
 
 function pressureToWind(r_gradE, r_gradN, r_sinLat,
-    r_windE, r_windN, r_windSpeed, numRegions) {
+    r_windE, r_windN, r_windSpeed, numRegions, geoMaxAngleDeg) {
     const sin5 = Math.sin(5 * DEG);
 
     for (let r = 0; r < numRegions; r++) {
@@ -502,7 +506,7 @@ function pressureToWind(r_gradE, r_gradN, r_sinLat,
         const absSinLat = Math.abs(sinLat);
 
         // Geostrophic deflection: 0° at equator → 70° at ≥5° latitude
-        const geoAngle = CLIMATE.WIND_GEOSTROPHIC_MAX_ANGLE_DEG * DEG * smoothstep(0, sin5, absSinLat);
+        const geoAngle = geoMaxAngleDeg * DEG * smoothstep(0, sin5, absSinLat);
 
         // Surface friction turns wind 20° back toward low pressure
         const frictionAngle = CLIMATE.WIND_FRICTION_BACK_ANGLE_DEG * DEG;
@@ -545,6 +549,18 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
     const numRegions = mesh.numRegions;
     const avgEdgeKm = (Math.PI * 6371) / Math.sqrt(numRegions);
     const tiltRad = axialTilt * DEG;
+    const seasonFactor = seasonFactorFromTilt(axialTilt);
+    // Seasonal-contrast quantities scale with tilt (×1 at Earth tilt, 0 at 0°):
+    // band migration, monsoon thermal low, and the winter continental high are
+    // all consequences of the seasonal insolation swing.
+    const effWind = {
+        subtropShiftDeg: CLIMATE.WIND_SUBTROP_SEASONAL_SHIFT_DEG * seasonFactor,
+        thermalLowHpa: CLIMATE.WIND_SUMMER_THERMAL_LOW_HPA * seasonFactor,
+        thermalHighHpa: CLIMATE.WIND_WINTER_THERMAL_HIGH_HPA * seasonFactor,
+        subtropHighLatDeg: CLIMATE.WIND_SUBTROP_HIGH_LAT_DEG,
+        subpolarLowLatDeg: CLIMATE.WIND_SUBPOLAR_LOW_LAT_DEG,
+        geoMaxAngleDeg: CLIMATE.WIND_GEOSTROPHIC_MAX_ANGLE_DEG,
+    };
     const timing = [];
 
     // ── Step 0: Precompute per-region properties ──
@@ -598,8 +614,8 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
 
     t0 = performance.now();
     const geoIndex = buildGeoIndex(r_lat, r_lon, r_sinLat, r_cosLat, r_elevation, r_isLand, numRegions);
-    const itczSummer = computeITCZ(geoIndex, 'summer', tiltRad);
-    const itczWinter = computeITCZ(geoIndex, 'winter', tiltRad);
+    const itczSummer = computeITCZ(geoIndex, 'summer', tiltRad, seasonFactor);
+    const itczWinter = computeITCZ(geoIndex, 'winter', tiltRad, seasonFactor);
     timing.push({ stage: 'Wind: ITCZ computation', ms: performance.now() - t0 });
 
     // ── Step 2–5: Compute pressure & wind for each season ──
@@ -817,7 +833,7 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
             r_pressure[r] = regionPressure(
                 r_lat[r], r_lon[r], itcz.spline, name,
                 r_continentality[r], r_elevation[r], noise,
-                r_xyz[3 * r], r_xyz[3 * r + 1], r_xyz[3 * r + 2]
+                r_xyz[3 * r], r_xyz[3 * r + 1], r_xyz[3 * r + 2], effWind
             );
         }
         smoothField(mesh, r_pressure, pressSmoothPasses);
@@ -838,7 +854,7 @@ export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noi
         const r_windN = new Float32Array(numRegions);
         const r_windSpeed = new Float32Array(numRegions);
         pressureToWind(r_gradE, r_gradN, r_sinLat,
-            r_windE, r_windN, r_windSpeed, numRegions);
+            r_windE, r_windN, r_windSpeed, numRegions, effWind.geoMaxAngleDeg);
 
         // Step 5: Normalize wind speed to 0-1
         const maxSpeed = percentile(r_windSpeed, 0.95);

--- a/js/wind.js
+++ b/js/wind.js
@@ -542,7 +542,7 @@ function pressureToWind(r_gradE, r_gradN, r_sinLat,
  * @param {Int32Array} r_plate - per-region plate ID
  * @param {SimplexNoise} noise - seeded noise instance
  * @param {number} [axialTilt=23.5] - axial tilt in degrees
- * @param {number} [rotationRate=1] - rotation rate multiplier (unused here; consumed by ocean.js)
+ * @param {number} [rotationRate=1] - rotation rate multiplier; scales circulation-band latitudes and geostrophic deflection here, and is also threaded to ocean.js
  * @returns {object} pressure and wind arrays for both seasons
  */
 export function computeWind(mesh, r_xyz, r_elevation, plateIsOcean, r_plate, noise, axialTilt = 23.5, rotationRate = 1) {

--- a/llms.txt
+++ b/llms.txt
@@ -10,6 +10,7 @@ World Orogen generates realistic procedural planets shaped by tectonic plate sim
 - Simulates tectonic plates with convergent, divergent, and transform boundaries
 - Applies glacial, hydraulic, and thermal erosion to carve fjords, river valleys, and talus slopes
 - Simulates seasonal climate: wind patterns, ocean currents, precipitation, and Köppen classification
+- Tunable planetary (axial tilt, rotation rate, greenhouse) and climate-character (winter severity, orographic rain, maritime influence, mountain chill) controls, recomputed on slider release
 - Creates hotspot volcanism with drift-trail island chains (like Hawaii)
 - Allows interactive editing — select multiple tectonic plates for batch reshaping with visual preview before rebuild
 - Import your own equirectangular B&W heightmaps (Earth, Mars, hand-drawn) onto a 3D globe with automatic climate simulation

--- a/styles.css
+++ b/styles.css
@@ -89,6 +89,14 @@ body { background: #000; overflow: hidden; font-family: 'Segoe UI', system-ui, s
     font-size: 11px; color: #678; line-height: 1.4;
     margin-bottom: 8px;
 }
+.cg-sub {
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    opacity: 0.55;
+    margin: 10px 0 2px;
+}
 .import-expect {
     font-size: 11px; color: #8ab; line-height: 1.5;
     background: rgba(68,136,255,0.08);

--- a/tuning/climate/param-space.mjs
+++ b/tuning/climate/param-space.mjs
@@ -50,6 +50,9 @@ export const PARAM_SPACE = {
     TEMP_OCEANIC_WARMING_MAX_C:       { min: 2,    max: 10,   high: true },
     TEMP_CLOUD_MOD_STRENGTH:          { min: 0.05, max: 0.3 },
     TEMP_CLEARSKY_AMP_STRENGTH:       { min: 0.05, max: 0.3 },
+    TEMP_GH_UNIFORM_C:                { min: 4,    max: 16 },
+    TEMP_GH_GRADIENT_FRAC:            { min: 0.1,  max: 0.5 },
+    TEMP_GH_WINTER_LIFT:              { min: 0,    max: 0.3 },
 
     // ── Precipitation (complex model) ──
     PRECIP_OCEAN_MOISTURE_BASE:       { min: 0.2,  max: 0.7 },

--- a/tuning/planet-code-check.mjs
+++ b/tuning/planet-code-check.mjs
@@ -1,0 +1,58 @@
+// Round-trip and legacy-decode checks for the SP4 planet-code format.
+//   node tuning/planet-code-check.mjs
+import { encodePlanetCode, decodePlanetCode } from '../js/planet-code.js';
+
+let failures = 0;
+function check(name, cond) {
+    if (!cond) { failures++; console.error('FAIL', name); }
+    else { console.log('ok  ', name); }
+}
+function near(a, b) { return Math.abs(a - b) < 1e-9; }
+
+// [seed, N, jitter, P, numContinents, roughness, terrainWarp, smoothing, glacial,
+//  hydraulic, thermal, ridge, soilCreep, csv, tempOff, precipOff, landCoverage,
+//  axialTilt, rotationRate, greenhouse, winterSeverity, orographicRain, maritimeInfluence, mountainChill]
+const CASES = [
+    { name: 'defaults', args: [12345, 204000, 0.75, 80, 4, 0.4, 0.75, 0.1, 0.5, 0.5, 0.5, 0.5, 0.75, 0.35, 0, 0, 0.3, 23.5, 1, 0, 1, 1, 1, 1] },
+    { name: 'minima', args: [0, 5000, 0, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, -15, -1, 0, 0, 0.5, -1, 0, 0, 0, 0] },
+    { name: 'maxima', args: [16777215, 2560000, 1, 120, 10, 0.5, 1, 1, 1, 1, 1, 1, 1, 1, 15, 1, 1, 45, 2, 1, 2, 2, 2, 2] },
+    { name: 'mixed', args: [999999, 500000, 0.5, 40, 7, 0.25, 0.5, 0.5, 0.2, 0.8, 0.3, 0.6, 0.75, 0.5, -5, 0.4, 0.55, 31.5, 1.3, -0.4, 1.7, 0.2, 1.1, 0.9] },
+];
+const FIELDS = ['seed', 'N', 'jitter', 'P', 'numContinents', 'roughness', 'terrainWarp', 'smoothing',
+    'glacialErosion', 'hydraulicErosion', 'thermalErosion', 'ridgeSharpening', 'soilCreep',
+    'continentSizeVariety', 'temperatureOffset', 'precipitationOffset', 'landCoverage',
+    'axialTilt', 'rotationRate', 'greenhouse', 'winterSeverity', 'orographicRain',
+    'maritimeInfluence', 'mountainChill'];
+
+for (const { name, args } of CASES) {
+    const code = encodePlanetCode(...args);
+    const d = decodePlanetCode(code);
+    check(`${name}: decodes`, d !== null);
+    if (!d) { continue; }
+    for (let i = 0; i < FIELDS.length; i++) {
+        check(`${name}: ${FIELDS[i]}`, near(d[FIELDS[i]], args[i]));
+    }
+    check(`${name}: base length 27`, code.split(/[-~]/)[0].length === 27);
+}
+
+// Suffixes survive the new format
+const withSuffixes = encodePlanetCode(12345, 204000, 0.75, 80, 4, 0.4, 0.75, 0.1, 0.5, 0.5, 0.5, 0.5, 0.75, 0.35, 3, -0.2, 0.3, 30, 1.5, 0.5, 1.2, 0.8, 1.4, 0.6, [3, 7]);
+const ds = decodePlanetCode(withSuffixes);
+check('suffixes: toggles', ds && ds.toggledIndices.length === 2 && ds.toggledIndices[0] === 3 && ds.toggledIndices[1] === 7);
+check('suffixes: tilt', ds && near(ds.axialTilt, 30));
+
+// Legacy 22-char codes (captured pre-SP4) decode with SP4 defaults
+const LEGACY_A = '0009j742vm5hlef0184d0g-0307'; // pre-SP4 22-char + -toggles (no motion suffix in this base)
+const LEGACY_B = '0000000000000000000pbt'; // pre-SP4 bare 22-char
+for (const [label, legacy] of [['legacyA', LEGACY_A], ['legacyB', LEGACY_B]]) {
+    const dl = decodePlanetCode(legacy);
+    check(`${label}: decodes`, dl !== null);
+    if (!dl) { continue; }
+    check(`${label}: tilt default`, dl.axialTilt === 23.5);
+    check(`${label}: rotation default`, dl.rotationRate === 1);
+    check(`${label}: greenhouse default`, dl.greenhouse === 0);
+    check(`${label}: character defaults`, dl.winterSeverity === 1 && dl.orographicRain === 1 && dl.maritimeInfluence === 1 && dl.mountainChill === 1);
+}
+check('legacyA: seed preserved', decodePlanetCode(LEGACY_A)?.seed === 12345);
+
+process.exit(failures ? 1 : 0);

--- a/tuning/regress.mjs
+++ b/tuning/regress.mjs
@@ -1,0 +1,218 @@
+/**
+ * Golden-master regression harness for World Orogen.
+ *
+ * Generates a fixed basket of planets headlessly and hashes the worker's
+ * deterministic output arrays (elevation + climate). SP1's contract is that
+ * these hashes never change; SP2/SP3 reuse this file in --diff mode to see
+ * intended changes.
+ *
+ *   node tuning/regress.mjs --update   # write baseline
+ *   node tuning/regress.mjs            # check against baseline (default)
+ *   node tuning/regress.mjs --diff     # report changed arrays, don't fail
+ *
+ * Screenshots are saved to tuning/regress-screenshots/ for optional human
+ * comparison but are NOT hash-asserted (GPU rasterization isn't bit-stable).
+ */
+
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const BASELINE_PATH = path.join(__dirname, 'regress-baseline.json');
+const SHOT_DIR = path.join(__dirname, 'regress-screenshots');
+fs.mkdirSync(SHOT_DIR, { recursive: true });
+
+const MODE = process.argv.includes('--update') ? 'update'
+           : process.argv.includes('--diff') ? 'diff'
+           : 'check';
+
+// Fixed basket: 3 seeds x 3 detail levels + one extra. All detail levels are
+// below AUTO_CLIMATE_THRESHOLD (300k) so climate is computed inline and its
+// arrays are present in state.curData for hashing.
+const CASES = [
+  { name: 'seed42-d5k',   seed: 42,  detail: 0,   sliders: {} },   // detail slider 0 -> 5,000 regions
+  { name: 'seed42-d50k',  seed: 42,  detail: 300, sliders: {} },
+  { name: 'seed42-d200k', seed: 42,  detail: 470, sliders: {} },
+  { name: 'seed100-d50k', seed: 100, detail: 300, sliders: { sP: 8,  sLc: 0.6 } },
+  { name: 'seed200-d50k', seed: 200, detail: 300, sliders: { sP: 80, sLc: 0.25 } },
+  { name: 'seed300-d50k', seed: 300, detail: 300, sliders: { sGl: 0.8, sHEr: 0.8, sTEr: 0.8 } },
+];
+
+// Arrays to hash (only those present are hashed; climate ones appear <300k).
+const HASH_KEYS = [
+  'r_elevation', 't_elevation',
+  'r_precip_summer', 'r_precip_winter',
+  'r_temperature_summer', 'r_temperature_winter',
+];
+
+const MIME = {
+  '.html':'text/html', '.js':'application/javascript', '.mjs':'application/javascript',
+  '.css':'text/css', '.json':'application/json', '.png':'image/png', '.svg':'image/svg+xml',
+  '.ico':'image/x-icon', '.woff':'font/woff', '.woff2':'font/woff2',
+  '.webmanifest':'application/manifest+json', '.txt':'text/plain', '.xml':'application/xml', '.wasm':'application/wasm',
+};
+
+function startServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let urlPath = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+      if (urlPath === '/' || urlPath === '') urlPath = '/index.html';
+      const filePath = path.join(PROJECT_ROOT, urlPath);
+      if (!filePath.startsWith(PROJECT_ROOT)) { res.writeHead(403); res.end(); return; }
+      fs.readFile(filePath, (err, data) => {
+        if (err) { res.writeHead(404); res.end('Not found'); return; }
+        res.writeHead(200, { 'Content-Type': MIME[path.extname(filePath).toLowerCase()] || 'application/octet-stream' });
+        res.end(data);
+      });
+    });
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+async function hashCase(page, tc) {
+  await page.evaluate(() => { window.__WO_CAPTURE = true; });
+
+  // Overlays off, detail + sliders set.
+  await page.evaluate(() => {
+    for (const id of ['tutorialOverlay', 'whatsNewOverlay']) {
+      const el = document.getElementById(id); if (el) el.style.display = 'none';
+    }
+  });
+
+  // The app auto-generates once on load with a random seed and default
+  // sliders (js/main.js), and #generate stays disabled with #buildOverlay
+  // (pointer-events: auto) covering it until that generation finishes. If we
+  // click before it settles the click is a no-op and the harness ends up
+  // hashing the random auto-gen instead of our seeded case. Wait for it to
+  // fully finish so the generate-done waiter installed below catches OUR
+  // generation, not the auto-gen's.
+  await page.waitForFunction(() => {
+    const o = document.getElementById('buildOverlay');
+    const b = document.getElementById('generate');
+    return o && o.classList.contains('hidden') && b && !b.disabled;
+  }, { timeout: 180_000 });
+
+  await page.evaluate(({ id, value }) => {
+    const el = document.getElementById(id); el.value = value;
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  }, { id: 'sN', value: String(tc.detail) });
+  for (const [id, val] of Object.entries(tc.sliders)) {
+    await page.evaluate(({ id, value }) => {
+      const el = document.getElementById(id); el.value = value;
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    }, { id, value: String(val) });
+  }
+
+  // Inject fixed seed by patching the next 'generate' postMessage.
+  await page.evaluate((seed) => {
+    const orig = Worker.prototype.postMessage;
+    Worker.prototype.postMessage = function (msg, ...rest) {
+      if (msg && msg.cmd === 'generate' && msg.seed === undefined) msg.seed = Number(seed);
+      return orig.call(this, msg, ...rest);
+    };
+  }, tc.seed);
+
+  const done = page.evaluate((timeout) => new Promise((resolve, reject) => {
+    const btn = document.getElementById('generate');
+    const timer = setTimeout(() => reject(new Error('gen timeout')), timeout);
+    btn.addEventListener('generate-done', () => { clearTimeout(timer); resolve(); }, { once: true });
+  }), 180_000);
+  await new Promise((r) => setTimeout(r, 100));
+
+  // For detail/erosion-only cases (no PLATE_SLIDERS change) the click handler
+  // would otherwise see isRebuild=true and reuse state.curData.seed, so the
+  // postMessage patch's `msg.seed === undefined` check never fires and our
+  // seed is silently ignored. Stripping 'stale' forces seed=undefined so the
+  // patch above actually injects tc.seed.
+  await page.evaluate(() => {
+    const b = document.getElementById('generate');
+    if (b) b.classList.remove('stale');
+  });
+  await page.click('#generate');
+  await done;
+  await new Promise((r) => setTimeout(r, 500));
+
+  // Hash arrays in-page (cyrb53 over the raw bytes) — only short hex crosses the bridge.
+  const hashes = await page.evaluate((keys) => {
+    const cyrb53 = (bytes) => {
+      let h1 = 0xdeadbeef, h2 = 0x41c6ce57;
+      for (let i = 0; i < bytes.length; i++) {
+        const ch = bytes[i];
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+      }
+      h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+      h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+      return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(16);
+    };
+    const d = window.__WO_state && window.__WO_state.curData;
+    const out = {};
+    if (!d) return out;
+    for (const k of keys) {
+      const arr = d[k];
+      if (arr && arr.buffer) out[k] = `${arr.length}:${cyrb53(new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength))}`;
+    }
+    return out;
+  }, HASH_KEYS);
+
+  // Advisory screenshot (not asserted).
+  const canvas = await page.$('#canvas');
+  if (canvas) await canvas.screenshot({ path: path.join(SHOT_DIR, `${tc.name}.png`) }).catch(() => {});
+
+  return hashes;
+}
+
+async function main() {
+  const { server, port } = await startServer();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const browser = await puppeteer.launch({
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--enable-webgl',
+           '--use-gl=angle', '--use-angle=swiftshader-webgl', '--enable-unsafe-swiftshader'],
+  });
+
+  const results = {};
+  try {
+    for (const tc of CASES) {
+      const page = await browser.newPage();
+      await page.setViewport({ width: 1200, height: 900 });
+      page.on('dialog', (d) => d.dismiss());
+      page.on('pageerror', (e) => console.log(`  [PAGE EXCEPTION] ${e.message}`));
+      await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+      await new Promise((r) => setTimeout(r, 2000));
+      console.log(`Generating ${tc.name}...`);
+      results[tc.name] = await hashCase(page, tc);
+      await page.close().catch(() => {});
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  if (MODE === 'update') {
+    fs.writeFileSync(BASELINE_PATH, JSON.stringify(results, null, 2));
+    console.log(`\nBaseline written to ${path.relative(PROJECT_ROOT, BASELINE_PATH)}`);
+    return;
+  }
+
+  const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+  let mismatches = 0;
+  for (const tc of CASES) {
+    const a = baseline[tc.name] || {}, b = results[tc.name] || {};
+    for (const k of new Set([...Object.keys(a), ...Object.keys(b)])) {
+      if (a[k] !== b[k]) {
+        mismatches++;
+        console.log(`  CHANGED ${tc.name}.${k}: ${a[k]} -> ${b[k]}`);
+      }
+    }
+  }
+  if (mismatches === 0) console.log('\nAll cases byte-identical to baseline.');
+  else console.log(`\n${mismatches} array(s) differ from baseline.`);
+  if (MODE === 'check' && mismatches > 0) process.exit(1);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/tuning/scale-invariance.mjs
+++ b/tuning/scale-invariance.mjs
@@ -1,0 +1,375 @@
+/**
+ * Cross-resolution scale-invariance harness for World Orogen (SP2).
+ *
+ * Generates the SAME seed across a Detail ladder and measures how much the
+ * terrain-metrics scorecard drifts with resolution. Scale-invariant code
+ * should produce near-identical metric values at every rung.
+ *
+ *   node tuning/scale-invariance.mjs --baseline            # record pre-fix divergence
+ *   node tuning/scale-invariance.mjs                       # report current vs baseline
+ *   node tuning/scale-invariance.mjs --check                # exit 1 unless gated metrics
+ *                                                            # improved by IMPROVE_FACTOR
+ *   node tuning/scale-invariance.mjs --verify-determinism   # acceptance gate: same planet
+ *                                                            # code -> identical metrics
+ *
+ * Metric groups:
+ *   GATE     — land-erosion/smoothing-sensitive, resolution-independent by
+ *              intent; these carry the pass/fail signal.
+ *   CONTROL  — quantities that are already ~resolution-invariant (land
+ *              fraction, ocean-floor stats untouched by land-only erosion).
+ *              Their spread defines the achievable noise floor.
+ *   RECORDED — everything else in the scorecard, reported but ungated
+ *              (e.g. coast_complexity_index legitimately rises with
+ *              resolution — Richardson effect — so it must not gate).
+ *
+ * Seed control:
+ *   The harness's original seed mechanism (patching Worker.prototype.postMessage)
+ *   never fired, so every generation used `Math.floor(Math.random() * 16777216)`
+ *   — the divergence numbers measured unrelated random worlds. Instead we drive
+ *   the app's deterministic URL-hash planet-code path: encode seed + params with
+ *   encodePlanetCode (js/planet-code.js, a pure function with no DOM access —
+ *   safe to import directly here) and navigate to `${baseUrl}#${code}`. main.js
+ *   decodes the hash, sets sliders, and calls generate(seed, ...) exactly once.
+ *
+ *   The harness computes metrics in-page from state.curData via the canonical
+ *   computeTerrainMetrics, which is robust regardless of whether generation ran
+ *   on the worker or the synchronous fallback — so it works whether or not
+ *   window.__terrainMetrics ends up populated. No js/ files are modified; this
+ *   only imports them.
+ */
+
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import puppeteer from 'puppeteer';
+import { encodePlanetCode } from '../js/planet-code.js';
+import { detailFromSlider } from '../js/detail-scale.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const BASELINE_PATH = path.join(__dirname, 'scale-invariance-baseline.json');
+const SHOT_DIR = path.join(__dirname, 'scale-invariance-screenshots');
+fs.mkdirSync(SHOT_DIR, { recursive: true });
+
+const MODE = process.argv.includes('--baseline') ? 'baseline'
+           : process.argv.includes('--check') ? 'check'
+           : process.argv.includes('--verify-determinism') ? 'verify-determinism'
+           : 'report';
+
+// First trustworthy measurement (2026-07-11, deterministic seed control via
+// URL-hash planet codes): pre-fix GATE aggregate 0.2723 vs post-fix 0.2327,
+// ratio 0.855 — the SP2 fixes measurably reduced cross-resolution GATE
+// divergence. IMPROVE_FACTOR = ceil(ratio * 10) / 10 = 0.9 with a small
+// margin: current must stay at or below 0.9x the recorded (pre-fix)
+// baseline, i.e. within reach of the post-fix improvement rather than
+// drifting back toward the old, worse behavior. This is a real regression
+// gate, not a loose tripwire, now that both post-fix runs reproduced
+// byte-for-byte identical metrics.
+const IMPROVE_FACTOR = 0.9;
+
+// Relative divergence (max-min)/|mean| is only meaningful when the metric's
+// mean is well clear of zero. A near-zero-mean quantity — e.g.
+// erosion_slope_correlation in the zero-erosion seed, where erosion is off —
+// makes the ratio explode on pure measurement noise and carries no
+// scale-invariance signal, so we exclude it. Every valid GATE/CONTROL metric
+// here has |mean| >= 0.16; the artifact sits at ~0.004, so 0.05 separates them.
+const MIN_MEAN_MAGNITUDE = 0.05;
+
+// Detail ladder: slider positions -> ~5K / 31K / 100K / 299K / 801K regions.
+// The 801K rung exercises the >300K range where the SP2 fixes actually bite.
+// Climate skipping is the app's own per-rung decision (shouldSkipClimate,
+// gated on AUTO_CLIMATE_THRESHOLD=300K): it runs for the <300K rungs and is
+// skipped for 801K. Either way it is orthogonal to the terrain GATE metrics
+// (computed from elevation before climate), so it affects only runtime.
+const LADDER = [
+  { pos: 0,   approxN: 5000 },
+  { pos: 400, approxN: 31000 },
+  { pos: 518, approxN: 100000 },
+  { pos: 649, approxN: 299000 },
+  { pos: 792, approxN: 801000 },
+];
+
+// Seeds: defaults (erosion at app-default sliders — glacial/hydraulic/thermal
+// left null so the DOM defaults are used), high-erosion (maximizes the
+// defect), zero-erosion (isolates the smoothing fixes from the erosion fixes).
+const SEEDS = [
+  { name: 'defaults',     seed: 42,  glacial: null, hydraulic: null, thermal: null },
+  { name: 'high-erosion', seed: 300, glacial: 0.8,  hydraulic: 0.8,  thermal: 0.8 },
+  { name: 'zero-erosion', seed: 500, glacial: 0,    hydraulic: 0,    thermal: 0 },
+];
+
+// Land-erosion/smoothing-sensitive, resolution-independent by intent.
+const GATE_KEYS = [
+  'relief_headroom', 'peak_clustering', 'hypsometry_trough_depth',
+  'land_mode_elev', 'erosion_slope_correlation',
+];
+// Already ~invariant: land fraction (computed below) + ocean-floor stats
+// (erosion is land-only; smoothElevation locks coasts).
+const CONTROL_KEYS = ['land_fraction', 'ocean_mode_elev', 'ocean_elev_stddev'];
+
+const MIME = {
+  '.html':'text/html', '.js':'application/javascript', '.mjs':'application/javascript',
+  '.css':'text/css', '.json':'application/json', '.png':'image/png', '.svg':'image/svg+xml',
+  '.ico':'image/x-icon', '.woff':'font/woff', '.woff2':'font/woff2',
+  '.webmanifest':'application/manifest+json', '.txt':'text/plain', '.xml':'application/xml', '.wasm':'application/wasm',
+};
+
+function startServer() {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      let urlPath = decodeURIComponent(new URL(req.url, 'http://localhost').pathname);
+      if (urlPath === '/' || urlPath === '') urlPath = '/index.html';
+      const filePath = path.join(PROJECT_ROOT, urlPath);
+      if (!filePath.startsWith(PROJECT_ROOT)) { res.writeHead(403); res.end(); return; }
+      fs.readFile(filePath, (err, data) => {
+        if (err) { res.writeHead(404); res.end('Not found'); return; }
+        res.writeHead(200, { 'Content-Type': MIME[path.extname(filePath).toLowerCase()] || 'application/octet-stream' });
+        res.end(data);
+      });
+    });
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+// Read the app's current (default) slider values from the DOM. These are
+// static HTML attribute values, identical across every call, so we read
+// them once per browser session rather than once per (seed, rung).
+async function readDefaultSliders(browser, baseUrl) {
+  const page = await browser.newPage();
+  try {
+    await page.goto(baseUrl, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+    return await page.evaluate(() => {
+      const val = (id) => +document.getElementById(id).value;
+      return {
+        jitter: val('sJ'), P: val('sP'), numContinents: val('sCn'),
+        roughness: val('sNs'), terrainWarp: val('sTw'), smoothing: val('sS'),
+        glacialErosion: val('sGl'), hydraulicErosion: val('sHEr'), thermalErosion: val('sTEr'),
+        ridgeSharpening: val('sRs'), continentSizeVariety: val('sCsv'),
+        temperatureOffset: val('sTmp'), precipitationOffset: val('sPrc'), landCoverage: val('sLc'),
+      };
+    });
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+// Build a deterministic planet code for (seed config, rung) against the
+// app's current DOM defaults for every param the seed config doesn't override.
+function buildPlanetCode(sc, rung, defaults) {
+  const N = detailFromSlider(rung.pos);
+  return encodePlanetCode(
+    sc.seed,
+    N,
+    defaults.jitter,
+    defaults.P,
+    defaults.numContinents,
+    defaults.roughness,
+    defaults.terrainWarp,
+    defaults.smoothing,
+    sc.glacial ?? defaults.glacialErosion,
+    sc.hydraulic ?? defaults.hydraulicErosion,
+    sc.thermal ?? defaults.thermalErosion,
+    defaults.ridgeSharpening,
+    0.75, // soilCreep: fixed app constant — main.js hardcodes 0.75, no UI slider exists
+    defaults.continentSizeVariety,
+    defaults.temperatureOffset,
+    defaults.precipitationOffset,
+    defaults.landCoverage,
+    [],
+  );
+}
+
+async function generateAndMeasure(browser, baseUrl, sc, rung, defaults, shotName) {
+  const page = await browser.newPage();
+  try {
+    await page.setViewport({ width: 1200, height: 900 });
+    page.on('dialog', (d) => d.dismiss());
+    page.on('pageerror', (e) => console.log(`  [PAGE EXCEPTION] ${e.message}`));
+
+    const code = buildPlanetCode(sc, rung, defaults);
+    await page.goto(`${baseUrl}#${code}`, { waitUntil: 'domcontentloaded', timeout: 60_000 });
+
+    await page.evaluate(() => {
+      for (const id of ['tutorialOverlay', 'whatsNewOverlay']) {
+        const el = document.getElementById(id); if (el) el.style.display = 'none';
+      }
+    });
+
+    // The hash-load path in main.js fires exactly one generate() call; wait
+    // for it to finish (button re-enabled by resetUI()).
+    await page.waitForFunction(
+      () => !document.getElementById('generate').disabled,
+      { timeout: 600_000, polling: 250 },
+    );
+
+    // Compute metrics in-page from the retained state.curData via the
+    // canonical computeTerrainMetrics — see module docstring. This works
+    // regardless of whether generation ran on the worker or the fallback.
+    const metrics = await page.evaluate(async () => {
+      const { state } = await import('/js/state.js');
+      const { computeTerrainMetrics } = await import('/js/terrain-metrics.js');
+      const d = state.curData;
+      if (!d) return { _error: 'no curData after generation' };
+      try {
+        return computeTerrainMetrics({
+          mesh: d.mesh, r_xyz: d.r_xyz, r_elevation: d.r_elevation,
+          r_plate: d.r_plate, plateIsOcean: d.plateIsOcean,
+          r_stress: d.r_stress, debugLayers: d.debugLayers, prePostElev: d.prePostElev,
+        });
+      } catch (e) {
+        return { _error: e.message };
+      }
+    });
+    if (!metrics || metrics._error) {
+      throw new Error(`no metrics for ${sc.name}@${rung.pos}: ${metrics && metrics._error}`);
+    }
+    // Derived control: land fraction (land_cells is a raw count ∝ N).
+    metrics.land_fraction = metrics.land_cells / (rung.approxN + 1);
+
+    if (shotName) {
+      // Advisory screenshot for the visual A/B grid (sidebar collapsed first).
+      await page.click('#sidebarToggle').catch(() => {});
+      await new Promise((r) => setTimeout(r, 800));
+      const canvas = await page.$('#canvas');
+      if (canvas) {
+        await canvas.screenshot({ path: path.join(SHOT_DIR, `${shotName}.png`) }).catch(() => {});
+      }
+    }
+    return metrics;
+  } finally {
+    await page.close().catch(() => {});
+  }
+}
+
+// Normalized spread of one metric across the ladder.
+function divergence(values) {
+  const nums = values.filter((v) => Number.isFinite(v));
+  if (nums.length < 2) return null;
+  const mean = nums.reduce((s, v) => s + v, 0) / nums.length;
+  if (Math.abs(mean) < MIN_MEAN_MAGNITUDE) return null;
+  return (Math.max(...nums) - Math.min(...nums)) / (Math.abs(mean) + 1e-9);
+}
+
+async function launchBrowser() {
+  return puppeteer.launch({
+    headless: true,
+    // The synchronous fallback path blocks the main thread for the whole
+    // generation, so CDP calls (Runtime.callFunctionOn, etc.) need a long
+    // protocol timeout or they time out mid-generation.
+    protocolTimeout: 600_000,
+    args: ['--no-sandbox', '--disable-setuid-sandbox', '--enable-webgl',
+           '--use-gl=angle', '--use-angle=swiftshader-webgl', '--enable-unsafe-swiftshader'],
+  });
+}
+
+async function verifyDeterminism(browser, baseUrl) {
+  const defaults = await readDefaultSliders(browser, baseUrl);
+  const rung = LADDER[0]; // fast rung, ~5K regions
+  const scDefault = SEEDS[0]; // seed 42, app-default erosion
+  const scOther = { name: 'seed999', seed: 999, glacial: null, hydraulic: null, thermal: null };
+
+  console.log(`Generating seed 42, run 1 @ slider ${rung.pos} (~${rung.approxN.toLocaleString()} regions)...`);
+  const run1 = await generateAndMeasure(browser, baseUrl, scDefault, rung, defaults);
+  console.log(`Generating seed 42, run 2 @ slider ${rung.pos} (~${rung.approxN.toLocaleString()} regions)...`);
+  const run2 = await generateAndMeasure(browser, baseUrl, scDefault, rung, defaults);
+  console.log(`Generating seed 999 @ slider ${rung.pos} (~${rung.approxN.toLocaleString()} regions)...`);
+  const run3 = await generateAndMeasure(browser, baseUrl, scOther, rung, defaults);
+
+  console.log('\n=== --verify-determinism ===');
+  console.log(`seed42 run1: land_cells=${run1.land_cells}  relief_headroom=${run1.relief_headroom}`);
+  console.log(`seed42 run2: land_cells=${run2.land_cells}  relief_headroom=${run2.relief_headroom}`);
+  console.log(`seed999:     land_cells=${run3.land_cells}  relief_headroom=${run3.relief_headroom}`);
+
+  const sameSeedReproducible = run1.land_cells === run2.land_cells && run1.relief_headroom === run2.relief_headroom;
+  const seedMatters = run1.land_cells !== run3.land_cells;
+
+  console.log(`\nSAME-SEED REPRODUCIBLE: ${sameSeedReproducible ? 'YES' : 'NO'} (run1 land_cells=${run1.land_cells} vs run2 land_cells=${run2.land_cells})`);
+  console.log(`SEED MATTERS:            ${seedMatters ? 'YES' : 'NO'} (seed42 land_cells=${run1.land_cells} vs seed999 land_cells=${run3.land_cells})`);
+
+  if (sameSeedReproducible && seedMatters) {
+    console.log('\nPASS: seed is under harness control.');
+    return true;
+  }
+  console.log('\nFAIL: seed is NOT under harness control.');
+  if (!sameSeedReproducible) console.log('  -> identical planet codes produced different metrics (non-determinism).');
+  if (!seedMatters) console.log('  -> different seeds produced identical metrics (seed not wired through).');
+  return false;
+}
+
+async function main() {
+  const { server, port } = await startServer();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const browser = await launchBrowser();
+
+  try {
+    if (MODE === 'verify-determinism') {
+      const ok = await verifyDeterminism(browser, baseUrl);
+      if (!ok) process.exit(1);
+      return;
+    }
+
+    const defaults = await readDefaultSliders(browser, baseUrl);
+    const perSeed = {};
+    for (const sc of SEEDS) {
+      const rows = [];
+      for (const rung of LADDER) {
+        console.log(`Generating ${sc.name} @ slider ${rung.pos} (~${rung.approxN.toLocaleString()} regions)...`);
+        rows.push(await generateAndMeasure(browser, baseUrl, sc, rung, defaults, `${sc.name}_pos${rung.pos}`));
+      }
+      // Divergence per metric key present in all rungs.
+      const allKeys = new Set(rows.flatMap((r) => Object.keys(r)));
+      const D = {};
+      for (const k of allKeys) {
+        if (k.startsWith('_')) continue;
+        const d = divergence(rows.map((r) => r[k]));
+        if (d !== null) D[k] = +d.toFixed(4);
+      }
+      perSeed[sc.name] = { D, rows };
+    }
+
+    const agg = (keys) => {
+      const vals = [];
+      for (const sc of SEEDS) {
+        for (const k of keys) {
+          const d = perSeed[sc.name].D[k];
+          if (Number.isFinite(d)) vals.push(d);
+        }
+      }
+      return vals.length ? vals.reduce((s, v) => s + v, 0) / vals.length : null;
+    };
+    const gateAgg = agg(GATE_KEYS);
+    const controlAgg = agg(CONTROL_KEYS);
+
+    console.log('\n=== Divergence across the Detail ladder (0 = perfectly scale-invariant) ===');
+    for (const sc of SEEDS) {
+      console.log(`\n[${sc.name}]`);
+      for (const k of [...GATE_KEYS, ...CONTROL_KEYS]) {
+        const tag = GATE_KEYS.includes(k) ? 'GATE   ' : 'CONTROL';
+        console.log(`  ${tag} ${k}: ${perSeed[sc.name].D[k] ?? 'n/a'}`);
+      }
+    }
+    console.log(`\nGATE aggregate:    ${gateAgg?.toFixed(4)}`);
+    console.log(`CONTROL aggregate: ${controlAgg?.toFixed(4)} (noise floor)`);
+
+    if (MODE === 'baseline') {
+      fs.writeFileSync(BASELINE_PATH, JSON.stringify({ gateAgg, controlAgg, perSeed }, null, 2));
+      console.log(`\nBaseline written to ${path.relative(PROJECT_ROOT, BASELINE_PATH)}`);
+      return;
+    }
+
+    const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, 'utf8'));
+    console.log(`\nBaseline GATE aggregate: ${baseline.gateAgg?.toFixed(4)}  ->  current: ${gateAgg?.toFixed(4)}`);
+    const target = baseline.gateAgg * IMPROVE_FACTOR;
+    const pass = gateAgg <= target;
+    console.log(pass
+      ? `PASS: ${gateAgg.toFixed(4)} <= ${target.toFixed(4)} (${IMPROVE_FACTOR} x baseline)`
+      : `FAIL: ${gateAgg.toFixed(4)} > ${target.toFixed(4)} (${IMPROVE_FACTOR} x baseline)`);
+    if (MODE === 'check' && !pass) process.exit(1);
+  } finally {
+    await browser.close();
+    server.close();
+  }
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

SP4 exposes World Orogen's existing climate physics as **7 new user-facing sliders** and couples them through the simulation — while remaining a **bit-identical no-op at every default**, so the Earth-tuned Köppen calibration and golden-master output are untouched unless a user deliberately moves a knob.

The climate view is the tool's most-cited differentiator; this PR deepens it rather than simplifying it, and keeps generation fast by splitting the knobs into a "Planet" group (invalidates the cached wind+ocean fields) and a "Character" group (reuses them — same cheap recompute path as today's Temperature slider).

### New sliders

**Planet** — reshape the circulation itself (recompute wind+ocean+precip+temp):

| Slider | ID | Range | Default | Effect |
|---|---|---|---|---|
| Axial Tilt | `sTilt` | 0–45° | 23.5° | Season strength via `s = sin(θ)/sin(23.5°)`; 0° = genuinely seasonless (wind, precip, temperature), 45° = violent seasons + deep monsoons |
| Rotation Rate | `sRot` | 0.5–2.0× | 1× | Coriolis deflection + circulation-band latitudes scale by `ρ^(−1/3)` (fast rotators compress bands equatorward) |
| Greenhouse | `sGh` | −1…+1 | 0 | Uniform warming + equator→pole gradient flattening (polar amplification) + slight winter lift |

**Character** — restyle within the cached wind+ocean (recompute precip+temp only, fast path):

| Slider | ID | Range | Default | Multiplies |
|---|---|---|---|---|
| Winter Severity | `sWs` | 0–2× | 1× | `TEMP_CONT_WINTER_COOL_C` |
| Orographic Rain | `sOro` | 0–2× | 1× | `PRECIP_ORO_UPLIFT_ADD`, `PRECIP_RS_APPLY_STRENGTH_SCALE`, `PRECIP_RS_APPLY_WINDWARD_ADD` (suppression caps stay fixed) |
| Maritime Influence | `sMar` | 0–2× | 1× | `TEMP_COASTAL_WARMTH_SHIFT_C`, `TEMP_OCEAN_WARMTH_DIFFUSE_KM` (reach stays scale-invariant) |
| Mountain Chill | `sLap` | 0–2× | 1× | `TEMP_MOIST_LAPSE_C_PER_KM`, `TEMP_DRY_LAPSE_EXTRA_C_PER_KM` |

All seven recompute climate-only on slider **release** (never per drag tick), are encoded in the planet code, and are documented in README, the tutorial, the What's New modal, JSON-LD/`<main>` SEO, and `llms.txt`.

### Architecture (Approach A — explicit param plumbing)

DOM sliders → worker message fields → `W` retention with wind/ocean cache invalidation on tilt/rotation change → trailing params / a `userClimate` object into `computeWind`/`computeOceanCurrents`/`computePrecipitation`/`computeTemperature`, applied **multiplicatively at point of use**. `CLIMATE` (the Earth-tuned internals) is never mutated by user knobs. A single `seasonFactorFromTilt()` helper in `climate-util.js` derives the season factor.

### Exactness (how the no-op is guaranteed, not merely tested)

- Pure multiplicative (`x × 1.0`) and additive (`x + 0`) couplings are exact in IEEE-754.
- `seasonFactorFromTilt(23.5)` returns **exactly** `1` via an early-equality return; `Math.pow(1, x) === 1` makes `ρ = 1` exact.
- The three non-exact forms carry a hoisted per-call guard so the default path is preserved bit-for-bit: the precip subtropical-band split and the heuristic season mods use `if (seasonFactor !== 1)`, and the geostrophic-deflection map uses `if (rotationRate === 1)`.
- Effective parameters are computed **once per compute call**, never per region.

### Planet code

Seven `SLIDERS` entries (counts 91, 16, 21, 21, 21, 21, 21) packed least-significant after `landCoverage` → base length **22 → 27**. The old 22-char format becomes a `PREV6` decode entry; **all** legacy lengths (13/14/16/17/18/21/22) keep decoding, with the new fields defaulted. A new `tuning/planet-code-check.mjs` asserts round-trip identity across extremes and legacy-decode defaults (117 checks).

## Isolation & compatibility

- **Based directly on `raguilar011095/planet_heightmap_generation:main` at `cc2662b`.**
- Contains **no fork-only SP1/SP2/SP3/SP6 shipping-code changes**. The only fork-originated content is the dev **test harness** (see dependency note below), which does not affect generated output.
- Preserves legacy behavior by construction: six terrain/climate golden-master cases are **byte-identical** to pristine upstream with all sliders at defaults.
- Planet codes from every prior version still load (new sliders default in).

## ⚠️ Dependency on SP1 (#56) and SP2 (#57) — please read

SP4's per-task gate is *bit-identical output at defaults*. Verifying that requires SP1's golden-master harness (`tuning/regress.mjs` + its inert `window.__WO_CAPTURE` hook in `generate.js`, PR #56), and final validation uses SP2's cross-resolution harness (`tuning/scale-invariance.mjs`, PR #57). Neither exists on pristine upstream, so the **first commit** of this branch brings them in as **test tooling only**:

| Commit | Owner | Purpose |
|---|---|---|
| `574d0ec` | **SP1 / SP2** | golden-master + scale-invariance harness + inert capture hook (the gates SP4 relies on) |
| `afdb7c7` | SP4 | thread the 7 user-params end-to-end (inert at defaults) |
| `e4dfe3a` | SP4 | climate panel Planet/Character sliders, on-release recompute |
| `d82a6dd` | SP4 | 27-char planet code with full legacy decode |
| `0b6fe85` | SP4 | axial-tilt coupling (ITCZ, pressure, swing, subtrop bands, ocean shift) |
| `98f4847` | SP4 | gradient-coupled greenhouse |
| `0bff021` | SP4 | rotation-rate (Coriolis deflection + band scaling + interim ocean bands) |
| `ef298c0` | SP4 | winter severity / orographic rain / maritime / mountain chill |
| `4b340e6` | SP4 | docs, tutorial, What's New, SEO, llms.txt, mobile |
| `0a8302a` | SP4 | JSDoc fix (whole-branch review follow-up) |

If SP1/SP2 land first, the harness commit becomes redundant and folds away cleanly (same files, same content). The inert `window.__WO_CAPTURE` hook in `generate.js` is a no-op unless a test harness sets the flag.

## Verification

- `node tuning/regress.mjs` → **"All cases byte-identical to baseline."** (6-case golden master; the default no-op is machine-proven, not tolerance-based).
- `node tuning/planet-code-check.mjs` → **117 checks green** (round-trip across extremes; every legacy length decodes with correct new-field defaults; toggle suffix survives).
- `node --check` clean on all changed JS modules.
- Independent whole-branch code review: **0 Critical, 0 Important** findings.

### Deferred (for the maintainer to run)

- **Earth-match** `node tuning/climate/evaluate.mjs`: `tuning/climate/data/` is gitignored and absent in this environment. Because defaults are exact no-ops (`score.mjs` passes no `userClimate`), the objective **cannot** regress — but please run it if you have the data locally.
- **Extremes visual grid** (manual, one seed): tilt {0, 45}, greenhouse {−1, +1}, rotation {0.5, 2}, each character knob {0, 2}. Expected: tilt 0° → summer≈winter fields; greenhouse +1 → polar Köppen retreats; rotation 2× → bands visibly equatorward.

## Test plan

- [x] `node tuning/regress.mjs` byte-identical at defaults
- [x] `node tuning/planet-code-check.mjs` (round-trip + legacy decode)
- [x] `node --check` on all changed modules
- [x] Whole-branch review clean
- [ ] Maintainer: `node tuning/climate/evaluate.mjs` (Köppen Earth-match, if `data/` present)
- [ ] Maintainer: extremes screenshot grid in-browser
